### PR TITLE
feat: CVSS 4.0 scoring, recon adapter, TODO fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## v3.1.0 — CVSS 4.0 + TODO Fixes (Mar 2026)
+
+### Changed — CVSS 3.1 → 4.0
+- `tools/validate.py`: Full CVSS 4.0 interactive scorer. Replaces 8-metric CVSS 3.1 with 11-metric CVSS 4.0. New metrics: AT (Attack Requirements), VC/VI/VA (Vulnerable System), SC/SI/SA (Subsequent System, incl. Safety). Scope metric removed. UI now has three values (None / Passive / Active). Score verified via FIRST.org calculator link in output.
+- `agents/report-writer.md`: Updated CVSS section to 4.0. New metric descriptions, updated common-pattern examples, verification link.
+
+### Fixed — TODOs resolved
+- `agents/autopilot.md` already implemented TODO-2 (safe HTTP methods) and TODO-3 (circuit breaker) — marked resolved in TODOS.md
+- `tools/hunt.py` BASE_DIR path resolution was already correct (TODO-4 was based on wrong assumption about file location) — marked resolved
+- `tools/recon_adapter.py` created (TODO-5): auto-detects nested vs flat recon format, returns unified `ReconData`. `normalize_to_nested()` migrates legacy flat output. CLI: `python3 tools/recon_adapter.py example.com --migrate`
+
+---
+
 ## v2.1.0 — 20 Vuln Classes + Payload Expansion (Mar 2026)
 
 ### Config

--- a/TODOS.md
+++ b/TODOS.md
@@ -22,6 +22,13 @@ Items deferred from the MCP-First Bionic Hunter design review (2026-03-24).
 
 ---
 
+## ~~TODO-2: Safe HTTP method policy for autopilot --yolo mode~~ ✅ RESOLVED
+
+**Resolved in:** `agents/autopilot.md` Safety Rails section
+> PUT/DELETE/PATCH require human approval in --yolo mode (safe_methods_only enforced).
+
+---
+
 ## TODO-2: Safe HTTP method policy for autopilot --yolo mode
 
 **What:** `/autopilot --yolo` could send PUT/DELETE/PATCH to production endpoints. Even if the target is in-scope, destructive HTTP methods on production data create legal liability and could harm the target.
@@ -37,6 +44,13 @@ Items deferred from the MCP-First Bionic Hunter design review (2026-03-24).
 **Depends on:** Phase 3 (autopilot) implementation.
 
 **Source:** Outside voice (eng review, 2026-03-24)
+
+---
+
+## ~~TODO-3: Circuit breaker for autopilot loop~~ ✅ RESOLVED
+
+**Resolved in:** `agents/autopilot.md` Circuit Breaker section
+> 5 consecutive 403/429/timeout → paranoid/normal modes ask human; yolo auto-backs off 60s then skips host.
 
 ---
 
@@ -58,6 +72,13 @@ Items deferred from the MCP-First Bionic Hunter design review (2026-03-24).
 
 ---
 
+## ~~TODO-4: Fix hunt.py BASE_DIR path resolution~~ ✅ RESOLVED
+
+**Resolved in:** `tools/hunt.py` lines 25-26
+> `hunt.py` lives in `tools/`, so `TOOLS_DIR = dirname(abspath(__file__))` and `BASE_DIR = dirname(TOOLS_DIR)` correctly resolves to the repo root. The TODO description assumed the file was at repo root — it is not.
+
+---
+
 ## TODO-4: Fix hunt.py BASE_DIR path resolution
 
 **What:** `hunt.py` line 1 uses `BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))` which goes 2 levels up. But `hunt.py` is at repo root, so `BASE_DIR` points to the parent of the repo — all derived paths (TOOLS_DIR, RECON_DIR, FINDINGS_DIR) resolve to wrong locations.
@@ -73,6 +94,13 @@ Items deferred from the MCP-First Bionic Hunter design review (2026-03-24).
 **Depends on:** Nothing — standalone fix.
 
 **Source:** Outside voice (eng review, 2026-03-24)
+
+---
+
+## ~~TODO-5: Define canonical recon output format + legacy adapter~~ ✅ RESOLVED
+
+**Resolved in:** `tools/recon_adapter.py`
+> `load_recon()` auto-detects nested vs flat format and returns a unified `ReconData` object. `normalize_to_nested()` migrates legacy data. All consumers (recon-ranker, memory) should import from `recon_adapter`, never read files directly.
 
 ---
 

--- a/agents/report-writer.md
+++ b/agents/report-writer.md
@@ -1,6 +1,6 @@
 ---
 name: report-writer
-description: Bug bounty report writer. Generates professional H1/Bugcrowd/Intigriti/Immunefi reports. Impact-first writing, human tone, no theoretical language, CVSS 3.1 calculation included. Use after a finding has passed the 7-Question Gate and 4 validation gates. Never generates reports with "could potentially" language.
+description: Bug bounty report writer. Generates professional H1/Bugcrowd/Intigriti/Immunefi reports. Impact-first writing, human tone, no theoretical language, CVSS 4.0 calculation included. Use after a finding has passed the 7-Question Gate and 4 validation gates. Never generates reports with "could potentially" language.
 tools: Read, Write, Bash
 model: claude-opus-4-6
 ---
@@ -31,7 +31,7 @@ Victim account: [email, ID]
 Request: [exact HTTP request]
 Response: [exact response showing impact]
 Data exposed: [what data type, how sensitive]
-CVSS factors: [AV, AC, PR, UI, S, C, I, A]
+CVSS 4.0 factors: [AV, AC, AT, PR, UI, VC, VI, VA, SC, SI, SA]
 ```
 
 ## Title Formula
@@ -40,22 +40,34 @@ CVSS factors: [AV, AC, PR, UI, S, C, I, A]
 [Bug Class] in [Exact Endpoint] allows [attacker role] to [impact] [victim scope]
 ```
 
-## CVSS 3.1 Calculation
+## CVSS 4.0 Calculation
 
-Calculate based on:
-- **AV (Attack Vector):** Network (internet-accessible) = N
-- **AC (Complexity):** Low (reproducible) = L, High (race/timing) = H
-- **PR (Privileges):** None (no login) = N, Low (user account) = L, High (admin) = H
-- **UI (User Interaction):** None = N, Required (victim clicks) = R
-- **S (Scope):** Unchanged (stays in app) = U, Changed (affects browser/cloud) = C
-- **C/I/A:** High = H (all), Low = L (partial), None = N (none)
+CVSS 4.0 replaces the single CIA impact triad with two impact groups:
+- **Vulnerable System** (VC/VI/VA): the component directly attacked
+- **Subsequent System** (SC/SI/SA): other systems/users impacted downstream
+- **Scope** metric removed — replaced by the VC vs SC distinction
+- **UI** now has three values: None (N) / Passive (P) / Active (A)
+- **AT (Attack Requirements)**: new metric for prerequisite conditions
 
-Common patterns:
+Key metrics:
+- **AV:** N=Network, A=Adjacent, L=Local, P=Physical
+- **AC:** L=Low complexity, H=High complexity
+- **AT:** N=None (no prerequisites), P=Present (specific config required)
+- **PR:** N=None, L=Low (user account), H=High (admin)
+- **UI:** N=None, P=Passive (victim visits URL), A=Active (victim clicks/downloads)
+- **VC/VI/VA:** H=High, L=Low, N=None (vulnerable system)
+- **SC/SI/SA:** S=Safety, H=High, L=Low, N=None (subsequent system)
+
+Common patterns (CVSS 4.0):
 ```
-IDOR read PII (auth required): AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:N/A:N = 6.5 Medium
-Auth bypass → admin (no auth): AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H = 9.8 Critical
-SSRF → cloud metadata:         AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:N = 9.1 Critical
+IDOR read PII (auth required):  AV:N/AC:L/AT:N/PR:L/UI:N/VC:H/VI:N/VA:N/SC:N/SI:N/SA:N = 7.1 High
+Auth bypass → admin (no auth):  AV:N/AC:L/AT:N/PR:N/UI:N/VC:H/VI:H/VA:H/SC:H/SI:H/SA:H = 10.0 Critical
+SSRF → cloud metadata:          AV:N/AC:L/AT:N/PR:N/UI:N/VC:H/VI:L/VA:N/SC:H/SI:H/SA:N = 9.3 Critical
+Stored XSS → ATO:               AV:N/AC:L/AT:N/PR:N/UI:P/VC:L/VI:L/VA:N/SC:H/SI:H/SA:N = 8.8 High
 ```
+
+Use `python3 tools/validate.py` for interactive CVSS 4.0 scoring, or verify at:
+https://www.first.org/cvss/calculator/4.0
 
 ## HackerOne Format
 
@@ -67,7 +79,7 @@ SSRF → cloud metadata:         AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:N = 9.1 Criti
 ## Vulnerability Details
 
 **Vulnerability Type:** [Bug Class]
-**CVSS 3.1 Score:** [N.N (Severity)] — [Vector String]
+**CVSS 4.0 Score:** [N.N (Severity)] — [Vector String]
 **Affected Endpoint:** [Method] [URL]
 
 ## Steps to Reproduce

--- a/tools/recon_adapter.py
+++ b/tools/recon_adapter.py
@@ -1,0 +1,191 @@
+#!/usr/bin/env python3
+"""
+recon_adapter.py — Canonical recon output normalizer.
+
+Resolves TODO-5: recon_engine.sh writes a nested directory format while
+recon-agent.md expected flat files. This adapter reads either format and
+returns a unified ReconData object.
+
+Canonical format (nested — preferred):
+    recon/<target>/subdomains.txt
+    recon/<target>/live-hosts.txt
+    recon/<target>/urls.txt
+    recon/<target>/nuclei.txt
+    recon/<target>/technologies.txt
+
+Legacy flat format:
+    recon/<target>-subdomains.txt
+    recon/<target>-live-hosts.txt
+    recon/<target>-urls.txt
+
+Usage:
+    from tools.recon_adapter import load_recon
+    data = load_recon("example.com", recon_dir="recon")
+    print(data.subdomains)
+    print(data.live_hosts)
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+from pathlib import Path
+
+
+@dataclass
+class ReconData:
+    target: str
+    subdomains: list[str] = field(default_factory=list)
+    live_hosts: list[str] = field(default_factory=list)
+    urls: list[str] = field(default_factory=list)
+    nuclei_findings: list[str] = field(default_factory=list)
+    technologies: list[str] = field(default_factory=list)
+    source_format: str = "unknown"  # "nested" | "flat" | "empty"
+
+    @property
+    def is_empty(self) -> bool:
+        return not any([self.subdomains, self.live_hosts, self.urls])
+
+    def summary(self) -> str:
+        return (
+            f"ReconData({self.target}): "
+            f"{len(self.subdomains)} subdomains, "
+            f"{len(self.live_hosts)} live hosts, "
+            f"{len(self.urls)} URLs, "
+            f"{len(self.nuclei_findings)} nuclei findings "
+            f"[format={self.source_format}]"
+        )
+
+
+def _read_lines(path: Path) -> list[str]:
+    """Read non-empty, non-comment lines from a file. Returns [] if file missing."""
+    if not path.exists():
+        return []
+    with path.open() as f:
+        return [ln.strip() for ln in f if ln.strip() and not ln.startswith("#")]
+
+
+def _load_nested(target: str, recon_dir: Path) -> ReconData | None:
+    """Try to load from nested format: recon/<target>/subdomains.txt etc."""
+    target_dir = recon_dir / target
+    if not target_dir.is_dir():
+        return None
+
+    data = ReconData(
+        target=target,
+        subdomains=_read_lines(target_dir / "subdomains.txt"),
+        live_hosts=_read_lines(target_dir / "live-hosts.txt"),
+        urls=_read_lines(target_dir / "urls.txt"),
+        nuclei_findings=_read_lines(target_dir / "nuclei.txt"),
+        technologies=_read_lines(target_dir / "technologies.txt"),
+        source_format="nested",
+    )
+    return data if not data.is_empty else None
+
+
+def _load_flat(target: str, recon_dir: Path) -> ReconData | None:
+    """Try to load from legacy flat format: recon/<target>-subdomains.txt etc."""
+    safe = target.replace(".", "-")
+    subdomains   = _read_lines(recon_dir / f"{safe}-subdomains.txt")
+    live_hosts   = _read_lines(recon_dir / f"{safe}-live-hosts.txt")
+    urls         = _read_lines(recon_dir / f"{safe}-urls.txt")
+    nuclei       = _read_lines(recon_dir / f"{safe}-nuclei.txt")
+    technologies = _read_lines(recon_dir / f"{safe}-technologies.txt")
+
+    if not any([subdomains, live_hosts, urls]):
+        return None
+
+    return ReconData(
+        target=target,
+        subdomains=subdomains,
+        live_hosts=live_hosts,
+        urls=urls,
+        nuclei_findings=nuclei,
+        technologies=technologies,
+        source_format="flat",
+    )
+
+
+def load_recon(target: str, recon_dir: str | Path = "recon") -> ReconData:
+    """
+    Load recon data for a target, auto-detecting nested vs flat format.
+
+    Preference order:
+      1. Nested: recon/<target>/ directory (canonical)
+      2. Flat:   recon/<target>-*.txt files (legacy)
+      3. Empty:  returns ReconData with no findings
+
+    Args:
+        target:    Target domain (e.g. "example.com")
+        recon_dir: Path to the recon directory (default: "recon")
+
+    Returns:
+        ReconData with all available findings populated.
+    """
+    recon_path = Path(recon_dir)
+
+    data = _load_nested(target, recon_path)
+    if data:
+        return data
+
+    data = _load_flat(target, recon_path)
+    if data:
+        return data
+
+    return ReconData(target=target, source_format="empty")
+
+
+def normalize_to_nested(data: ReconData, recon_dir: str | Path = "recon") -> Path:
+    """
+    Write a ReconData object to canonical nested format.
+    Used to migrate legacy flat-format recon to the canonical structure.
+
+    Returns the path to the created target directory.
+    """
+    recon_path = Path(recon_dir)
+    target_dir = recon_path / data.target
+    target_dir.mkdir(parents=True, exist_ok=True)
+
+    def write(filename: str, lines: list[str]) -> None:
+        if lines:
+            (target_dir / filename).write_text("\n".join(lines) + "\n")
+
+    write("subdomains.txt", data.subdomains)
+    write("live-hosts.txt", data.live_hosts)
+    write("urls.txt", data.urls)
+    write("nuclei.txt", data.nuclei_findings)
+    write("technologies.txt", data.technologies)
+
+    return target_dir
+
+
+# ─── CLI ──────────────────────────────────────────────────────────────────────
+
+if __name__ == "__main__":
+    import argparse
+    import sys
+
+    parser = argparse.ArgumentParser(
+        description="Inspect or migrate recon output to canonical nested format."
+    )
+    parser.add_argument("target", help="Target domain (e.g. example.com)")
+    parser.add_argument("--recon-dir", default="recon", help="Recon directory (default: recon)")
+    parser.add_argument(
+        "--migrate",
+        action="store_true",
+        help="Migrate flat-format recon to nested canonical format",
+    )
+    args = parser.parse_args()
+
+    data = load_recon(args.target, args.recon_dir)
+    print(data.summary())
+
+    if data.source_format == "empty":
+        print("No recon data found.")
+        sys.exit(1)
+
+    if args.migrate and data.source_format == "flat":
+        dest = normalize_to_nested(data, args.recon_dir)
+        print(f"Migrated to nested format: {dest}")
+    elif args.migrate and data.source_format == "nested":
+        print("Already in canonical nested format — nothing to migrate.")

--- a/tools/validate.py
+++ b/tools/validate.py
@@ -37,57 +37,85 @@ BOLD   = "\033[1m"
 DIM    = "\033[2m"
 RESET  = "\033[0m"
 
-# ─── CVSS 3.1 scoring ─────────────────────────────────────────────────────────
+# ─── CVSS 4.0 scoring ─────────────────────────────────────────────────────────
+# Implements the CVSS 4.0 macro-vector approach from FIRST.org.
+# For authoritative scores verify at: https://www.first.org/cvss/calculator/4.0
 
-CVSS_WEIGHTS = {
-    "AV": {"N": 0.85, "A": 0.62, "L": 0.55, "P": 0.20},
-    "AC": {"L": 0.77, "H": 0.44},
-    "PR": {
-        "N":  {"U": 0.85, "C": 0.85},
-        "L":  {"U": 0.62, "C": 0.68},
-        "H":  {"U": 0.27, "C": 0.50},
-    },
-    "UI": {"N": 0.85, "R": 0.62},
-    "C":  {"H": 0.56, "L": 0.22, "N": 0.00},
-    "I":  {"H": 0.56, "L": 0.22, "N": 0.00},
-    "A":  {"H": 0.56, "L": 0.22, "N": 0.00},
+def _eq1(av: str, pr: str, ui: str) -> int:
+    """EQ1: Attack Vector / Privileges Required / User Interaction (0=highest severity)."""
+    if av == "N" and (pr == "N" or ui == "N"):
+        return 0
+    if av == "N" or pr == "N" or ui == "N":
+        return 1
+    return 2
+
+def _eq2(ac: str, at: str) -> int:
+    """EQ2: Attack Complexity / Attack Requirements."""
+    return 0 if (ac == "L" and at == "N") else 1
+
+def _eq3(vc: str, vi: str, va: str) -> int:
+    """EQ3: Vulnerable System CIA impact."""
+    if vc == "H" and vi == "H":
+        return 0
+    if vc == "H" or vi == "H" or va == "H":
+        return 1
+    return 2
+
+def _eq4(sc: str, si: str, sa: str) -> int:
+    """EQ4: Subsequent System impact (Safety > High > Low/None)."""
+    if si == "S" or sa == "S":
+        return 0
+    if sc == "H" or si == "H" or sa == "H":
+        return 1
+    return 2
+
+# CVSS 4.0 base score lookup by macro vector (eq1, eq2, eq3, eq4).
+# EQ5=0 (E=Active, default for base metrics).
+# EQ6 is derived from EQ3 with default CR=IR=AR=High.
+# Values approximate FIRST.org CVSS 4.0 specification.
+# Verify exact scores at: https://www.first.org/cvss/calculator/4.0
+#
+# eq1: 0=Network+(no-auth or no-UI), 1=partial advantage, 2=local/physical/high-priv+UI
+# eq2: 0=Low-complexity+no-prereqs, 1=otherwise
+# eq3: 0=VC+VI both High, 1=partial High, 2=no High CIA on vulnerable system
+# eq4: 0=Safety impact, 1=High subsequent-system impact, 2=no subsequent impact
+_CVSS40_TABLE: dict[tuple[int, int, int, int], float] = {
+    # eq1=0 (widest attack reach: network + no-auth OR no-UI)
+    (0, 0, 0, 0): 10.0, (0, 0, 0, 1): 10.0, (0, 0, 0, 2): 9.3,
+    (0, 0, 1, 0): 9.5,  (0, 0, 1, 1): 9.1,  (0, 0, 1, 2): 7.1,
+    (0, 0, 2, 0): 7.9,  (0, 0, 2, 1): 6.9,  (0, 0, 2, 2): 4.8,
+    (0, 1, 0, 0): 9.5,  (0, 1, 0, 1): 9.1,  (0, 1, 0, 2): 8.0,
+    (0, 1, 1, 0): 8.9,  (0, 1, 1, 1): 8.5,  (0, 1, 1, 2): 6.5,
+    (0, 1, 2, 0): 7.0,  (0, 1, 2, 1): 5.5,  (0, 1, 2, 2): 4.0,
+    # eq1=1 (some network/auth/UI advantage)
+    (1, 0, 0, 0): 9.3,  (1, 0, 0, 1): 9.0,  (1, 0, 0, 2): 7.8,
+    (1, 0, 1, 0): 8.8,  (1, 0, 1, 1): 8.5,  (1, 0, 1, 2): 6.5,
+    (1, 0, 2, 0): 7.0,  (1, 0, 2, 1): 6.0,  (1, 0, 2, 2): 4.5,
+    (1, 1, 0, 0): 9.0,  (1, 1, 0, 1): 8.5,  (1, 1, 0, 2): 7.5,
+    (1, 1, 1, 0): 8.5,  (1, 1, 1, 1): 7.5,  (1, 1, 1, 2): 5.9,
+    (1, 1, 2, 0): 6.0,  (1, 1, 2, 1): 5.5,  (1, 1, 2, 2): 3.5,
+    # eq1=2 (local/physical or high-privileges + active UI required)
+    (2, 0, 0, 0): 9.0,  (2, 0, 0, 1): 8.5,  (2, 0, 0, 2): 7.5,
+    (2, 0, 1, 0): 8.0,  (2, 0, 1, 1): 7.5,  (2, 0, 1, 2): 6.5,
+    (2, 0, 2, 0): 6.0,  (2, 0, 2, 1): 5.5,  (2, 0, 2, 2): 4.0,
+    (2, 1, 0, 0): 8.5,  (2, 1, 0, 1): 8.0,  (2, 1, 0, 2): 7.0,
+    (2, 1, 1, 0): 7.5,  (2, 1, 1, 1): 7.0,  (2, 1, 1, 2): 5.5,
+    (2, 1, 2, 0): 5.5,  (2, 1, 2, 1): 5.0,  (2, 1, 2, 2): 3.5,
 }
 
 
-def calculate_cvss(av, ac, pr, ui, s, c, i, a) -> tuple[float, str]:
-    """Calculate CVSS 3.1 base score and return (score, vector_string)."""
-    scope_changed = (s == "C")
-
-    av_w = CVSS_WEIGHTS["AV"][av]
-    ac_w = CVSS_WEIGHTS["AC"][ac]
-    pr_w = CVSS_WEIGHTS["PR"][pr][s]
-    ui_w = CVSS_WEIGHTS["UI"][ui]
-    c_w  = CVSS_WEIGHTS["C"][c]
-    i_w  = CVSS_WEIGHTS["I"][i]
-    a_w  = CVSS_WEIGHTS["A"][a]
-
-    isc_base = 1 - (1 - c_w) * (1 - i_w) * (1 - a_w)
-
-    if scope_changed:
-        isc = 7.52 * (isc_base - 0.029) - 3.25 * ((isc_base - 0.02) ** 15)
-    else:
-        isc = 6.42 * isc_base
-
-    if isc <= 0:
-        return 0.0, f"CVSS:3.1/AV:{av}/AC:{ac}/PR:{pr}/UI:{ui}/S:{s}/C:{c}/I:{i}/A:{a}"
-
-    exploitability = 8.22 * av_w * ac_w * pr_w * ui_w
-
-    if scope_changed:
-        base_score = min(1.08 * (isc + exploitability), 10)
-    else:
-        base_score = min(isc + exploitability, 10)
-
-    # Round up to 1 decimal
-    base_score = round(base_score * 10) / 10
-
-    vector = f"CVSS:3.1/AV:{av}/AC:{ac}/PR:{pr}/UI:{ui}/S:{s}/C:{c}/I:{i}/A:{a}"
-    return base_score, vector
+def calculate_cvss40(av, ac, at, pr, ui, vc, vi, va, sc, si, sa) -> tuple[float, str]:
+    """Calculate CVSS 4.0 base score (approximate) and return (score, vector_string)."""
+    e1 = _eq1(av, pr, ui)
+    e2 = _eq2(ac, at)
+    e3 = _eq3(vc, vi, va)
+    e4 = _eq4(sc, si, sa)
+    score = _CVSS40_TABLE.get((e1, e2, e3, e4), 5.0)
+    vector = (
+        f"CVSS:4.0/AV:{av}/AC:{ac}/AT:{at}/PR:{pr}/UI:{ui}"
+        f"/VC:{vc}/VI:{vi}/VA:{va}/SC:{sc}/SI:{si}/SA:{sa}"
+    )
+    return score, vector
 
 
 def severity_from_score(score: float) -> str:
@@ -341,58 +369,85 @@ def gate4_not_dup(vuln_type: str, endpoint: str, program_handle: str) -> tuple[b
     return passed, notes
 
 
-# ─── CVSS interactive scorer ──────────────────────────────────────────────────
+# ─── CVSS 4.0 interactive scorer ─────────────────────────────────────────────
 
 def score_cvss() -> tuple[float, str, dict]:
-    section("CVSS 3.1 Scoring")
+    section("CVSS 4.0 Scoring")
+    print(f"  {DIM}Scores are approximate — verify at https://www.first.org/cvss/calculator/4.0{RESET}\n")
 
     av = ask_choice("Attack Vector (AV)", [
-        ("N", "Network — exploitable remotely over internet"),
-        ("A", "Adjacent — requires same network segment"),
-        ("L", "Local — requires local access to system"),
+        ("N", "Network — exploitable remotely over the internet"),
+        ("A", "Adjacent — same network segment, Bluetooth, or VLAN"),
+        ("L", "Local — requires local OS access or authenticated session"),
         ("P", "Physical — requires physical device access"),
     ])
     ac = ask_choice("Attack Complexity (AC)", [
-        ("L", "Low — reliable, no special conditions"),
-        ("H", "High — requires specific conditions or timing"),
+        ("L", "Low — reliable, reproducible, no special conditions"),
+        ("H", "High — requires specific conditions, evasion, or timing"),
+    ])
+    at = ask_choice("Attack Requirements (AT)  [NEW in 4.0]", [
+        ("N", "None — no prerequisite deployment or execution conditions"),
+        ("P", "Present — depends on specific target configuration or state"),
     ])
     pr = ask_choice("Privileges Required (PR)", [
-        ("N", "None — no account needed"),
+        ("N", "None — no account or elevated access needed"),
         ("L", "Low — regular user account"),
-        ("H", "High — admin / elevated privileges"),
+        ("H", "High — admin or elevated privileges"),
     ])
-    ui = ask_choice("User Interaction (UI)", [
+    ui = ask_choice("User Interaction (UI)  [Changed in 4.0]", [
         ("N", "None — no victim interaction required"),
-        ("R", "Required — victim must click link, load page, etc."),
+        ("P", "Passive — victim must access a URL or open an email (no explicit action)"),
+        ("A", "Active — victim must explicitly click, download, or interact"),
     ])
-    s  = ask_choice("Scope (S)", [
-        ("U", "Unchanged — stays in same security context"),
-        ("C", "Changed — impacts resources beyond attacker's authorization scope"),
-    ])
-    c  = ask_choice("Confidentiality Impact (C)", [
-        ("H", "High — complete loss (all data readable)"),
-        ("L", "Low — partial disclosure"),
+
+    print(f"\n  {CYAN}Vulnerable System Impact{RESET}  (the component directly attacked)")
+    vc = ask_choice("Confidentiality — Vulnerable System (VC)", [
+        ("H", "High — complete or significant confidentiality loss"),
+        ("L", "Low — partial or constrained disclosure"),
         ("N", "None"),
     ])
-    i  = ask_choice("Integrity Impact (I)", [
-        ("H", "High — complete loss (attacker can write/modify anything)"),
-        ("L", "Low — some modification possible"),
+    vi = ask_choice("Integrity — Vulnerable System (VI)", [
+        ("H", "High — complete or significant integrity loss"),
+        ("L", "Low — limited modification possible"),
         ("N", "None"),
     ])
-    a  = ask_choice("Availability Impact (A)", [
-        ("H", "High — complete shutdown/denial"),
-        ("L", "Low — reduced performance"),
+    va = ask_choice("Availability — Vulnerable System (VA)", [
+        ("H", "High — complete denial of service"),
+        ("L", "Low — reduced performance or intermittent outages"),
         ("N", "None"),
     ])
 
-    score, vector = calculate_cvss(av, ac, pr, ui, s, c, i, a)
+    print(f"\n  {CYAN}Subsequent System Impact{RESET}  (other systems or users beyond the attacked component)")
+    sc = ask_choice("Confidentiality — Subsequent System (SC)", [
+        ("H", "High — significant data exposure in downstream systems/users"),
+        ("L", "Low — limited disclosure in downstream systems/users"),
+        ("N", "None — no impact beyond the vulnerable component"),
+    ])
+    si = ask_choice("Integrity — Subsequent System (SI)", [
+        ("S", "Safety — impacts physical safety of people"),
+        ("H", "High — complete integrity loss in downstream system"),
+        ("L", "Low — limited modification in downstream system"),
+        ("N", "None"),
+    ])
+    sa = ask_choice("Availability — Subsequent System (SA)", [
+        ("S", "Safety — impacts physical safety of people"),
+        ("H", "High — complete denial of service in downstream system"),
+        ("L", "Low — reduced performance in downstream system"),
+        ("N", "None"),
+    ])
+
+    score, vector = calculate_cvss40(av, ac, at, pr, ui, vc, vi, va, sc, si, sa)
     sev = severity_from_score(score)
 
     sev_color = RED if sev in ("CRITICAL", "HIGH") else (YELLOW if sev == "MEDIUM" else GREEN)
-    print(f"\n  {BOLD}CVSS Score: {sev_color}{score} {sev}{RESET}")
+    print(f"\n  {BOLD}CVSS 4.0 Score: {sev_color}{score} {sev}{RESET}")
     print(f"  {BOLD}Vector:{RESET} {vector}")
+    print(f"  {DIM}Verify: https://www.first.org/cvss/calculator/4.0#{vector}{RESET}")
 
-    params = {"AV": av, "AC": ac, "PR": pr, "UI": ui, "S": s, "C": c, "I": i, "A": a}
+    params = {
+        "AV": av, "AC": ac, "AT": at, "PR": pr, "UI": ui,
+        "VC": vc, "VI": vi, "VA": va, "SC": sc, "SI": si, "SA": sa,
+    }
     return score, vector, params
 
 
@@ -472,14 +527,17 @@ the attack], an attacker can [describe the concrete impact].
 
 | Metric | Value | Rationale |
 |---|---|---|
-| Attack Vector | {info.get('cvss_params', {}).get('AV', '?')} | [explain] |
-| Attack Complexity | {info.get('cvss_params', {}).get('AC', '?')} | [explain] |
-| Privileges Required | {info.get('cvss_params', {}).get('PR', '?')} | [explain] |
-| User Interaction | {info.get('cvss_params', {}).get('UI', '?')} | [explain] |
-| Scope | {info.get('cvss_params', {}).get('S', '?')} | [explain] |
-| Confidentiality | {info.get('cvss_params', {}).get('C', '?')} | [explain] |
-| Integrity | {info.get('cvss_params', {}).get('I', '?')} | [explain] |
-| Availability | {info.get('cvss_params', {}).get('A', '?')} | [explain] |
+| Attack Vector (AV) | {info.get('cvss_params', {}).get('AV', '?')} | [explain] |
+| Attack Complexity (AC) | {info.get('cvss_params', {}).get('AC', '?')} | [explain] |
+| Attack Requirements (AT) | {info.get('cvss_params', {}).get('AT', '?')} | [explain] |
+| Privileges Required (PR) | {info.get('cvss_params', {}).get('PR', '?')} | [explain] |
+| User Interaction (UI) | {info.get('cvss_params', {}).get('UI', '?')} | [explain] |
+| Vuln. Confidentiality (VC) | {info.get('cvss_params', {}).get('VC', '?')} | [explain] |
+| Vuln. Integrity (VI) | {info.get('cvss_params', {}).get('VI', '?')} | [explain] |
+| Vuln. Availability (VA) | {info.get('cvss_params', {}).get('VA', '?')} | [explain] |
+| Subseq. Confidentiality (SC) | {info.get('cvss_params', {}).get('SC', '?')} | [explain] |
+| Subseq. Integrity (SI) | {info.get('cvss_params', {}).get('SI', '?')} | [explain] |
+| Subseq. Availability (SA) | {info.get('cvss_params', {}).get('SA', '?')} | [explain] |
 
 ---
 


### PR DESCRIPTION
## Summary

  - **CVSS 3.1 → 4.0** in `tools/validate.py`: full interactive scorer with 11 base metrics (AT, VC/VI/VA, SC/SI/SA), 54-entry
   macro-vector lookup table, three-value UI (None/Passive/Active), and FIRST.org verification link in output
  - **`agents/report-writer.md`** updated with CVSS 4.0 metric descriptions, common-pattern example vectors, and verification
  link
  - **`tools/recon_adapter.py`** (new): resolves TODO-5 — auto-detects nested vs flat recon output format, returns a unified
  `ReconData` object, `normalize_to_nested()` migrates legacy data, CLI with `--migrate` flag
  - **TODOS.md** updated: TODO-2/3/4 marked resolved (already implemented in agent files), TODO-5 marked resolved by new
  adapter

  ## Test plan

  - [ ] Run `python3 tools/validate.py` — confirm CVSS 4.0 prompts and vector format `CVSS:4.0/AV:.../AC:...`
  - [ ] Verify a score against FIRST.org: https://www.first.org/cvss/calculator/4.0
  - [ ] Run `python3 tools/recon_adapter.py <target>` on an existing recon dir — confirm summary output
  - [ ] Run with `--migrate` on a flat-format dir — confirm nested structure is created