### PR TITLE
fix: restore tools/__init__.py so tools.* imports work in tests

### DIFF
--- a/tools/__init__.py
+++ b/tools/__init__.py
@@ -1,0 +1,6 @@
+"""Claude Bug Bounty tool package.
+
+Marks ``tools/`` as an importable Python package so tests can do
+``from tools.credential_store import CredentialStore`` etc. without
+path hacks.
+"""


### PR DESCRIPTION
## Summary

Two test modules currently fail to collect under ``pytest tests/``:

- ``tests/test_credential_store.py`` → ``ModuleNotFoundError: No module named 'tools.credential_store'``
- ``tests/test_token_scanner.py`` → same for ``tools.token_scanner``

Both do ``from tools.credential_store import CredentialStore`` etc., which requires ``tools/`` to be an importable Python package. There is no ``tools/__init__.py`` in the tree, so pytest bails out during collection and **55 otherwise-passing tests disappear**.

Adding a trivial ``tools/__init__.py`` restores them.

## Before / after

```
# before
$ PYTHONPATH=. pytest tests/
...
ERROR tests/test_credential_store.py - ModuleNotFoundError: No module named 'tools.credential_store'
ERROR tests/test_token_scanner.py   - ModuleNotFoundError: No module named 'tools.token_scanner'

# after
$ PYTHONPATH=. pytest tests/ --ignore tests/test_cicd_scanner.sh --ignore tests/test_recon_adapter.py
242 passed
```

Net change: **191 → 242 passing tests** (+55 recovered, including the 4 from the recent PR #19 auto-detect patch).

## Not addressed here

``tests/test_recon_adapter.py`` also fails to import, but for a different reason:

```
ImportError: cannot import name 'ReconAdapter' from 'tools.recon_adapter'
```

The test expects an OO ``ReconAdapter`` class; the module only exposes functional APIs (``load_recon``, ``normalize_to_nested``, ``ReconData`` dataclass). That's a module/test API drift — worth a separate PR that either adds a ``ReconAdapter`` wrapper class or rewrites the test against the functional API. I deliberately left it out of this change to keep the diff minimal and reviewable.

## Test plan

- [x] ``PYTHONPATH=. pytest tests/test_credential_store.py tests/test_token_scanner.py -v`` — 55 pass, 0 error
- [x] ``PYTHONPATH=. pytest tests/ --ignore tests/test_cicd_scanner.sh --ignore tests/test_recon_adapter.py`` — 242 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)