### PR TITLE
Installation Verification stops after first found tool due to `((INSTALLED++))` bash pitfall

### DIFF
--- a/install_tools.sh
+++ b/install_tools.sh
@@ -190,10 +190,10 @@ MISSING=0
 for tool in "${ALL_TOOLS[@]}"; do
     if command -v "$tool" &>/dev/null; then
         log_ok "$tool: $(which "$tool")"
-        ((INSTALLED++))
+        ((++INSTALLED))
     else
         log_err "$tool: NOT FOUND"
-        ((MISSING++))
+        ((++MISSING))
     fi
 done
 


### PR DESCRIPTION
## Description

The installation verification section in `install_tools.sh` exits prematurely after printing only the first found tool.

```
[*] Installation Verification
[+] subfinder: /home/linuxbrew/.linuxbrew/bin/subfinder
(script stops here)
```

In bash, `((expr))` returns exit code 1 when the expression evaluates to 0. Since `INSTALLED` is initialized to 0, the first `((INSTALLED++))` uses post-increment, it evaluates the old value (0), which is false, returning exit code 1.

Combined with `set -e` (or equivalent error handling), this kills the script immediately after the first successful tool is printed.

## Fix

```bash
# Use pre-increment (evaluates new value, always >= 1)
((++INSTALLED))
((++MISSING))
```