### PR TITLE
Add: IP and CIDR target support (hunt.py + recon_engine.sh)

### DIFF
--- a/tests/test_hunt_target_types.py
+++ b/tests/test_hunt_target_types.py
@@ -59,3 +59,11 @@ def test_run_recon_rejects_large_cidr_before_spawning(monkeypatch):
 
     assert hunt.run_recon("192.0.2.0/23") is False
     assert popen_called is False
+
+
+def test_recon_engine_expands_cidr_when_nmap_is_unavailable():
+    recon_engine = (Path(__file__).resolve().parents[1] / "tools" / "recon_engine.sh").read_text()
+
+    assert "_expand_cidr_hosts" in recon_engine
+    assert 'log_warn "nmap not installed — expanding the CIDR locally for downstream probing"' in recon_engine
+    assert 'log_warn "nmap did not identify live hosts — expanding the CIDR locally for downstream probing"' in recon_engine

--- a/tests/test_hunt_target_types.py
+++ b/tests/test_hunt_target_types.py
@@ -1,0 +1,61 @@
+"""Tests for target type detection and CIDR safety limits in tools/hunt.py."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+
+def load_hunt_module():
+    hunt_path = Path(__file__).resolve().parents[1] / "tools" / "hunt.py"
+    spec = importlib.util.spec_from_file_location("hunt_module", hunt_path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_detect_target_type_domain():
+    hunt = load_hunt_module()
+    assert hunt.detect_target_type("example.com") == "domain"
+
+
+def test_detect_target_type_ip():
+    hunt = load_hunt_module()
+    assert hunt.detect_target_type("192.0.2.10") == "ip"
+
+
+def test_detect_target_type_cidr():
+    hunt = load_hunt_module()
+    assert hunt.detect_target_type("192.0.2.0/24") == "cidr"
+
+
+def test_expand_cidr_small_range():
+    hunt = load_hunt_module()
+    assert hunt.expand_cidr("192.0.2.0/30") == ["192.0.2.1", "192.0.2.2"]
+
+
+def test_expand_cidr_rejects_large_ranges():
+    hunt = load_hunt_module()
+    try:
+        hunt.expand_cidr("192.0.2.0/23")
+    except ValueError as exc:
+        assert "supported limit" in str(exc)
+    else:
+        raise AssertionError("expected oversized CIDR to be rejected")
+
+
+def test_run_recon_rejects_large_cidr_before_spawning(monkeypatch):
+    hunt = load_hunt_module()
+
+    popen_called = False
+
+    def fake_popen(*args, **kwargs):
+        nonlocal popen_called
+        popen_called = True
+        raise AssertionError("subprocess should not be started for oversized CIDR")
+
+    monkeypatch.setattr(hunt.subprocess, "Popen", fake_popen)
+
+    assert hunt.run_recon("192.0.2.0/23") is False
+    assert popen_called is False

--- a/tools/hunt.py
+++ b/tools/hunt.py
@@ -16,6 +16,7 @@ Usage:
 """
 
 import argparse
+import itertools
 import ipaddress
 import json
 import os
@@ -26,6 +27,8 @@ from datetime import datetime
 
 # ── Target type detection (FQDN / single IP / CIDR) ──────────────────────────
 
+MAX_CIDR_HOSTS = 254
+
 def detect_target_type(target: str) -> str:
     """Return 'cidr', 'ip', or 'domain'."""
     try:
@@ -35,14 +38,20 @@ def detect_target_type(target: str) -> str:
         return "domain"
 
 
-def expand_cidr(cidr: str, max_hosts: int = 254) -> list:
-    """Expand CIDR to list of host IPs (up to max_hosts)."""
-    try:
-        net = ipaddress.ip_network(cidr, strict=False)
-        hosts = [str(h) for h in net.hosts()]
-        return hosts[:max_hosts]
-    except ValueError:
-        return [cidr]
+def expand_cidr(cidr: str, max_hosts: int = MAX_CIDR_HOSTS) -> list[str]:
+    """Expand CIDR to host IPs, rejecting ranges larger than max_hosts."""
+    net = ipaddress.ip_network(cidr, strict=False)
+    hosts = [str(host) for host in itertools.islice(net.hosts(), max_hosts + 1)]
+
+    if len(hosts) > max_hosts:
+        raise ValueError(
+            f"CIDR {cidr} expands beyond the supported limit of {max_hosts} hosts; "
+            "use /24 or smaller ranges"
+        )
+
+    if not hosts:
+        return [str(net.network_address)]
+    return hosts
 
 TOOLS_DIR = os.path.dirname(os.path.abspath(__file__))
 BASE_DIR = os.path.dirname(TOOLS_DIR)
@@ -161,7 +170,11 @@ def run_recon(domain, quick=False, scope_lock=False):
         scope_lock = True  # IPs/CIDRs never need subdomain enum
         log("info", f"Target type: {target_type.upper()} — subdomain enum skipped")
         if target_type == "cidr":
-            hosts = expand_cidr(domain)
+            try:
+                hosts = expand_cidr(domain)
+            except ValueError as exc:
+                log("err", str(exc))
+                return False
             log("info", f"CIDR {domain} → {len(hosts)} host(s) to scan")
 
     scope_env  = "SCOPE_LOCK=1 " if scope_lock else ""

--- a/tools/hunt.py
+++ b/tools/hunt.py
@@ -16,11 +16,33 @@ Usage:
 """
 
 import argparse
+import ipaddress
 import json
 import os
 import subprocess
 import sys
 from datetime import datetime
+
+
+# ── Target type detection (FQDN / single IP / CIDR) ──────────────────────────
+
+def detect_target_type(target: str) -> str:
+    """Return 'cidr', 'ip', or 'domain'."""
+    try:
+        net = ipaddress.ip_network(target, strict=False)
+        return "cidr" if net.num_addresses > 1 else "ip"
+    except ValueError:
+        return "domain"
+
+
+def expand_cidr(cidr: str, max_hosts: int = 254) -> list:
+    """Expand CIDR to list of host IPs (up to max_hosts)."""
+    try:
+        net = ipaddress.ip_network(cidr, strict=False)
+        hosts = [str(h) for h in net.hosts()]
+        return hosts[:max_hosts]
+    except ValueError:
+        return [cidr]
 
 TOOLS_DIR = os.path.dirname(os.path.abspath(__file__))
 BASE_DIR = os.path.dirname(TOOLS_DIR)
@@ -127,19 +149,31 @@ def select_targets(top_n=10):
     return []
 
 
-def run_recon(domain, quick=False):
-    """Run recon engine on a domain."""
+def run_recon(domain, quick=False, scope_lock=False):
+    """Run recon engine on a domain, single IP, or CIDR range."""
     log("info", f"Running recon on {domain}...")
     script = os.path.join(TOOLS_DIR, "recon_engine.sh")
     quick_flag = "--quick" if quick else ""
 
+    # Detect target type and pass to recon_engine.sh
+    target_type = detect_target_type(domain)
+    if target_type in ("ip", "cidr"):
+        scope_lock = True  # IPs/CIDRs never need subdomain enum
+        log("info", f"Target type: {target_type.upper()} — subdomain enum skipped")
+        if target_type == "cidr":
+            hosts = expand_cidr(domain)
+            log("info", f"CIDR {domain} → {len(hosts)} host(s) to scan")
+
+    scope_env  = "SCOPE_LOCK=1 " if scope_lock else ""
+    type_env   = f'TARGET_TYPE="{target_type}" '
+
     # Run with live output
     try:
         proc = subprocess.Popen(
-            f'bash "{script}" "{domain}" {quick_flag}',
+            f'{scope_env}{type_env}bash "{script}" "{domain}" {quick_flag}',
             shell=True, cwd=BASE_DIR
         )
-        proc.wait(timeout=1800)  # 30 min timeout
+        proc.wait(timeout=3600)  # 60 min timeout (CIDR ranges can be large)
         return proc.returncode == 0
     except subprocess.TimeoutExpired:
         proc.kill()
@@ -363,7 +397,7 @@ Examples:
   python3 hunt.py --setup-wordlists          Download wordlists
         """
     )
-    parser.add_argument("--target", type=str, help="Specific target domain to hunt")
+    parser.add_argument("--target", type=str, help="Target: FQDN, IP, or CIDR (e.g. example.com, 192.168.1.1, 10.0.0.0/24)")
     parser.add_argument("--quick", action="store_true", help="Quick scan mode (fewer checks)")
     parser.add_argument("--recon-only", action="store_true", help="Only run reconnaissance")
     parser.add_argument("--scan-only", action="store_true", help="Only run vulnerability scanner")

--- a/tools/recon_engine.sh
+++ b/tools/recon_engine.sh
@@ -35,6 +35,21 @@ _detect_target_type() {
     elif [[ "$t" =~ ^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$ ]];        then echo "ip"
     else echo "domain"; fi
 }
+
+_expand_cidr_hosts() {
+    local target="$1"
+    python3 - "$target" <<'PY'
+import ipaddress
+import itertools
+import sys
+
+network = ipaddress.ip_network(sys.argv[1], strict=False)
+hosts = [str(host) for host in itertools.islice(network.hosts(), 254)]
+if not hosts:
+    hosts = [str(network.network_address)]
+print("\n".join(hosts))
+PY
+}
 TARGET_TYPE="${TARGET_TYPE:-$(_detect_target_type "$TARGET")}"
 
 # For IP/CIDR: always scope-lock — no subdomain enum needed
@@ -65,11 +80,14 @@ if [ "$TARGET_TYPE" = "cidr" ]; then
             | awk '/Up$/{print $2}' \
             > "$RECON_DIR/subdomains/all.txt" || true
         LIVE_COUNT=$(wc -l < "$RECON_DIR/subdomains/all.txt" 2>/dev/null || echo 0)
-        [ "$LIVE_COUNT" -eq 0 ] && echo "$TARGET" > "$RECON_DIR/subdomains/all.txt"
+        if [ "$LIVE_COUNT" -eq 0 ]; then
+            log_warn "nmap did not identify live hosts — expanding the CIDR locally for downstream probing"
+            _expand_cidr_hosts "$TARGET" > "$RECON_DIR/subdomains/all.txt"
+        fi
         log_ok "CIDR sweep: $(wc -l < "$RECON_DIR/subdomains/all.txt") live host(s) discovered"
     else
-        log_warn "nmap not installed — writing CIDR as single target"
-        echo "$TARGET" > "$RECON_DIR/subdomains/all.txt"
+        log_warn "nmap not installed — expanding the CIDR locally for downstream probing"
+        _expand_cidr_hosts "$TARGET" > "$RECON_DIR/subdomains/all.txt"
     fi
     # Skip all subdomain enum tools — jump straight to live host probing
 elif [ "${SCOPE_LOCK:-0}" = "1" ] && [ "$TARGET_TYPE" = "ip" ]; then

--- a/tools/recon_engine.sh
+++ b/tools/recon_engine.sh
@@ -20,13 +20,27 @@ log_info()  { echo -e "${CYAN}[*]${NC} $1"; }
 log_step()  { echo -e "    ${CYAN}[>]${NC} $1"; }
 log_done()  { echo -e "    ${GREEN}[✓]${NC} $1"; }
 
-TARGET="${1:?Usage: $0 <target-domain> [--quick]}"
+TARGET="${1:?Usage: $0 <target> [--quick]  (target = FQDN, IP, or CIDR)}"
 QUICK_MODE="${2:-}"
 BASE_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 RECON_DIR="$BASE_DIR/recon/$TARGET"
 TIMESTAMP=$(date +%Y%m%d_%H%M%S)
 THREADS=20
 RATE_LIMIT=50  # requests per second
+
+# ── Detect target type (passed from hunt.py or auto-detected here) ────────────
+_detect_target_type() {
+    local t="$1"
+    if [[ "$t" =~ ^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+/[0-9]+$ ]]; then echo "cidr"
+    elif [[ "$t" =~ ^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$ ]];        then echo "ip"
+    else echo "domain"; fi
+}
+TARGET_TYPE="${TARGET_TYPE:-$(_detect_target_type "$TARGET")}"
+
+# For IP/CIDR: always scope-lock — no subdomain enum needed
+if [ "$TARGET_TYPE" = "ip" ] || [ "$TARGET_TYPE" = "cidr" ]; then
+    SCOPE_LOCK=1
+fi
 
 mkdir -p "$RECON_DIR"/{subdomains,live,ports,urls,js,dirs,params}
 
@@ -39,9 +53,29 @@ echo "============================================="
 echo ""
 
 # ============================================================
-# Phase 1: Subdomain Enumeration
+# Phase 1: Subdomain Enumeration (or Host Discovery for IP/CIDR)
 # ============================================================
 log_info "Phase 1: Subdomain Enumeration"
+
+# ── For IP / CIDR targets: skip subdomain tools, do host discovery instead ───
+if [ "$TARGET_TYPE" = "cidr" ]; then
+    log_info "CIDR target — running nmap ping sweep to discover live hosts"
+    if command -v nmap &>/dev/null; then
+        nmap -sn "$TARGET" -oG - 2>/dev/null \
+            | awk '/Up$/{print $2}' \
+            > "$RECON_DIR/subdomains/all.txt" || true
+        LIVE_COUNT=$(wc -l < "$RECON_DIR/subdomains/all.txt" 2>/dev/null || echo 0)
+        [ "$LIVE_COUNT" -eq 0 ] && echo "$TARGET" > "$RECON_DIR/subdomains/all.txt"
+        log_ok "CIDR sweep: $(wc -l < "$RECON_DIR/subdomains/all.txt") live host(s) discovered"
+    else
+        log_warn "nmap not installed — writing CIDR as single target"
+        echo "$TARGET" > "$RECON_DIR/subdomains/all.txt"
+    fi
+    # Skip all subdomain enum tools — jump straight to live host probing
+elif [ "${SCOPE_LOCK:-0}" = "1" ] && [ "$TARGET_TYPE" = "ip" ]; then
+    log_info "Single IP target — skipping subdomain enumeration"
+    echo "$TARGET" > "$RECON_DIR/subdomains/all.txt"
+else
 
 # Subfinder (passive, fast)
 if command -v subfinder &>/dev/null; then
@@ -95,6 +129,8 @@ log_done "wayback: $(wc -l < "$RECON_DIR/subdomains/wayback_subs.txt" 2>/dev/nul
 cat "$RECON_DIR/subdomains/"*.txt 2>/dev/null | sort -u > "$RECON_DIR/subdomains/all.txt"
 TOTAL_SUBS=$(wc -l < "$RECON_DIR/subdomains/all.txt" 2>/dev/null || echo 0)
 log_ok "Total unique subdomains: $TOTAL_SUBS"
+
+fi  # end of domain-only subdomain enum block
 
 # ============================================================
 # Phase 2: HTTP Probing


### PR DESCRIPTION
## Summary

- `hunt.py` and `recon_engine.sh` now accept **single IPs** and **CIDR ranges** as targets
- No new dependencies — uses Python's stdlib `ipaddress` module and bash regex
- All existing domain-based behaviour is unchanged

## New target formats

```bash
python3 hunt.py --target 192.168.1.100      # single IP
python3 hunt.py --target 10.0.0.0/24        # CIDR range
python3 hunt.py --target example.com        # domain — unchanged
```

## How it works

**hunt.py:**
- `detect_target_type(target)` → `'domain'` | `'ip'` | `'cidr'`
- `expand_cidr(cidr)` → list of host IPs (up to 254)
- `run_recon()` sets `SCOPE_LOCK=1` and `TARGET_TYPE` env var for IPs/CIDRs
- Passes `TARGET_TYPE` to `recon_engine.sh`

**recon_engine.sh:**
- `_detect_target_type()` bash function (pure regex, no deps)
- **CIDR**: runs `nmap -sn` ping sweep → writes live hosts to `subdomains/all.txt`
- **Single IP**: writes IP directly, skips all subdomain enum tools
- **Domain**: all existing subfinder/amass/wayback logic unchanged

## Test plan

- [ ] `python3 hunt.py --target 127.0.0.1` — skips subfinder, probes the IP directly
- [ ] `python3 hunt.py --target 192.168.1.0/24 --quick` — nmap sweep, then httpx on live hosts
- [ ] `python3 hunt.py --target example.com` — existing behaviour unchanged

---
> Contributed from [venkatas/obsidian](https://github.com/venkatas/obsidian) — an evolution of this project.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)