### PR TITLE
fix: brain auto-detect prioritizes cloud providers with API keys

### DIFF
--- a/brain.py
+++ b/brain.py
@@ -101,8 +101,21 @@ class LLMClient:
         else:
             self._init_provider(self.provider)
 
+    # Env var a provider's API key is read from; keyed for quick lookup.
+    PROVIDER_KEY_ENV = {
+        "claude": "ANTHROPIC_API_KEY",
+        "openai": "OPENAI_API_KEY",
+        "grok":   "XAI_API_KEY",
+    }
+
     def _auto_detect(self) -> str:
-        for p in self.PROVIDER_PRIORITY:
+        # Front-load cloud providers whose API keys are set so users with
+        # only ANTHROPIC_API_KEY don't wait on an Ollama probe that will
+        # fail or mis-route. Ollama stays as the final fallback.
+        key_providers = [p for p, env in self.PROVIDER_KEY_ENV.items()
+                         if os.environ.get(env)]
+        rest = [p for p in self.PROVIDER_PRIORITY if p not in key_providers]
+        for p in key_providers + rest:
             try:
                 self._init_provider(p)
                 if self.available:

--- a/tests/test_brain_auto_detect.py
+++ b/tests/test_brain_auto_detect.py
@@ -1,0 +1,94 @@
+"""Tests for LLMClient._auto_detect provider-priority reshuffling.
+
+Users with only a cloud API key set (e.g. ANTHROPIC_API_KEY) should hit
+the matching provider first. Without any key, the original ordering
+(Ollama → Claude → OpenAI → Grok) still applies.
+"""
+
+import importlib
+import os
+import sys
+
+import pytest
+
+ROOT = os.path.join(os.path.dirname(__file__), "..")
+sys.path.insert(0, ROOT)
+
+
+@pytest.fixture
+def brain_module(monkeypatch):
+    for env in ("BRAIN_PROVIDER", "ANTHROPIC_API_KEY", "OPENAI_API_KEY", "XAI_API_KEY"):
+        monkeypatch.delenv(env, raising=False)
+    import brain
+    importlib.reload(brain)
+    return brain
+
+
+class _Tracker:
+    """Records _init_provider calls; marks a chosen provider available."""
+
+    def __init__(self, available_provider: str | None = None):
+        self.calls: list[str] = []
+        self.available_provider = available_provider
+
+    def bind(self, client):
+        def _init(provider: str) -> None:
+            self.calls.append(provider)
+            client.available = provider == self.available_provider
+        client._init_provider = _init
+
+
+def test_anthropic_key_jumps_to_front(brain_module, monkeypatch):
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test")
+    client = brain_module.LLMClient.__new__(brain_module.LLMClient)
+    client.available = False
+    tracker = _Tracker(available_provider="claude")
+    tracker.bind(client)
+
+    chosen = brain_module.LLMClient._auto_detect(client)
+
+    assert chosen == "claude"
+    assert tracker.calls[0] == "claude", "claude must be probed first when its key is set"
+
+
+def test_openai_and_grok_keys_both_front_nothing_available(brain_module, monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    monkeypatch.setenv("XAI_API_KEY", "xai-test")
+    client = brain_module.LLMClient.__new__(brain_module.LLMClient)
+    client.available = False
+    tracker = _Tracker(available_provider=None)
+    tracker.bind(client)
+
+    chosen = brain_module.LLMClient._auto_detect(client)
+
+    assert chosen == "ollama"
+    assert set(tracker.calls[:2]) == {"openai", "grok"}, \
+        "key-bearing providers must be probed before the rest"
+    assert tracker.calls[2:] == ["ollama", "claude"], \
+        "providers without keys keep their original relative order"
+
+
+def test_no_keys_falls_back_to_default_priority(brain_module):
+    client = brain_module.LLMClient.__new__(brain_module.LLMClient)
+    client.available = False
+    tracker = _Tracker(available_provider=None)
+    tracker.bind(client)
+
+    chosen = brain_module.LLMClient._auto_detect(client)
+
+    assert chosen == "ollama"
+    assert tracker.calls == list(brain_module.LLMClient.PROVIDER_PRIORITY)
+
+
+def test_key_set_but_provider_unavailable_falls_through(brain_module, monkeypatch):
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test")
+    client = brain_module.LLMClient.__new__(brain_module.LLMClient)
+    client.available = False
+    tracker = _Tracker(available_provider="ollama")
+    tracker.bind(client)
+
+    chosen = brain_module.LLMClient._auto_detect(client)
+
+    assert chosen == "ollama"
+    assert tracker.calls[0] == "claude"
+    assert "ollama" in tracker.calls


### PR DESCRIPTION
## Summary

`LLMClient._auto_detect()` in `brain.py` iterates `PROVIDER_PRIORITY = ["ollama", "claude", "openai", "grok"]` in fixed order. If a user only has `ANTHROPIC_API_KEY` set (no local Ollama server), auto-detect still probes Ollama first — the probe fails slowly or, worse, succeeds and routes chat through the wrong model.

This PR promotes any provider whose API key env var is set to the front of the probe order. Ollama stays as the final fallback when no keys are configured.

## Changes

- `brain.py` — add `PROVIDER_KEY_ENV` map and reshuffle probe order in `_auto_detect()` (net +14 lines)
- `tests/test_brain_auto_detect.py` — 4 new unit tests

## Behavior

| Env state                              | Probe order                          | Chosen (when available)     |
|----------------------------------------|--------------------------------------|-----------------------------|
| `ANTHROPIC_API_KEY` only               | claude → ollama → openai → grok      | claude                      |
| `OPENAI_API_KEY` + `XAI_API_KEY`       | openai → grok → ollama → claude      | openai or grok              |
| No keys                                | ollama → claude → openai → grok      | ollama (unchanged)          |
| `ANTHROPIC_API_KEY` set, SDK missing   | claude → ollama → openai → grok      | ollama (graceful fallback)  |

## Test plan

- [x] `pytest tests/test_brain_auto_detect.py -v` — 4 new tests pass
- [x] `pytest tests/ --ignore tests/test_cicd_scanner.sh --ignore tests/test_credential_store.py --ignore tests/test_recon_adapter.py --ignore tests/test_token_scanner.py` — 191 passed, 0 failed (ignored suites have pre-existing `tools.*` import errors unrelated to this PR)
- [x] Manual: `BRAIN_PROVIDER` env var still wins (explicit override unchanged)
- [x] Manual: `LLMClient("ollama")` constructor arg still wins

🤖 Generated with [Claude Code](https://claude.com/claude-code)