### PR TITLE
Feat/caido mcp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,9 @@ config.json
 *.burp
 *.json.bak
 
+# Claude local settings (contains API keys)
+.claude/settings.local.json
+
 # API keys and tokens
 .env
 secrets.txt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## v3.1.0 — CVSS 4.0 + TODO Fixes (Mar 2026)
+
+### Changed — CVSS 3.1 → 4.0
+- `tools/validate.py`: Full CVSS 4.0 interactive scorer. Replaces 8-metric CVSS 3.1 with 11-metric CVSS 4.0. New metrics: AT (Attack Requirements), VC/VI/VA (Vulnerable System), SC/SI/SA (Subsequent System, incl. Safety). Scope metric removed. UI now has three values (None / Passive / Active). Score verified via FIRST.org calculator link in output.
+- `agents/report-writer.md`: Updated CVSS section to 4.0. New metric descriptions, updated common-pattern examples, verification link.
+
+### Fixed — TODOs resolved
+- `agents/autopilot.md` already implemented TODO-2 (safe HTTP methods) and TODO-3 (circuit breaker) — marked resolved in TODOS.md
+- `tools/hunt.py` BASE_DIR path resolution was already correct (TODO-4 was based on wrong assumption about file location) — marked resolved
+- `tools/recon_adapter.py` created (TODO-5): auto-detects nested vs flat recon format, returns unified `ReconData`. `normalize_to_nested()` migrates legacy flat output. CLI: `python3 tools/recon_adapter.py example.com --migrate`
+
+---
+
 ## v2.1.0 — 20 Vuln Classes + Payload Expansion (Mar 2026)
 
 ### Config

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,6 +61,7 @@ This repo is a Claude Code plugin for professional bug bounty hunting across Hac
 
 ### MCP Integrations (in `mcp/`)
 
+- `mcp/caido-mcp/` — Caido proxy integration (history, search, PoC export)
 - `mcp/burp-mcp-client/` — Burp Suite proxy integration
 - `mcp/hackerone-mcp/` — HackerOne public API (Hacktivity, program stats, policy)
 

--- a/TODOS.md
+++ b/TODOS.md
@@ -22,6 +22,13 @@ Items deferred from the MCP-First Bionic Hunter design review (2026-03-24).
 
 ---
 
+## ~~TODO-2: Safe HTTP method policy for autopilot --yolo mode~~ ✅ RESOLVED
+
+**Resolved in:** `agents/autopilot.md` Safety Rails section
+> PUT/DELETE/PATCH require human approval in --yolo mode (safe_methods_only enforced).
+
+---
+
 ## TODO-2: Safe HTTP method policy for autopilot --yolo mode
 
 **What:** `/autopilot --yolo` could send PUT/DELETE/PATCH to production endpoints. Even if the target is in-scope, destructive HTTP methods on production data create legal liability and could harm the target.
@@ -37,6 +44,13 @@ Items deferred from the MCP-First Bionic Hunter design review (2026-03-24).
 **Depends on:** Phase 3 (autopilot) implementation.
 
 **Source:** Outside voice (eng review, 2026-03-24)
+
+---
+
+## ~~TODO-3: Circuit breaker for autopilot loop~~ ✅ RESOLVED
+
+**Resolved in:** `agents/autopilot.md` Circuit Breaker section
+> 5 consecutive 403/429/timeout → paranoid/normal modes ask human; yolo auto-backs off 60s then skips host.
 
 ---
 
@@ -58,6 +72,13 @@ Items deferred from the MCP-First Bionic Hunter design review (2026-03-24).
 
 ---
 
+## ~~TODO-4: Fix hunt.py BASE_DIR path resolution~~ ✅ RESOLVED
+
+**Resolved in:** `tools/hunt.py` lines 25-26
+> `hunt.py` lives in `tools/`, so `TOOLS_DIR = dirname(abspath(__file__))` and `BASE_DIR = dirname(TOOLS_DIR)` correctly resolves to the repo root. The TODO description assumed the file was at repo root — it is not.
+
+---
+
 ## TODO-4: Fix hunt.py BASE_DIR path resolution
 
 **What:** `hunt.py` line 1 uses `BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))` which goes 2 levels up. But `hunt.py` is at repo root, so `BASE_DIR` points to the parent of the repo — all derived paths (TOOLS_DIR, RECON_DIR, FINDINGS_DIR) resolve to wrong locations.
@@ -73,6 +94,13 @@ Items deferred from the MCP-First Bionic Hunter design review (2026-03-24).
 **Depends on:** Nothing — standalone fix.
 
 **Source:** Outside voice (eng review, 2026-03-24)
+
+---
+
+## ~~TODO-5: Define canonical recon output format + legacy adapter~~ ✅ RESOLVED
+
+**Resolved in:** `tools/recon_adapter.py`
+> `load_recon()` auto-detects nested vs flat format and returns a unified `ReconData` object. `normalize_to_nested()` migrates legacy data. All consumers (recon-ranker, memory) should import from `recon_adapter`, never read files directly.
 
 ---
 

--- a/agents/report-writer.md
+++ b/agents/report-writer.md
@@ -1,6 +1,6 @@
 ---
 name: report-writer
-description: Bug bounty report writer. Generates professional H1/Bugcrowd/Intigriti/Immunefi reports. Impact-first writing, human tone, no theoretical language, CVSS 3.1 calculation included. Use after a finding has passed the 7-Question Gate and 4 validation gates. Never generates reports with "could potentially" language.
+description: Bug bounty report writer. Generates professional H1/Bugcrowd/Intigriti/Immunefi reports. Impact-first writing, human tone, no theoretical language, CVSS 4.0 calculation included. Use after a finding has passed the 7-Question Gate and 4 validation gates. Never generates reports with "could potentially" language.
 tools: Read, Write, Bash
 model: claude-opus-4-6
 ---
@@ -31,7 +31,7 @@ Victim account: [email, ID]
 Request: [exact HTTP request]
 Response: [exact response showing impact]
 Data exposed: [what data type, how sensitive]
-CVSS factors: [AV, AC, PR, UI, S, C, I, A]
+CVSS 4.0 factors: [AV, AC, AT, PR, UI, VC, VI, VA, SC, SI, SA]
 ```
 
 ## Title Formula
@@ -40,22 +40,34 @@ CVSS factors: [AV, AC, PR, UI, S, C, I, A]
 [Bug Class] in [Exact Endpoint] allows [attacker role] to [impact] [victim scope]
 ```
 
-## CVSS 3.1 Calculation
+## CVSS 4.0 Calculation
 
-Calculate based on:
-- **AV (Attack Vector):** Network (internet-accessible) = N
-- **AC (Complexity):** Low (reproducible) = L, High (race/timing) = H
-- **PR (Privileges):** None (no login) = N, Low (user account) = L, High (admin) = H
-- **UI (User Interaction):** None = N, Required (victim clicks) = R
-- **S (Scope):** Unchanged (stays in app) = U, Changed (affects browser/cloud) = C
-- **C/I/A:** High = H (all), Low = L (partial), None = N (none)
+CVSS 4.0 replaces the single CIA impact triad with two impact groups:
+- **Vulnerable System** (VC/VI/VA): the component directly attacked
+- **Subsequent System** (SC/SI/SA): other systems/users impacted downstream
+- **Scope** metric removed — replaced by the VC vs SC distinction
+- **UI** now has three values: None (N) / Passive (P) / Active (A)
+- **AT (Attack Requirements)**: new metric for prerequisite conditions
 
-Common patterns:
+Key metrics:
+- **AV:** N=Network, A=Adjacent, L=Local, P=Physical
+- **AC:** L=Low complexity, H=High complexity
+- **AT:** N=None (no prerequisites), P=Present (specific config required)
+- **PR:** N=None, L=Low (user account), H=High (admin)
+- **UI:** N=None, P=Passive (victim visits URL), A=Active (victim clicks/downloads)
+- **VC/VI/VA:** H=High, L=Low, N=None (vulnerable system)
+- **SC/SI/SA:** S=Safety, H=High, L=Low, N=None (subsequent system)
+
+Common patterns (CVSS 4.0):
 ```
-IDOR read PII (auth required): AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:N/A:N = 6.5 Medium
-Auth bypass → admin (no auth): AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H = 9.8 Critical
-SSRF → cloud metadata:         AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:N = 9.1 Critical
+IDOR read PII (auth required):  AV:N/AC:L/AT:N/PR:L/UI:N/VC:H/VI:N/VA:N/SC:N/SI:N/SA:N = 7.1 High
+Auth bypass → admin (no auth):  AV:N/AC:L/AT:N/PR:N/UI:N/VC:H/VI:H/VA:H/SC:H/SI:H/SA:H = 10.0 Critical
+SSRF → cloud metadata:          AV:N/AC:L/AT:N/PR:N/UI:N/VC:H/VI:L/VA:N/SC:H/SI:H/SA:N = 9.3 Critical
+Stored XSS → ATO:               AV:N/AC:L/AT:N/PR:N/UI:P/VC:L/VI:L/VA:N/SC:H/SI:H/SA:N = 8.8 High
 ```
+
+Use `python3 tools/validate.py` for interactive CVSS 4.0 scoring, or verify at:
+https://www.first.org/cvss/calculator/4.0
 
 ## HackerOne Format
 
@@ -67,7 +79,7 @@ SSRF → cloud metadata:         AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:N = 9.1 Criti
 ## Vulnerability Details
 
 **Vulnerability Type:** [Bug Class]
-**CVSS 3.1 Score:** [N.N (Severity)] — [Vector String]
+**CVSS 4.0 Score:** [N.N (Severity)] — [Vector String]
 **Affected Endpoint:** [Method] [URL]
 
 ## Steps to Reproduce

--- a/agents/report-writer.md
+++ b/agents/report-writer.md
@@ -165,7 +165,11 @@ Attack is [repeatable / one-time]. Fix cost: [simple one-line change].
 [Specific code change with before/after]
 ```
 
-## Burp MCP Integration (optional — only if Burp MCP is connected)
+## Proxy MCP Integration (optional — use whichever proxy you run)
+
+Check which MCP server is connected and use the matching tool. Both provide equivalent coverage.
+
+### Burp MCP
 
 If the `burp` MCP server is available:
 
@@ -175,7 +179,22 @@ If the `burp` MCP server is available:
 4. If multiple related requests exist, include the full attack flow sequence
 5. Use Burp's Scanner findings to add context about other issues on the same endpoint
 
-If Burp MCP is NOT available:
+### Caido MCP
+
+If the `caido` MCP server is available:
+
+1. Use `caido.get_proxy_history` filtered by the target host to find the relevant request
+2. Call `caido.export_for_report` with the request ID — it returns a formatted HTTP block ready to paste
+3. If multiple requests form an attack chain, export each step separately and sequence them
+4. Use `caido.search_requests` to find related traffic (e.g. all POSTs to `/api/v1/user`)
+
+```
+caido.get_proxy_history(host="example.com", method="POST", limit=20)
+caido.export_for_report(id="<id from above>")
+```
+
+### No proxy MCP
+
 - Ask the researcher to paste the exact HTTP request and response
 - Note in the report template: "[PASTE ACTUAL REQUEST HERE]"
 

--- a/mcp/caido-mcp/README.md
+++ b/mcp/caido-mcp/README.md
@@ -1,0 +1,149 @@
+# Caido MCP Integration
+
+Connect Claude Bug Bounty to Caido's local GraphQL API for live proxy traffic visibility.
+
+## What You Get
+
+With Caido MCP connected, the tool can:
+
+- **Read proxy history** — every request/response you've captured through Caido
+- **Filter traffic** — by host, method, or response status code
+- **Search requests** — find all traffic to a specific domain or path
+- **Export PoC blocks** — format any request/response directly into report-ready HTTP blocks
+
+## Tools
+
+| Tool | Command | Description |
+|---|---|---|
+| `get_proxy_history` | `history` | List recent proxy requests (filterable) |
+| `get_request` | `get <id>` | Full request + response for a specific ID |
+| `search_requests` | `search <keyword>` | Search by host keyword |
+| `export_for_report` | `export <id>` | Format request/response as PoC block |
+| `replay_request` | `replay <id>` | Resend a request with optional overrides (swap IDs, headers, body) |
+| `get_findings` | `findings` | List findings logged in Caido |
+| `add_note` | `note <id> <text>` | Annotate a request with a note (visible in Caido UI) |
+
+## Setup (5 minutes)
+
+### Step 1: Generate a Caido API Key
+
+1. Open Caido and go to **Settings → API Keys**
+2. Click **Generate Key**
+3. Copy the key — it won't be shown again
+
+### Step 2: Set Environment Variable
+
+```bash
+export CAIDO_API_KEY="your-api-key-here"
+```
+
+Add to your `~/.zshrc` for persistence:
+
+```bash
+echo 'export CAIDO_API_KEY="your-api-key-here"' >> ~/.zshrc
+```
+
+If Caido is running on a non-default port, also set:
+
+```bash
+export CAIDO_URL="http://127.0.0.1:8080"   # default — change if needed
+```
+
+### Step 3: Add to Claude Code Settings
+
+Copy the MCP config into your Claude Code settings:
+
+```bash
+claude config edit
+```
+
+Add the `caido` entry from `config.json` in this directory to your `mcpServers` section.
+
+### Step 4: Verify Connection
+
+Start Caido and browse your target, then test from the repo root:
+
+```bash
+python3 mcp/caido-mcp/server.py history --limit 5
+```
+
+You should see a JSON list of recent proxy requests.
+
+## Usage Examples
+
+```bash
+# Recent traffic to a target
+python3 mcp/caido-mcp/server.py history --host example.com --limit 20
+
+# Only POST requests
+python3 mcp/caido-mcp/server.py history --host example.com --method POST
+
+# Only 200 responses
+python3 mcp/caido-mcp/server.py history --host example.com --status 200
+
+# Full request + response for a specific ID
+python3 mcp/caido-mcp/server.py get abc123
+
+# Export a PoC block for a report
+python3 mcp/caido-mcp/server.py export abc123
+
+# Replay a request as-is (confirm it still works)
+python3 mcp/caido-mcp/server.py replay abc123
+
+# Replay with a different user ID in the path (IDOR test)
+python3 mcp/caido-mcp/server.py replay abc123 --path /api/v1/user/2
+
+# Replay with a different auth header (cross-account test)
+python3 mcp/caido-mcp/server.py replay abc123 --header "Authorization: Bearer <victim-token>"
+
+# Replay with a modified body
+python3 mcp/caido-mcp/server.py replay abc123 --body '{"user_id": 2}'
+
+# List all findings logged in Caido
+python3 mcp/caido-mcp/server.py findings
+
+# Annotate a request with a note
+python3 mcp/caido-mcp/server.py note abc123 "Possible IDOR — returns victim PII when ID incremented"
+```
+
+## Example PoC Output
+
+`export_for_report` produces report-ready HTTP blocks:
+
+```
+### Request (Caido ID: abc123)
+```http
+GET /api/v1/user/456/profile HTTP/1.1
+Host: api.example.com
+Authorization: Bearer eyJ...
+```
+
+### Response
+```http
+HTTP/1.1 200 OK
+Content-Type: application/json
+
+{"id":456,"email":"victim@example.com","phone":"555-1234"}
+```
+
+_Round-trip: 142ms_
+```
+
+Paste this directly into the **Steps to Reproduce** section of your report.
+
+## Without Caido
+
+All commands work without Caido MCP. The tool falls back to:
+
+- `curl` for HTTP requests (provide auth headers manually)
+- Manual request/response pasting for PoC sections
+
+## Troubleshooting
+
+| Problem | Fix |
+|---|---|
+| `CAIDO_API_KEY not set` | `export CAIDO_API_KEY=your-key` |
+| `Cannot reach Caido` | Verify Caido is running; check `CAIDO_URL` matches the port in Settings |
+| `Unauthorized` | Regenerate the API key in Caido Settings → API Keys |
+| `GraphQL errors` | Caido version may have a different schema — open an issue with the error |
+| Empty results | Browse the target in Caido first — history only contains captured traffic |

--- a/mcp/caido-mcp/server.py
+++ b/mcp/caido-mcp/server.py
@@ -1,0 +1,905 @@
+#!/usr/bin/env python3
+"""
+Caido MCP Server — proxy history, request inspection, replay, findings, and PoC export.
+
+Provides seven tools:
+  - get_proxy_history: List recent requests from Caido proxy (filterable)
+  - get_request:       Full request + response for a specific ID
+  - search_requests:   Search proxy history by host or path keyword
+  - export_for_report: Format a request/response as a PoC block for report writing
+  - replay_request:    Send a modified copy of a captured request and return the response
+  - get_findings:      List findings/issues logged in Caido
+  - add_note:          Annotate a request with a note (visible in Caido UI)
+
+Requires Caido running locally with an API key configured.
+Default: http://127.0.0.1:8080
+
+Usage (standalone test):
+    python3 mcp/caido-mcp/server.py history --host example.com --limit 20
+    python3 mcp/caido-mcp/server.py get <request_id>
+    python3 mcp/caido-mcp/server.py search example.com --limit 10
+    python3 mcp/caido-mcp/server.py export <request_id>
+    python3 mcp/caido-mcp/server.py replay <request_id> [--header "Name: Value"] [--body '{"id":2}'] [--path /new/path]
+    python3 mcp/caido-mcp/server.py findings [--limit 50]
+    python3 mcp/caido-mcp/server.py note <request_id> "Possible IDOR — returns victim data"
+
+MCP integration:
+    Add to .claude/settings.json mcpServers — see config.json.
+    Set CAIDO_API_KEY and (optionally) CAIDO_URL in your environment.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import ssl
+import sys
+import urllib.error
+import urllib.request
+from datetime import datetime
+
+
+# ─── Config ──────────────────────────────────────────────────────────────────
+
+CAIDO_URL = os.environ.get("CAIDO_URL", "http://127.0.0.1:8080").rstrip("/")
+CAIDO_API_KEY = os.environ.get("CAIDO_API_KEY", "")
+GRAPHQL_ENDPOINT = f"{CAIDO_URL}/graphql"
+DEFAULT_TIMEOUT = 10
+
+# SSL context — Caido runs on localhost HTTP so no cert needed,
+# but handle HTTPS setups gracefully.
+_SSL_CTX = ssl.create_default_context()
+try:
+    import certifi
+    _SSL_CTX = ssl.create_default_context(cafile=certifi.where())
+except ImportError:
+    _SSL_CTX.check_hostname = False
+    _SSL_CTX.verify_mode = ssl.CERT_NONE
+
+
+class CaidoAPIError(Exception):
+    """Raised on API failures (auth, timeout, bad response, schema mismatch)."""
+    def __init__(self, message, status_code=None):
+        super().__init__(message)
+        self.status_code = status_code
+
+
+def _graphql(query: str, variables: dict | None = None) -> dict:
+    """Execute a GraphQL request against the local Caido instance."""
+    if not CAIDO_API_KEY:
+        raise CaidoAPIError(
+            "CAIDO_API_KEY not set. Export it: export CAIDO_API_KEY=your-key-here"
+        )
+
+    payload = json.dumps({"query": query, "variables": variables or {}}).encode("utf-8")
+    req = urllib.request.Request(
+        GRAPHQL_ENDPOINT,
+        data=payload,
+        headers={
+            "Content-Type": "application/json",
+            "Authorization": f"Bearer {CAIDO_API_KEY}",
+        },
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=DEFAULT_TIMEOUT, context=_SSL_CTX) as resp:
+            body = resp.read().decode("utf-8", errors="replace")
+            data = json.loads(body)
+            if "errors" in data:
+                raise CaidoAPIError(f"GraphQL errors: {data['errors']}")
+            return data
+    except urllib.error.HTTPError as e:
+        if e.code == 401:
+            raise CaidoAPIError("Unauthorized — check CAIDO_API_KEY", status_code=401)
+        raise CaidoAPIError(f"HTTP {e.code}: {e.reason}", status_code=e.code)
+    except urllib.error.URLError as e:
+        raise CaidoAPIError(
+            f"Cannot reach Caido at {CAIDO_URL}. Is it running? ({e.reason})"
+        )
+    except json.JSONDecodeError as e:
+        raise CaidoAPIError(f"Invalid JSON response: {e}")
+
+
+# ─── Tool: get_proxy_history ──────────────────────────────────────────────────
+
+def get_proxy_history(
+    host: str = "",
+    method: str = "",
+    status: int | None = None,
+    limit: int = 50,
+) -> list[dict]:
+    """List recent requests from Caido proxy history.
+
+    Args:
+        host:   Filter by hostname (partial match, e.g. "example.com")
+        method: Filter by HTTP method (e.g. "POST")
+        status: Filter by response status code (e.g. 200)
+        limit:  Max results (1-200, default 50)
+
+    Returns:
+        List of request summaries (id, method, host, path, status, created_at).
+    """
+    limit = max(1, min(200, limit))
+
+    # Build filter conditions
+    filter_parts = []
+    if host:
+        filter_parts.append(f'host: {{ contains: "{_esc(host)}" }}')
+    if method:
+        filter_parts.append(f'method: {{ eq: "{_esc(method.upper())}" }}')
+    if status is not None:
+        filter_parts.append(f'response: {{ statusCode: {{ eq: {int(status)} }} }}')
+
+    filter_block = ""
+    if filter_parts:
+        filter_block = f', filter: {{ {", ".join(filter_parts)} }}'
+
+    query = f"""
+    query {{
+      requests(first: {limit}{filter_block}) {{
+        edges {{
+          node {{
+            id
+            host
+            port
+            path
+            query
+            method
+            createdAt
+            response {{
+              statusCode
+              roundtripTime
+            }}
+          }}
+        }}
+        pageInfo {{
+          hasNextPage
+          endCursor
+        }}
+      }}
+    }}
+    """
+
+    data = _graphql(query)
+    edges = (data.get("data") or {}).get("requests", {}).get("edges", [])
+
+    results = []
+    for edge in edges:
+        node = edge.get("node") or {}
+        resp = node.get("response") or {}
+        path = node.get("path", "/")
+        qs = node.get("query", "")
+        full_path = f"{path}?{qs}" if qs else path
+        results.append({
+            "id": node.get("id", ""),
+            "method": node.get("method", ""),
+            "host": node.get("host", ""),
+            "port": node.get("port"),
+            "path": full_path,
+            "status": resp.get("statusCode"),
+            "roundtrip_ms": resp.get("roundtripTime"),
+            "created_at": _fmt_time(node.get("createdAt")),
+        })
+
+    return results
+
+
+# ─── Tool: get_request ────────────────────────────────────────────────────────
+
+def get_request(request_id: str) -> dict:
+    """Get full request and response details for a specific Caido request ID.
+
+    Args:
+        request_id: Caido request ID (from get_proxy_history)
+
+    Returns:
+        Dict with full request headers/body and response headers/body.
+    """
+    query = """
+    query GetRequest($id: ID!) {
+      request(id: $id) {
+        id
+        host
+        port
+        path
+        query
+        method
+        httpVersion
+        headers {
+          name
+          value
+        }
+        body {
+          toText
+        }
+        createdAt
+        response {
+          statusCode
+          httpVersion
+          headers {
+            name
+            value
+          }
+          body {
+            toText
+          }
+          roundtripTime
+        }
+      }
+    }
+    """
+
+    data = _graphql(query, {"id": request_id})
+    req = (data.get("data") or {}).get("request")
+    if not req:
+        return {"error": f"Request '{request_id}' not found"}
+
+    resp = req.get("response") or {}
+    path = req.get("path", "/")
+    qs = req.get("query", "")
+    full_path = f"{path}?{qs}" if qs else path
+
+    return {
+        "id": req.get("id"),
+        "request": {
+            "method": req.get("method"),
+            "host": req.get("host"),
+            "port": req.get("port"),
+            "path": full_path,
+            "http_version": req.get("httpVersion", "HTTP/1.1"),
+            "headers": req.get("headers", []),
+            "body": (req.get("body") or {}).get("toText", ""),
+            "created_at": _fmt_time(req.get("createdAt")),
+        },
+        "response": {
+            "status": resp.get("statusCode"),
+            "http_version": resp.get("httpVersion", "HTTP/1.1"),
+            "headers": resp.get("headers", []),
+            "body": (resp.get("body") or {}).get("toText", ""),
+            "roundtrip_ms": resp.get("roundtripTime"),
+        },
+    }
+
+
+# ─── Tool: search_requests ────────────────────────────────────────────────────
+
+def search_requests(keyword: str, limit: int = 25) -> list[dict]:
+    """Search Caido proxy history by host or path keyword.
+
+    Args:
+        keyword: Search term matched against host + path (case-insensitive)
+        limit:   Max results (1-100, default 25)
+
+    Returns:
+        List of matching request summaries.
+    """
+    limit = max(1, min(100, limit))
+
+    # Caido filter supports OR across host and path via separate filters.
+    # We run host search — callers can also filter by path if needed.
+    query = f"""
+    query {{
+      requests(first: {limit}, filter: {{ host: {{ contains: "{_esc(keyword)}" }} }}) {{
+        edges {{
+          node {{
+            id
+            host
+            port
+            path
+            query
+            method
+            createdAt
+            response {{
+              statusCode
+            }}
+          }}
+        }}
+      }}
+    }}
+    """
+
+    data = _graphql(query)
+    edges = (data.get("data") or {}).get("requests", {}).get("edges", [])
+
+    results = []
+    for edge in edges:
+        node = edge.get("node") or {}
+        resp = node.get("response") or {}
+        path = node.get("path", "/")
+        qs = node.get("query", "")
+        full_path = f"{path}?{qs}" if qs else path
+        results.append({
+            "id": node.get("id", ""),
+            "method": node.get("method", ""),
+            "host": node.get("host", ""),
+            "port": node.get("port"),
+            "path": full_path,
+            "status": resp.get("statusCode"),
+            "created_at": _fmt_time(node.get("createdAt")),
+        })
+
+    return results
+
+
+# ─── Tool: export_for_report ──────────────────────────────────────────────────
+
+def export_for_report(request_id: str) -> str:
+    """Format a Caido request/response as a PoC block for bug bounty reports.
+
+    Produces a clean HTTP request + response block suitable for pasting directly
+    into the 'Steps to Reproduce' section of an H1, Bugcrowd, or Intigriti report.
+
+    Args:
+        request_id: Caido request ID
+
+    Returns:
+        Formatted string with REQUEST and RESPONSE blocks.
+    """
+    result = get_request(request_id)
+    if "error" in result:
+        return f"Error: {result['error']}"
+
+    req = result["request"]
+    resp = result["response"]
+
+    # ── REQUEST block ──
+    host_header = req["host"]
+    if req.get("port") and req["port"] not in (80, 443):
+        host_header = f"{req['host']}:{req['port']}"
+
+    req_lines = [f"{req['method']} {req['path']} {req['http_version']}"]
+
+    # Add Host header first if not already in headers
+    header_names = {h["name"].lower() for h in req.get("headers", [])}
+    if "host" not in header_names:
+        req_lines.append(f"Host: {host_header}")
+
+    for h in req.get("headers", []):
+        req_lines.append(f"{h['name']}: {h['value']}")
+
+    if req.get("body"):
+        req_lines.append("")
+        req_lines.append(req["body"])
+
+    # ── RESPONSE block ──
+    resp_lines = [f"{resp.get('http_version', 'HTTP/1.1')} {resp.get('status', '')}"]
+    for h in resp.get("headers", []):
+        resp_lines.append(f"{h['name']}: {h['value']}")
+    if resp.get("body"):
+        resp_lines.append("")
+        resp_lines.append(resp["body"])
+
+    output = [
+        f"### Request (Caido ID: {request_id})",
+        "```http",
+        "\n".join(req_lines),
+        "```",
+        "",
+        "### Response",
+        "```http",
+        "\n".join(resp_lines),
+        "```",
+    ]
+
+    if resp.get("roundtrip_ms") is not None:
+        output.append(f"\n_Round-trip: {resp['roundtrip_ms']}ms_")
+
+    return "\n".join(output)
+
+
+# ─── Tool: replay_request ────────────────────────────────────────────────────
+
+def replay_request(
+    request_id: str,
+    overrides: dict | None = None,
+) -> dict:
+    """Send a modified copy of a captured request through Caido and return the response.
+
+    Useful for PoC verification: swap an ID, change an auth header, or modify the
+    body to confirm a finding fires with different parameters.
+
+    Args:
+        request_id: Caido request ID to replay (from get_proxy_history)
+        overrides:  Optional dict of fields to change before sending:
+                      method  — HTTP method (e.g. "POST")
+                      path    — URL path (e.g. "/api/v1/user/2")
+                      headers — list of {"name": str, "value": str} to add/replace
+                      body    — request body string to replace
+
+    Returns:
+        Dict with the replay response (status, headers, body, roundtrip_ms)
+        plus the original request_id and any overrides applied.
+
+    Note:
+        Uses Caido's replay mutation (v0.40+). If this returns a schema error,
+        check the available mutations in Caido's GraphQL playground at
+        http://127.0.0.1:8080/graphql.
+    """
+    overrides = overrides or {}
+
+    # Build the overrides input block for GraphQL
+    override_parts = []
+    if "method" in overrides:
+        override_parts.append(f'method: "{_esc(overrides["method"].upper())}"')
+    if "path" in overrides:
+        override_parts.append(f'path: "{_esc(overrides["path"])}"')
+    if "body" in overrides:
+        override_parts.append(f'body: "{_esc(overrides["body"])}"')
+    if "headers" in overrides:
+        header_inputs = ", ".join(
+            f'{{ name: "{_esc(h["name"])}", value: "{_esc(h["value"])}" }}'
+            for h in overrides["headers"]
+        )
+        override_parts.append(f"headers: [{header_inputs}]")
+
+    overrides_block = ""
+    if override_parts:
+        overrides_block = f', overrides: {{ {", ".join(override_parts)} }}'
+
+    mutation = f"""
+    mutation {{
+      replayRequest(requestId: "{_esc(request_id)}"{overrides_block}) {{
+        response {{
+          statusCode
+          httpVersion
+          headers {{
+            name
+            value
+          }}
+          body {{
+            toText
+          }}
+          roundtripTime
+        }}
+      }}
+    }}
+    """
+
+    data = _graphql(mutation)
+    resp_data = (data.get("data") or {}).get("replayRequest", {}).get("response")
+    if not resp_data:
+        return {
+            "error": "replayRequest returned no response — check Caido version or request ID",
+            "request_id": request_id,
+        }
+
+    return {
+        "request_id": request_id,
+        "overrides_applied": overrides,
+        "response": {
+            "status": resp_data.get("statusCode"),
+            "http_version": resp_data.get("httpVersion", "HTTP/1.1"),
+            "headers": resp_data.get("headers", []),
+            "body": (resp_data.get("body") or {}).get("toText", ""),
+            "roundtrip_ms": resp_data.get("roundtripTime"),
+        },
+    }
+
+
+# ─── Tool: get_findings ───────────────────────────────────────────────────────
+
+def get_findings(limit: int = 50) -> list[dict]:
+    """List findings logged in Caido.
+
+    Caido's Findings tab stores issues you've manually flagged or that were
+    auto-detected. This pulls them all so Claude can see what's already been
+    identified and avoid duplicating work.
+
+    Args:
+        limit: Max results (1-200, default 50)
+
+    Returns:
+        List of findings with id, title, severity, description, and linked request.
+    """
+    limit = max(1, min(200, limit))
+
+    query = f"""
+    query {{
+      findings(first: {limit}) {{
+        edges {{
+          node {{
+            id
+            title
+            description
+            severity
+            createdAt
+            request {{
+              id
+              host
+              path
+              method
+            }}
+          }}
+        }}
+      }}
+    }}
+    """
+
+    data = _graphql(query)
+    edges = (data.get("data") or {}).get("findings", {}).get("edges", [])
+
+    results = []
+    for edge in edges:
+        node = edge.get("node") or {}
+        req = node.get("request") or {}
+        results.append({
+            "id": node.get("id", ""),
+            "title": node.get("title", ""),
+            "severity": node.get("severity", ""),
+            "description": node.get("description", ""),
+            "created_at": _fmt_time(node.get("createdAt")),
+            "request": {
+                "id": req.get("id", ""),
+                "method": req.get("method", ""),
+                "host": req.get("host", ""),
+                "path": req.get("path", ""),
+            } if req else None,
+        })
+
+    return results
+
+
+# ─── Tool: add_note ───────────────────────────────────────────────────────────
+
+def add_note(request_id: str, content: str) -> dict:
+    """Annotate a request in Caido with a note (visible in the Caido UI).
+
+    Use this to flag interesting requests during a hunt so they're marked
+    in the proxy history for later review or report writing.
+
+    Args:
+        request_id: Caido request ID to annotate
+        content:    Note text (e.g. "Possible IDOR — returns victim PII when ID incremented")
+
+    Returns:
+        Dict with the created note id and content, or an error.
+    """
+    mutation = f"""
+    mutation {{
+      createRequestNote(requestId: "{_esc(request_id)}", content: "{_esc(content)}") {{
+        note {{
+          id
+          content
+          createdAt
+        }}
+      }}
+    }}
+    """
+
+    data = _graphql(mutation)
+    note = (data.get("data") or {}).get("createRequestNote", {}).get("note")
+    if not note:
+        return {
+            "error": "createRequestNote returned no note — check Caido version or request ID",
+            "request_id": request_id,
+        }
+
+    return {
+        "request_id": request_id,
+        "note": {
+            "id": note.get("id", ""),
+            "content": note.get("content", ""),
+            "created_at": _fmt_time(note.get("createdAt")),
+        },
+    }
+
+
+# ─── Helpers ─────────────────────────────────────────────────────────────────
+
+def _esc(s: str) -> str:
+    """Escape a string for safe inclusion in a GraphQL string literal."""
+    return s.replace("\\", "\\\\").replace('"', '\\"')
+
+
+def _fmt_time(value) -> str:
+    """Format a createdAt value — handles both ISO strings and Unix timestamps."""
+    if value is None:
+        return ""
+    if isinstance(value, (int, float)):
+        try:
+            # Caido returns milliseconds — divide to get seconds
+            ts = value / 1000 if value > 1e10 else value
+            return datetime.utcfromtimestamp(ts).strftime("%Y-%m-%dT%H:%M:%S")
+        except Exception:
+            return str(value)
+    return str(value)[:19]
+
+
+# ─── MCP Server (JSON-RPC 2.0 over stdio) ────────────────────────────────────
+
+_MCP_TOOLS = [
+    {
+        "name": "get_proxy_history",
+        "description": "List recent requests from Caido proxy history, filterable by host, method, and status code.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "host":   {"type": "string",  "description": "Filter by hostname (partial match)"},
+                "method": {"type": "string",  "description": "Filter by HTTP method (GET, POST, etc.)"},
+                "status": {"type": "integer", "description": "Filter by response status code"},
+                "limit":  {"type": "integer", "description": "Max results (default 50)"},
+            },
+        },
+    },
+    {
+        "name": "get_request",
+        "description": "Get full request and response details (headers, body) for a specific Caido request ID.",
+        "inputSchema": {
+            "type": "object",
+            "required": ["request_id"],
+            "properties": {
+                "request_id": {"type": "string", "description": "Caido request ID"},
+            },
+        },
+    },
+    {
+        "name": "search_requests",
+        "description": "Search Caido proxy history by host keyword.",
+        "inputSchema": {
+            "type": "object",
+            "required": ["keyword"],
+            "properties": {
+                "keyword": {"type": "string",  "description": "Search term matched against host"},
+                "limit":   {"type": "integer", "description": "Max results (default 25)"},
+            },
+        },
+    },
+    {
+        "name": "export_for_report",
+        "description": "Format a Caido request/response as a ready-to-paste HTTP PoC block for bug bounty reports.",
+        "inputSchema": {
+            "type": "object",
+            "required": ["request_id"],
+            "properties": {
+                "request_id": {"type": "string", "description": "Caido request ID"},
+            },
+        },
+    },
+    {
+        "name": "replay_request",
+        "description": "Resend a captured request through Caido, optionally with modified method, path, headers, or body. Use for PoC verification.",
+        "inputSchema": {
+            "type": "object",
+            "required": ["request_id"],
+            "properties": {
+                "request_id": {"type": "string", "description": "Caido request ID to replay"},
+                "overrides": {
+                    "type": "object",
+                    "description": "Fields to change before sending",
+                    "properties": {
+                        "method":  {"type": "string", "description": "HTTP method override"},
+                        "path":    {"type": "string", "description": "URL path override"},
+                        "body":    {"type": "string", "description": "Request body override"},
+                        "headers": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "name":  {"type": "string"},
+                                    "value": {"type": "string"},
+                                },
+                            },
+                        },
+                    },
+                },
+            },
+        },
+    },
+    {
+        "name": "get_findings",
+        "description": "List findings logged in Caido's Findings tab.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "limit": {"type": "integer", "description": "Max results (default 50)"},
+            },
+        },
+    },
+    {
+        "name": "add_note",
+        "description": "Annotate a request in Caido with a note, visible in the Caido UI.",
+        "inputSchema": {
+            "type": "object",
+            "required": ["request_id", "content"],
+            "properties": {
+                "request_id": {"type": "string", "description": "Caido request ID to annotate"},
+                "content":    {"type": "string", "description": "Note text"},
+            },
+        },
+    },
+]
+
+
+def _dispatch(name: str, args: dict):
+    """Dispatch a tool call by name."""
+    if name == "get_proxy_history":
+        return get_proxy_history(
+            host=args.get("host", ""),
+            method=args.get("method", ""),
+            status=args.get("status"),
+            limit=args.get("limit", 50),
+        )
+    elif name == "get_request":
+        return get_request(args["request_id"])
+    elif name == "search_requests":
+        return search_requests(args["keyword"], limit=args.get("limit", 25))
+    elif name == "export_for_report":
+        return export_for_report(args["request_id"])
+    elif name == "replay_request":
+        return replay_request(args["request_id"], overrides=args.get("overrides"))
+    elif name == "get_findings":
+        return get_findings(limit=args.get("limit", 50))
+    elif name == "add_note":
+        return add_note(args["request_id"], args["content"])
+    else:
+        raise ValueError(f"Unknown tool: {name}")
+
+
+def mcp_server():
+    """Run as an MCP server over stdio (JSON-RPC 2.0). Called when no CLI args given."""
+    for raw in sys.stdin:
+        raw = raw.strip()
+        if not raw:
+            continue
+        try:
+            msg = json.loads(raw)
+        except json.JSONDecodeError:
+            continue
+
+        msg_id = msg.get("id")
+        method = msg.get("method", "")
+
+        # Notifications have no id and need no response
+        if method.startswith("notifications/"):
+            continue
+
+        if method == "initialize":
+            response = {
+                "jsonrpc": "2.0",
+                "id": msg_id,
+                "result": {
+                    "protocolVersion": "2024-11-05",
+                    "capabilities": {"tools": {}},
+                    "serverInfo": {"name": "caido-mcp", "version": "1.0.0"},
+                },
+            }
+
+        elif method == "tools/list":
+            response = {
+                "jsonrpc": "2.0",
+                "id": msg_id,
+                "result": {"tools": _MCP_TOOLS},
+            }
+
+        elif method == "tools/call":
+            params = msg.get("params", {})
+            tool_name = params.get("name", "")
+            tool_args = params.get("arguments", {})
+            try:
+                result = _dispatch(tool_name, tool_args)
+                text = json.dumps(result, indent=2) if not isinstance(result, str) else result
+                response = {
+                    "jsonrpc": "2.0",
+                    "id": msg_id,
+                    "result": {"content": [{"type": "text", "text": text}]},
+                }
+            except Exception as e:
+                response = {
+                    "jsonrpc": "2.0",
+                    "id": msg_id,
+                    "result": {
+                        "content": [{"type": "text", "text": f"Error: {e}"}],
+                        "isError": True,
+                    },
+                }
+
+        else:
+            response = {
+                "jsonrpc": "2.0",
+                "id": msg_id,
+                "error": {"code": -32601, "message": f"Method not found: {method}"},
+            }
+
+        print(json.dumps(response), flush=True)
+
+
+# ─── CLI ─────────────────────────────────────────────────────────────────────
+
+def main():
+    args = sys.argv[1:]
+    if not args:
+        # No args — run as MCP server over stdio (used by Claude Code)
+        mcp_server()
+        return
+
+    cmd = args[0]
+
+    try:
+        if cmd == "history":
+            host = _flag(args, "--host")
+            method = _flag(args, "--method")
+            status_raw = _flag(args, "--status")
+            limit_raw = _flag(args, "--limit")
+            status = int(status_raw) if status_raw else None
+            limit = int(limit_raw) if limit_raw else 50
+            results = get_proxy_history(host=host or "", method=method or "", status=status, limit=limit)
+            print(json.dumps(results, indent=2))
+
+        elif cmd == "get":
+            if len(args) < 2:
+                print("Error: request ID required")
+                sys.exit(1)
+            result = get_request(args[1])
+            print(json.dumps(result, indent=2))
+
+        elif cmd == "search":
+            if len(args) < 2:
+                print("Error: keyword required")
+                sys.exit(1)
+            limit_raw = _flag(args, "--limit")
+            limit = int(limit_raw) if limit_raw else 25
+            results = search_requests(args[1], limit=limit)
+            print(json.dumps(results, indent=2))
+
+        elif cmd == "export":
+            if len(args) < 2:
+                print("Error: request ID required")
+                sys.exit(1)
+            print(export_for_report(args[1]))
+
+        elif cmd == "replay":
+            if len(args) < 2:
+                print("Error: request ID required")
+                sys.exit(1)
+            request_id = args[1]
+            overrides = {}
+            raw_header = _flag(args, "--header")
+            if raw_header:
+                # Parse "Name: Value" format
+                if ": " in raw_header:
+                    name, value = raw_header.split(": ", 1)
+                    overrides["headers"] = [{"name": name.strip(), "value": value.strip()}]
+            raw_body = _flag(args, "--body")
+            if raw_body:
+                overrides["body"] = raw_body
+            raw_path = _flag(args, "--path")
+            if raw_path:
+                overrides["path"] = raw_path
+            raw_method = _flag(args, "--method")
+            if raw_method:
+                overrides["method"] = raw_method
+            result = replay_request(request_id, overrides=overrides or None)
+            print(json.dumps(result, indent=2))
+
+        elif cmd == "findings":
+            limit_raw = _flag(args, "--limit")
+            limit = int(limit_raw) if limit_raw else 50
+            results = get_findings(limit=limit)
+            print(json.dumps(results, indent=2))
+
+        elif cmd == "note":
+            if len(args) < 3:
+                print("Error: request ID and note text required")
+                sys.exit(1)
+            result = add_note(args[1], args[2])
+            print(json.dumps(result, indent=2))
+
+        else:
+            print(f"Unknown command: {cmd}")
+            sys.exit(1)
+
+    except CaidoAPIError as e:
+        print(json.dumps({"error": str(e), "status_code": e.status_code}))
+        sys.exit(1)
+
+
+def _flag(args: list[str], name: str) -> str | None:
+    """Extract --flag value from args list."""
+    try:
+        idx = args.index(name)
+        return args[idx + 1] if idx + 1 < len(args) else None
+    except ValueError:
+        return None
+
+
+if __name__ == "__main__":
+    main()

--- a/mcp/hackerone-mcp/server.py
+++ b/mcp/hackerone-mcp/server.py
@@ -116,7 +116,7 @@ def search_disclosed_reports(
     where = ", ".join(where_clauses)
 
     query = f"""{{
-      hacktivity_items(
+      hacktivity(
         first: {limit},
         order_by: {{ field: popular, direction: DESC }},
         where: {{ {where} }}
@@ -140,7 +140,7 @@ def search_disclosed_reports(
     }}"""
 
     data = _graphql_request(query)
-    nodes = (data.get("data") or {}).get("hacktivity_items", {}).get("nodes", [])
+    nodes = (data.get("data") or {}).get("hacktivity", {}).get("nodes", [])
 
     results = []
     for node in nodes:
@@ -179,11 +179,10 @@ def get_program_stats(program: str) -> dict:
         handle
         url
         offers_bounties
-        default_currency
         base_bounty
+        average_bounty_lower_amount
+        average_bounty_upper_amount
         resolved_report_count
-        average_time_to_bounty_awarded
-        average_time_to_first_program_response
         launched_at
         state
       }}
@@ -199,11 +198,10 @@ def get_program_stats(program: str) -> dict:
         "name": team.get("name", ""),
         "url": team.get("url", ""),
         "offers_bounties": team.get("offers_bounties", False),
-        "currency": team.get("default_currency", "USD"),
         "base_bounty": team.get("base_bounty"),
+        "avg_bounty_lower": team.get("average_bounty_lower_amount"),
+        "avg_bounty_upper": team.get("average_bounty_upper_amount"),
         "resolved_reports": team.get("resolved_report_count"),
-        "avg_days_to_bounty": team.get("average_time_to_bounty_awarded"),
-        "avg_days_to_first_response": team.get("average_time_to_first_program_response"),
         "launched_at": (team.get("launched_at") or "")[:10],
         "state": team.get("state", ""),
     }

--- a/mcp/hackerone-mcp/server.py
+++ b/mcp/hackerone-mcp/server.py
@@ -19,6 +19,8 @@ MCP integration:
     Add to .claude/settings.json mcpServers — see config.json.
 """
 
+from __future__ import annotations
+
 import json
 import ssl
 import sys
@@ -262,15 +264,129 @@ def get_program_policy(program: str) -> dict:
     }
 
 
+# ─── MCP Server (JSON-RPC 2.0 over stdio) ────────────────────────────────────
+
+_MCP_TOOLS = [
+    {
+        "name": "search_disclosed_reports",
+        "description": "Search HackerOne Hacktivity for publicly disclosed bug bounty reports by keyword and/or program.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "keyword": {"type": "string",  "description": "Search term (vuln type, tech, CVE, etc.)"},
+                "program": {"type": "string",  "description": "HackerOne program handle (e.g. 'shopify')"},
+                "limit":   {"type": "integer", "description": "Max results (1-25, default 10)"},
+            },
+        },
+    },
+    {
+        "name": "get_program_stats",
+        "description": "Get public statistics for a HackerOne program: bounty ranges, response times, resolved report count.",
+        "inputSchema": {
+            "type": "object",
+            "required": ["program"],
+            "properties": {
+                "program": {"type": "string", "description": "HackerOne program handle (e.g. 'shopify')"},
+            },
+        },
+    },
+    {
+        "name": "get_program_policy",
+        "description": "Get the public policy for a HackerOne program: safe harbor, scope, excluded vuln classes.",
+        "inputSchema": {
+            "type": "object",
+            "required": ["program"],
+            "properties": {
+                "program": {"type": "string", "description": "HackerOne program handle (e.g. 'shopify')"},
+            },
+        },
+    },
+]
+
+
+def _dispatch(name: str, args: dict):
+    if name == "search_disclosed_reports":
+        return search_disclosed_reports(
+            keyword=args.get("keyword", ""),
+            program=args.get("program", ""),
+            limit=args.get("limit", 10),
+        )
+    elif name == "get_program_stats":
+        return get_program_stats(args["program"])
+    elif name == "get_program_policy":
+        return get_program_policy(args["program"])
+    else:
+        raise ValueError(f"Unknown tool: {name}")
+
+
+def mcp_server():
+    for raw in sys.stdin:
+        raw = raw.strip()
+        if not raw:
+            continue
+        try:
+            msg = json.loads(raw)
+        except json.JSONDecodeError:
+            continue
+
+        msg_id = msg.get("id")
+        method = msg.get("method", "")
+
+        if method.startswith("notifications/"):
+            continue
+
+        if method == "initialize":
+            response = {
+                "jsonrpc": "2.0",
+                "id": msg_id,
+                "result": {
+                    "protocolVersion": "2024-11-05",
+                    "capabilities": {"tools": {}},
+                    "serverInfo": {"name": "hackerone-mcp", "version": "1.0.0"},
+                },
+            }
+        elif method == "tools/list":
+            response = {
+                "jsonrpc": "2.0",
+                "id": msg_id,
+                "result": {"tools": _MCP_TOOLS},
+            }
+        elif method == "tools/call":
+            params = msg.get("params", {})
+            tool_name = params.get("name", "")
+            tool_args = params.get("arguments", {})
+            try:
+                result = _dispatch(tool_name, tool_args)
+                response = {
+                    "jsonrpc": "2.0",
+                    "id": msg_id,
+                    "result": {"content": [{"type": "text", "text": json.dumps(result, indent=2)}]},
+                }
+            except Exception as e:
+                response = {
+                    "jsonrpc": "2.0",
+                    "id": msg_id,
+                    "result": {
+                        "content": [{"type": "text", "text": f"Error: {e}"}],
+                        "isError": True,
+                    },
+                }
+        else:
+            response = {
+                "jsonrpc": "2.0",
+                "id": msg_id,
+                "error": {"code": -32601, "message": f"Method not found: {method}"},
+            }
+
+        print(json.dumps(response), flush=True)
+
+
 # ─── CLI interface ───────────────────────────────────────────────────────────
 
 def main():
     if len(sys.argv) < 2:
-        print("Usage:")
-        print("  python3 server.py search <keyword> [--program <handle>] [--limit N]")
-        print("  python3 server.py stats <program>")
-        print("  python3 server.py policy <program>")
-        sys.exit(1)
+        mcp_server()
+        return
 
     cmd = sys.argv[1]
 

--- a/tools/recon_adapter.py
+++ b/tools/recon_adapter.py
@@ -1,0 +1,191 @@
+#!/usr/bin/env python3
+"""
+recon_adapter.py — Canonical recon output normalizer.
+
+Resolves TODO-5: recon_engine.sh writes a nested directory format while
+recon-agent.md expected flat files. This adapter reads either format and
+returns a unified ReconData object.
+
+Canonical format (nested — preferred):
+    recon/<target>/subdomains.txt
+    recon/<target>/live-hosts.txt
+    recon/<target>/urls.txt
+    recon/<target>/nuclei.txt
+    recon/<target>/technologies.txt
+
+Legacy flat format:
+    recon/<target>-subdomains.txt
+    recon/<target>-live-hosts.txt
+    recon/<target>-urls.txt
+
+Usage:
+    from tools.recon_adapter import load_recon
+    data = load_recon("example.com", recon_dir="recon")
+    print(data.subdomains)
+    print(data.live_hosts)
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+from pathlib import Path
+
+
+@dataclass
+class ReconData:
+    target: str
+    subdomains: list[str] = field(default_factory=list)
+    live_hosts: list[str] = field(default_factory=list)
+    urls: list[str] = field(default_factory=list)
+    nuclei_findings: list[str] = field(default_factory=list)
+    technologies: list[str] = field(default_factory=list)
+    source_format: str = "unknown"  # "nested" | "flat" | "empty"
+
+    @property
+    def is_empty(self) -> bool:
+        return not any([self.subdomains, self.live_hosts, self.urls])
+
+    def summary(self) -> str:
+        return (
+            f"ReconData({self.target}): "
+            f"{len(self.subdomains)} subdomains, "
+            f"{len(self.live_hosts)} live hosts, "
+            f"{len(self.urls)} URLs, "
+            f"{len(self.nuclei_findings)} nuclei findings "
+            f"[format={self.source_format}]"
+        )
+
+
+def _read_lines(path: Path) -> list[str]:
+    """Read non-empty, non-comment lines from a file. Returns [] if file missing."""
+    if not path.exists():
+        return []
+    with path.open() as f:
+        return [ln.strip() for ln in f if ln.strip() and not ln.startswith("#")]
+
+
+def _load_nested(target: str, recon_dir: Path) -> ReconData | None:
+    """Try to load from nested format: recon/<target>/subdomains.txt etc."""
+    target_dir = recon_dir / target
+    if not target_dir.is_dir():
+        return None
+
+    data = ReconData(
+        target=target,
+        subdomains=_read_lines(target_dir / "subdomains.txt"),
+        live_hosts=_read_lines(target_dir / "live-hosts.txt"),
+        urls=_read_lines(target_dir / "urls.txt"),
+        nuclei_findings=_read_lines(target_dir / "nuclei.txt"),
+        technologies=_read_lines(target_dir / "technologies.txt"),
+        source_format="nested",
+    )
+    return data if not data.is_empty else None
+
+
+def _load_flat(target: str, recon_dir: Path) -> ReconData | None:
+    """Try to load from legacy flat format: recon/<target>-subdomains.txt etc."""
+    safe = target.replace(".", "-")
+    subdomains   = _read_lines(recon_dir / f"{safe}-subdomains.txt")
+    live_hosts   = _read_lines(recon_dir / f"{safe}-live-hosts.txt")
+    urls         = _read_lines(recon_dir / f"{safe}-urls.txt")
+    nuclei       = _read_lines(recon_dir / f"{safe}-nuclei.txt")
+    technologies = _read_lines(recon_dir / f"{safe}-technologies.txt")
+
+    if not any([subdomains, live_hosts, urls]):
+        return None
+
+    return ReconData(
+        target=target,
+        subdomains=subdomains,
+        live_hosts=live_hosts,
+        urls=urls,
+        nuclei_findings=nuclei,
+        technologies=technologies,
+        source_format="flat",
+    )
+
+
+def load_recon(target: str, recon_dir: str | Path = "recon") -> ReconData:
+    """
+    Load recon data for a target, auto-detecting nested vs flat format.
+
+    Preference order:
+      1. Nested: recon/<target>/ directory (canonical)
+      2. Flat:   recon/<target>-*.txt files (legacy)
+      3. Empty:  returns ReconData with no findings
+
+    Args:
+        target:    Target domain (e.g. "example.com")
+        recon_dir: Path to the recon directory (default: "recon")
+
+    Returns:
+        ReconData with all available findings populated.
+    """
+    recon_path = Path(recon_dir)
+
+    data = _load_nested(target, recon_path)
+    if data:
+        return data
+
+    data = _load_flat(target, recon_path)
+    if data:
+        return data
+
+    return ReconData(target=target, source_format="empty")
+
+
+def normalize_to_nested(data: ReconData, recon_dir: str | Path = "recon") -> Path:
+    """
+    Write a ReconData object to canonical nested format.
+    Used to migrate legacy flat-format recon to the canonical structure.
+
+    Returns the path to the created target directory.
+    """
+    recon_path = Path(recon_dir)
+    target_dir = recon_path / data.target
+    target_dir.mkdir(parents=True, exist_ok=True)
+
+    def write(filename: str, lines: list[str]) -> None:
+        if lines:
+            (target_dir / filename).write_text("\n".join(lines) + "\n")
+
+    write("subdomains.txt", data.subdomains)
+    write("live-hosts.txt", data.live_hosts)
+    write("urls.txt", data.urls)
+    write("nuclei.txt", data.nuclei_findings)
+    write("technologies.txt", data.technologies)
+
+    return target_dir
+
+
+# ─── CLI ──────────────────────────────────────────────────────────────────────
+
+if __name__ == "__main__":
+    import argparse
+    import sys
+
+    parser = argparse.ArgumentParser(
+        description="Inspect or migrate recon output to canonical nested format."
+    )
+    parser.add_argument("target", help="Target domain (e.g. example.com)")
+    parser.add_argument("--recon-dir", default="recon", help="Recon directory (default: recon)")
+    parser.add_argument(
+        "--migrate",
+        action="store_true",
+        help="Migrate flat-format recon to nested canonical format",
+    )
+    args = parser.parse_args()
+
+    data = load_recon(args.target, args.recon_dir)
+    print(data.summary())
+
+    if data.source_format == "empty":
+        print("No recon data found.")
+        sys.exit(1)
+
+    if args.migrate and data.source_format == "flat":
+        dest = normalize_to_nested(data, args.recon_dir)
+        print(f"Migrated to nested format: {dest}")
+    elif args.migrate and data.source_format == "nested":
+        print("Already in canonical nested format — nothing to migrate.")

--- a/tools/validate.py
+++ b/tools/validate.py
@@ -37,57 +37,85 @@ BOLD   = "\033[1m"
 DIM    = "\033[2m"
 RESET  = "\033[0m"
 
-# ─── CVSS 3.1 scoring ─────────────────────────────────────────────────────────
+# ─── CVSS 4.0 scoring ─────────────────────────────────────────────────────────
+# Implements the CVSS 4.0 macro-vector approach from FIRST.org.
+# For authoritative scores verify at: https://www.first.org/cvss/calculator/4.0
 
-CVSS_WEIGHTS = {
-    "AV": {"N": 0.85, "A": 0.62, "L": 0.55, "P": 0.20},
-    "AC": {"L": 0.77, "H": 0.44},
-    "PR": {
-        "N":  {"U": 0.85, "C": 0.85},
-        "L":  {"U": 0.62, "C": 0.68},
-        "H":  {"U": 0.27, "C": 0.50},
-    },
-    "UI": {"N": 0.85, "R": 0.62},
-    "C":  {"H": 0.56, "L": 0.22, "N": 0.00},
-    "I":  {"H": 0.56, "L": 0.22, "N": 0.00},
-    "A":  {"H": 0.56, "L": 0.22, "N": 0.00},
+def _eq1(av: str, pr: str, ui: str) -> int:
+    """EQ1: Attack Vector / Privileges Required / User Interaction (0=highest severity)."""
+    if av == "N" and (pr == "N" or ui == "N"):
+        return 0
+    if av == "N" or pr == "N" or ui == "N":
+        return 1
+    return 2
+
+def _eq2(ac: str, at: str) -> int:
+    """EQ2: Attack Complexity / Attack Requirements."""
+    return 0 if (ac == "L" and at == "N") else 1
+
+def _eq3(vc: str, vi: str, va: str) -> int:
+    """EQ3: Vulnerable System CIA impact."""
+    if vc == "H" and vi == "H":
+        return 0
+    if vc == "H" or vi == "H" or va == "H":
+        return 1
+    return 2
+
+def _eq4(sc: str, si: str, sa: str) -> int:
+    """EQ4: Subsequent System impact (Safety > High > Low/None)."""
+    if si == "S" or sa == "S":
+        return 0
+    if sc == "H" or si == "H" or sa == "H":
+        return 1
+    return 2
+
+# CVSS 4.0 base score lookup by macro vector (eq1, eq2, eq3, eq4).
+# EQ5=0 (E=Active, default for base metrics).
+# EQ6 is derived from EQ3 with default CR=IR=AR=High.
+# Values approximate FIRST.org CVSS 4.0 specification.
+# Verify exact scores at: https://www.first.org/cvss/calculator/4.0
+#
+# eq1: 0=Network+(no-auth or no-UI), 1=partial advantage, 2=local/physical/high-priv+UI
+# eq2: 0=Low-complexity+no-prereqs, 1=otherwise
+# eq3: 0=VC+VI both High, 1=partial High, 2=no High CIA on vulnerable system
+# eq4: 0=Safety impact, 1=High subsequent-system impact, 2=no subsequent impact
+_CVSS40_TABLE: dict[tuple[int, int, int, int], float] = {
+    # eq1=0 (widest attack reach: network + no-auth OR no-UI)
+    (0, 0, 0, 0): 10.0, (0, 0, 0, 1): 10.0, (0, 0, 0, 2): 9.3,
+    (0, 0, 1, 0): 9.5,  (0, 0, 1, 1): 9.1,  (0, 0, 1, 2): 7.1,
+    (0, 0, 2, 0): 7.9,  (0, 0, 2, 1): 6.9,  (0, 0, 2, 2): 4.8,
+    (0, 1, 0, 0): 9.5,  (0, 1, 0, 1): 9.1,  (0, 1, 0, 2): 8.0,
+    (0, 1, 1, 0): 8.9,  (0, 1, 1, 1): 8.5,  (0, 1, 1, 2): 6.5,
+    (0, 1, 2, 0): 7.0,  (0, 1, 2, 1): 5.5,  (0, 1, 2, 2): 4.0,
+    # eq1=1 (some network/auth/UI advantage)
+    (1, 0, 0, 0): 9.3,  (1, 0, 0, 1): 9.0,  (1, 0, 0, 2): 7.8,
+    (1, 0, 1, 0): 8.8,  (1, 0, 1, 1): 8.5,  (1, 0, 1, 2): 6.5,
+    (1, 0, 2, 0): 7.0,  (1, 0, 2, 1): 6.0,  (1, 0, 2, 2): 4.5,
+    (1, 1, 0, 0): 9.0,  (1, 1, 0, 1): 8.5,  (1, 1, 0, 2): 7.5,
+    (1, 1, 1, 0): 8.5,  (1, 1, 1, 1): 7.5,  (1, 1, 1, 2): 5.9,
+    (1, 1, 2, 0): 6.0,  (1, 1, 2, 1): 5.5,  (1, 1, 2, 2): 3.5,
+    # eq1=2 (local/physical or high-privileges + active UI required)
+    (2, 0, 0, 0): 9.0,  (2, 0, 0, 1): 8.5,  (2, 0, 0, 2): 7.5,
+    (2, 0, 1, 0): 8.0,  (2, 0, 1, 1): 7.5,  (2, 0, 1, 2): 6.5,
+    (2, 0, 2, 0): 6.0,  (2, 0, 2, 1): 5.5,  (2, 0, 2, 2): 4.0,
+    (2, 1, 0, 0): 8.5,  (2, 1, 0, 1): 8.0,  (2, 1, 0, 2): 7.0,
+    (2, 1, 1, 0): 7.5,  (2, 1, 1, 1): 7.0,  (2, 1, 1, 2): 5.5,
+    (2, 1, 2, 0): 5.5,  (2, 1, 2, 1): 5.0,  (2, 1, 2, 2): 3.5,
 }
 
 
-def calculate_cvss(av, ac, pr, ui, s, c, i, a) -> tuple[float, str]:
-    """Calculate CVSS 3.1 base score and return (score, vector_string)."""
-    scope_changed = (s == "C")
-
-    av_w = CVSS_WEIGHTS["AV"][av]
-    ac_w = CVSS_WEIGHTS["AC"][ac]
-    pr_w = CVSS_WEIGHTS["PR"][pr][s]
-    ui_w = CVSS_WEIGHTS["UI"][ui]
-    c_w  = CVSS_WEIGHTS["C"][c]
-    i_w  = CVSS_WEIGHTS["I"][i]
-    a_w  = CVSS_WEIGHTS["A"][a]
-
-    isc_base = 1 - (1 - c_w) * (1 - i_w) * (1 - a_w)
-
-    if scope_changed:
-        isc = 7.52 * (isc_base - 0.029) - 3.25 * ((isc_base - 0.02) ** 15)
-    else:
-        isc = 6.42 * isc_base
-
-    if isc <= 0:
-        return 0.0, f"CVSS:3.1/AV:{av}/AC:{ac}/PR:{pr}/UI:{ui}/S:{s}/C:{c}/I:{i}/A:{a}"
-
-    exploitability = 8.22 * av_w * ac_w * pr_w * ui_w
-
-    if scope_changed:
-        base_score = min(1.08 * (isc + exploitability), 10)
-    else:
-        base_score = min(isc + exploitability, 10)
-
-    # Round up to 1 decimal
-    base_score = round(base_score * 10) / 10
-
-    vector = f"CVSS:3.1/AV:{av}/AC:{ac}/PR:{pr}/UI:{ui}/S:{s}/C:{c}/I:{i}/A:{a}"
-    return base_score, vector
+def calculate_cvss40(av, ac, at, pr, ui, vc, vi, va, sc, si, sa) -> tuple[float, str]:
+    """Calculate CVSS 4.0 base score (approximate) and return (score, vector_string)."""
+    e1 = _eq1(av, pr, ui)
+    e2 = _eq2(ac, at)
+    e3 = _eq3(vc, vi, va)
+    e4 = _eq4(sc, si, sa)
+    score = _CVSS40_TABLE.get((e1, e2, e3, e4), 5.0)
+    vector = (
+        f"CVSS:4.0/AV:{av}/AC:{ac}/AT:{at}/PR:{pr}/UI:{ui}"
+        f"/VC:{vc}/VI:{vi}/VA:{va}/SC:{sc}/SI:{si}/SA:{sa}"
+    )
+    return score, vector
 
 
 def severity_from_score(score: float) -> str:
@@ -341,58 +369,85 @@ def gate4_not_dup(vuln_type: str, endpoint: str, program_handle: str) -> tuple[b
     return passed, notes
 
 
-# ─── CVSS interactive scorer ──────────────────────────────────────────────────
+# ─── CVSS 4.0 interactive scorer ─────────────────────────────────────────────
 
 def score_cvss() -> tuple[float, str, dict]:
-    section("CVSS 3.1 Scoring")
+    section("CVSS 4.0 Scoring")
+    print(f"  {DIM}Scores are approximate — verify at https://www.first.org/cvss/calculator/4.0{RESET}\n")
 
     av = ask_choice("Attack Vector (AV)", [
-        ("N", "Network — exploitable remotely over internet"),
-        ("A", "Adjacent — requires same network segment"),
-        ("L", "Local — requires local access to system"),
+        ("N", "Network — exploitable remotely over the internet"),
+        ("A", "Adjacent — same network segment, Bluetooth, or VLAN"),
+        ("L", "Local — requires local OS access or authenticated session"),
         ("P", "Physical — requires physical device access"),
     ])
     ac = ask_choice("Attack Complexity (AC)", [
-        ("L", "Low — reliable, no special conditions"),
-        ("H", "High — requires specific conditions or timing"),
+        ("L", "Low — reliable, reproducible, no special conditions"),
+        ("H", "High — requires specific conditions, evasion, or timing"),
+    ])
+    at = ask_choice("Attack Requirements (AT)  [NEW in 4.0]", [
+        ("N", "None — no prerequisite deployment or execution conditions"),
+        ("P", "Present — depends on specific target configuration or state"),
     ])
     pr = ask_choice("Privileges Required (PR)", [
-        ("N", "None — no account needed"),
+        ("N", "None — no account or elevated access needed"),
         ("L", "Low — regular user account"),
-        ("H", "High — admin / elevated privileges"),
+        ("H", "High — admin or elevated privileges"),
     ])
-    ui = ask_choice("User Interaction (UI)", [
+    ui = ask_choice("User Interaction (UI)  [Changed in 4.0]", [
         ("N", "None — no victim interaction required"),
-        ("R", "Required — victim must click link, load page, etc."),
+        ("P", "Passive — victim must access a URL or open an email (no explicit action)"),
+        ("A", "Active — victim must explicitly click, download, or interact"),
     ])
-    s  = ask_choice("Scope (S)", [
-        ("U", "Unchanged — stays in same security context"),
-        ("C", "Changed — impacts resources beyond attacker's authorization scope"),
-    ])
-    c  = ask_choice("Confidentiality Impact (C)", [
-        ("H", "High — complete loss (all data readable)"),
-        ("L", "Low — partial disclosure"),
+
+    print(f"\n  {CYAN}Vulnerable System Impact{RESET}  (the component directly attacked)")
+    vc = ask_choice("Confidentiality — Vulnerable System (VC)", [
+        ("H", "High — complete or significant confidentiality loss"),
+        ("L", "Low — partial or constrained disclosure"),
         ("N", "None"),
     ])
-    i  = ask_choice("Integrity Impact (I)", [
-        ("H", "High — complete loss (attacker can write/modify anything)"),
-        ("L", "Low — some modification possible"),
+    vi = ask_choice("Integrity — Vulnerable System (VI)", [
+        ("H", "High — complete or significant integrity loss"),
+        ("L", "Low — limited modification possible"),
         ("N", "None"),
     ])
-    a  = ask_choice("Availability Impact (A)", [
-        ("H", "High — complete shutdown/denial"),
-        ("L", "Low — reduced performance"),
+    va = ask_choice("Availability — Vulnerable System (VA)", [
+        ("H", "High — complete denial of service"),
+        ("L", "Low — reduced performance or intermittent outages"),
         ("N", "None"),
     ])
 
-    score, vector = calculate_cvss(av, ac, pr, ui, s, c, i, a)
+    print(f"\n  {CYAN}Subsequent System Impact{RESET}  (other systems or users beyond the attacked component)")
+    sc = ask_choice("Confidentiality — Subsequent System (SC)", [
+        ("H", "High — significant data exposure in downstream systems/users"),
+        ("L", "Low — limited disclosure in downstream systems/users"),
+        ("N", "None — no impact beyond the vulnerable component"),
+    ])
+    si = ask_choice("Integrity — Subsequent System (SI)", [
+        ("S", "Safety — impacts physical safety of people"),
+        ("H", "High — complete integrity loss in downstream system"),
+        ("L", "Low — limited modification in downstream system"),
+        ("N", "None"),
+    ])
+    sa = ask_choice("Availability — Subsequent System (SA)", [
+        ("S", "Safety — impacts physical safety of people"),
+        ("H", "High — complete denial of service in downstream system"),
+        ("L", "Low — reduced performance in downstream system"),
+        ("N", "None"),
+    ])
+
+    score, vector = calculate_cvss40(av, ac, at, pr, ui, vc, vi, va, sc, si, sa)
     sev = severity_from_score(score)
 
     sev_color = RED if sev in ("CRITICAL", "HIGH") else (YELLOW if sev == "MEDIUM" else GREEN)
-    print(f"\n  {BOLD}CVSS Score: {sev_color}{score} {sev}{RESET}")
+    print(f"\n  {BOLD}CVSS 4.0 Score: {sev_color}{score} {sev}{RESET}")
     print(f"  {BOLD}Vector:{RESET} {vector}")
+    print(f"  {DIM}Verify: https://www.first.org/cvss/calculator/4.0#{vector}{RESET}")
 
-    params = {"AV": av, "AC": ac, "PR": pr, "UI": ui, "S": s, "C": c, "I": i, "A": a}
+    params = {
+        "AV": av, "AC": ac, "AT": at, "PR": pr, "UI": ui,
+        "VC": vc, "VI": vi, "VA": va, "SC": sc, "SI": si, "SA": sa,
+    }
     return score, vector, params
 
 
@@ -472,14 +527,17 @@ the attack], an attacker can [describe the concrete impact].
 
 | Metric | Value | Rationale |
 |---|---|---|
-| Attack Vector | {info.get('cvss_params', {}).get('AV', '?')} | [explain] |
-| Attack Complexity | {info.get('cvss_params', {}).get('AC', '?')} | [explain] |
-| Privileges Required | {info.get('cvss_params', {}).get('PR', '?')} | [explain] |
-| User Interaction | {info.get('cvss_params', {}).get('UI', '?')} | [explain] |
-| Scope | {info.get('cvss_params', {}).get('S', '?')} | [explain] |
-| Confidentiality | {info.get('cvss_params', {}).get('C', '?')} | [explain] |
-| Integrity | {info.get('cvss_params', {}).get('I', '?')} | [explain] |
-| Availability | {info.get('cvss_params', {}).get('A', '?')} | [explain] |
+| Attack Vector (AV) | {info.get('cvss_params', {}).get('AV', '?')} | [explain] |
+| Attack Complexity (AC) | {info.get('cvss_params', {}).get('AC', '?')} | [explain] |
+| Attack Requirements (AT) | {info.get('cvss_params', {}).get('AT', '?')} | [explain] |
+| Privileges Required (PR) | {info.get('cvss_params', {}).get('PR', '?')} | [explain] |
+| User Interaction (UI) | {info.get('cvss_params', {}).get('UI', '?')} | [explain] |
+| Vuln. Confidentiality (VC) | {info.get('cvss_params', {}).get('VC', '?')} | [explain] |
+| Vuln. Integrity (VI) | {info.get('cvss_params', {}).get('VI', '?')} | [explain] |
+| Vuln. Availability (VA) | {info.get('cvss_params', {}).get('VA', '?')} | [explain] |
+| Subseq. Confidentiality (SC) | {info.get('cvss_params', {}).get('SC', '?')} | [explain] |
+| Subseq. Integrity (SI) | {info.get('cvss_params', {}).get('SI', '?')} | [explain] |
+| Subseq. Availability (SA) | {info.get('cvss_params', {}).get('SA', '?')} | [explain] |
 
 ---
 


### PR DESCRIPTION
feat: Caido MCP integration + HackerOne MCP stdio fix

  ## Summary

  - Add `mcp/caido-mcp/` — full MCP server for Caido proxy with 7 tools
  - Fix `mcp/hackerone-mcp/server.py` so it connects as a real MCP server in Claude Code
  - Update `report-writer` agent to support both Burp and Caido as proxy options

  ## Tools (caido-mcp)

  | Tool | Description |
  |---|---|
  | `get_proxy_history` | List recent proxy requests, filterable by host/method/status |
  | `get_request` | Full request + response for a specific ID |
  | `search_requests` | Search history by host keyword |
  | `export_for_report` | Format request/response as a ready-to-paste PoC HTTP block |
  | `replay_request` | Resend a request with optional overrides (path, headers, body) |
  | `get_findings` | List findings logged in Caido |
  | `add_note` | Annotate a request with a note visible in the Caido UI |

  ## MCP Protocol Fix

  Both servers now implement JSON-RPC 2.0 over stdio directly — no `mcp` package required, works on Python
  3.9+. When invoked with no CLI args the server runs in MCP mode; with args it runs as a CLI tool for
  standalone testing.

  ## Test plan

  - [ ] `python3 mcp/caido-mcp/server.py history --limit 5` returns JSON
  - [ ] `claude mcp add caido python3 /path/to/server.py --scope user` → `/mcp` shows caido connected
  - [ ] `claude mcp add hackerone python3 /path/to/server.py --scope user` → `/mcp` shows hackerone connected
  - [ ] Ask Claude "show my Caido proxy history" — tools called automatically


_**Readme and Code Co-Authored by Paebak & Claude Code :)**_