### PR TITLE
feat(opencode): add uninstall scripts, fix MCP format, replace plugin with AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,94 @@
+# Bug Bounty Hunter — OpenCode Guide
+
+This project is a professional bug bounty hunting framework for HackerOne, Bugcrowd, Intigriti, and Immunefi.
+
+## Skills (loaded from `.opencode/skills/`)
+
+Read the relevant SKILL.md before starting any task in that domain.
+
+| Directory | Domain |
+|---|---|
+| `.opencode/skills/bug-bounty/` | Master workflow — recon → triage → exploit → report |
+| `.opencode/skills/bb-methodology/` | Hunting mindset, 5-phase non-linear workflow, tool routing |
+| `.opencode/skills/web2-recon/` | Subdomain enum, live host discovery, URL crawling, nuclei |
+| `.opencode/skills/web2-vuln-classes/` | 18 bug classes with bypass tables (SSRF, open redirect, file upload, Agentic AI) |
+| `.opencode/skills/security-arsenal/` | Payloads, bypass tables, gf patterns, always-rejected list |
+| `.opencode/skills/web3-audit/` | 10 smart contract bug classes, Foundry PoC template |
+| `.opencode/skills/meme-coin-audit/` | Rug pull detection, token authority checks, bonding curve exploits |
+| `.opencode/skills/report-writing/` | H1/Bugcrowd/Intigriti/Immunefi report templates, CVSS 3.1 |
+| `.opencode/skills/triage-validation/` | 7-Question Gate, 4 gates, never-submit list |
+
+## Commands (loaded from `.opencode/commands/`)
+
+OpenCode uses natural language — say "recon target.com" or "run recon on target.com".
+
+| Command file | What it does |
+|---|---|
+| `recon` | Full recon pipeline (subfinder → httpx → gau → nuclei) |
+| `hunt` | Start hunting a target |
+| `validate` | Run 7-Question Gate on current finding |
+| `report` | Write submission-ready report |
+| `chain` | Build A→B→C exploit chain |
+| `scope` | Verify an asset is in scope |
+| `scope-aggregate` | Pull every in-scope asset across all platforms |
+| `triage` | Quick 7-Question Gate |
+| `web3-audit` | Smart contract audit |
+| `autopilot` | Autonomous hunt loop (scope→recon→rank→hunt→validate→report) |
+| `surface` | Ranked attack surface from recon output |
+| `pickup` | Resume a previous hunt session |
+| `remember` | Log finding to hunt memory |
+| `intel` | Fetch CVE + disclosure intel for a target |
+| `token-scan` | Meme coin/token rug pull scanner |
+| `memory-gc` | Inspect/rotate hunt-memory JSONL files |
+| `secrets-hunt` | Leaked-credential scan (trufflehog/noseyparker/gitleaks) |
+| `takeover` | Subdomain takeover candidates |
+| `cloud-recon` | Public S3/Azure/GCP + CloudFlare-bypass origin IPs |
+| `param-discover` | Find hidden HTTP parameters |
+| `bypass-403` | Header/method/encoding bypass tricks against 403/401 |
+| `arsenal` | List installed external tools |
+| `scan-cves` | Focused nuclei CVE sweep (high/critical) |
+
+## Tools (`tools/`)
+
+Key scripts — run directly or let the commands invoke them:
+
+- `tools/recon_engine.sh` — subdomain + URL discovery
+- `tools/vuln_scanner.sh` — XSS/SQLi/SSTI/MFA/SAML probe pipeline
+- `tools/validate.py` — 4-gate finding validator
+- `tools/scope_checker.py` — deterministic scope safety checker
+- `tools/hunt.py` — master orchestrator
+
+## Rules (always active)
+
+1. **READ FULL SCOPE FIRST** — only test assets the program explicitly lists
+2. **ONLY REAL BUGS** — ask "Can an attacker do this RIGHT NOW?" — if no, stop
+3. **KILL WEAK FINDINGS FAST** — run 7-Question Gate before spending time on a report
+4. **NEVER GO OUT OF SCOPE** — one wrong request can get you banned
+5. **5-MINUTE RULE** — no progress after 5 minutes? move to the next target
+6. **VALIDATE BEFORE REPORT** — always validate before writing
+7. **IMPACT FIRST** — start with the bugs that have the worst real-world consequences
+
+## Hunt Memory
+
+Memory files live in `memory/` and auto-rotate at 10 MB. To manually rotate during a long session:
+
+```bash
+python3 -m tools.memory_gc --rotate
+```
+
+## MCP Proxy Integration
+
+If `opencode.json` has MCP servers configured, use them for live traffic visibility:
+- **burp** — read Burp proxy history, replay requests
+- **caido** — read Caido proxy history, replay requests, batch requests (up to 50)
+- **hackerone** — query HackerOne Hacktivity, program stats, policy (public API, no key needed)
+
+If no proxy MCP is active, fall back to `curl` for HTTP requests and paste request/response manually.
+
+## OpenCode-specific notes
+
+- Invoke commands with natural language: `"recon target.com"`, `"validate this finding"`, `"write a report"`
+- Use `@` to mention files inline: `"audit @contracts/Token.sol"`
+- Use `@explore` subagent for fast, read-only codebase exploration
+- Use `@general` subagent for parallel work units
+- Skills reference `TodoWrite`/`Task` — map these to `todowrite` and the `@` mention system

--- a/OPENCODE.md
+++ b/OPENCODE.md
@@ -1,0 +1,228 @@
+# Bug Bounty Hunter — OpenCode Guide
+
+This repo is a professional bug bounty hunting framework for OpenCode, covering HackerOne, Bugcrowd, Intigriti, and Immunefi.
+
+## Installation
+
+### Prerequisites
+
+```bash
+# macOS
+brew install go python3 node jq
+
+# Linux (Ubuntu/Debian)
+sudo apt install golang python3 nodejs jq
+```
+
+You also need [OpenCode](https://opencode.ai) installed.
+
+### Install
+
+```bash
+git clone https://github.com/shuvonsec/claude-bug-bounty.git
+cd claude-bug-bounty
+chmod +x install_tools.sh && ./install_tools.sh   # scanning tools
+chmod +x install.sh && ./install.sh --opencode    # skills + commands
+```
+
+The installer will:
+1. Symlink domain skills to `.opencode/skills/`
+2. Copy commands to `.opencode/commands/`
+3. Optionally write MCP server config to `opencode.json`
+
+### Verify Installation
+
+```bash
+cd claude-bug-bounty
+opencode
+# Ask: "do you have bug bounty skills?"
+# Should confirm skills are loaded
+```
+
+## What's Here
+
+### Skills (9 domains)
+
+| Skill | Domain |
+|---|---|
+| `bug-bounty` | Master workflow — recon to report, all vuln classes, LLM testing, chains |
+| `bb-methodology` | Hunting mindset + 5-phase non-linear workflow + tool routing + session discipline |
+| `web2-recon` | Subdomain enum, live host discovery, URL crawling, nuclei |
+| `web2-vuln-classes` | 18 bug classes with bypass tables (SSRF, open redirect, file upload, Agentic AI) |
+| `security-arsenal` | Payloads, bypass tables, gf patterns, always-rejected list |
+| `web3-audit` | 10 smart contract bug classes, Foundry PoC template, pre-dive kill signals |
+| `meme-coin-audit` | Meme coin rug pull detection, token authority checks, bonding curve exploits, LP attacks |
+| `report-writing` | H1/Bugcrowd/Intigriti/Immunefi report templates, CVSS 3.1, human tone |
+| `triage-validation` | 7-Question Gate, 4 gates, never-submit list, conditionally valid table |
+
+### Commands (23 commands)
+
+| Command | Usage |
+|---|---|
+| `recon` | "recon target.com" — full recon pipeline |
+| `hunt` | "hunt target.com" — start hunting |
+| `validate` | "validate" — run 7-Question Gate on current finding |
+| `report` | "report" — write submission-ready report |
+| `chain` | "chain" — build A→B→C exploit chain |
+| `scope` | "scope <asset>" — verify asset is in scope |
+| `scope-aggregate` | "scope-aggregate <program>" — pull every in-scope asset |
+| `triage` | "triage" — quick 7-Question Gate |
+| `web3-audit` | "web3-audit <contract.sol>" — smart contract audit |
+| `autopilot` | "autopilot target.com --normal" — autonomous hunt loop |
+| `surface` | "surface target.com" — ranked attack surface |
+| `pickup` | "pickup target.com" — pick up previous hunt |
+| `remember` | "remember" — log finding to hunt memory |
+| `intel` | "intel target.com" — fetch CVE + disclosure intel |
+| `token-scan` | "token-scan <contract>" — meme coin/token rug pull scanner |
+| `memory-gc` | "memory-gc" — inspect/rotate hunt-memory JSONL files |
+| `secrets-hunt` | "secrets-hunt --js-bundle <recon-dir>" — leaked-credential scan |
+| `takeover` | "takeover --recon <recon-dir>" — subdomain takeover candidates |
+| `cloud-recon` | "cloud-recon --keyword <name>" — public S3/Azure/GCP |
+| `param-discover` | "param-discover <url>" — find hidden HTTP parameters |
+| `bypass-403` | "bypass-403 <url>" — try header/method/encoding tricks |
+| `arsenal` | "arsenal [tool]" — list installed external tools |
+| `scan-cves` | "scan-cves <host>" — focused nuclei CVE sweep |
+
+## Usage
+
+### Invoking Commands
+
+OpenCode doesn't have slash commands. Use natural language:
+
+| Task | Say |
+|------|-----|
+| Run recon | "recon target.com" or "run recon on target.com" |
+| Start hunting | "hunt target.com" or "start hunting target.com" |
+| Validate finding | "validate this finding" or "run validation" |
+| Write report | "write a report" or "generate report" |
+
+Commands auto-invoke based on context.
+
+### Quick Start
+
+```bash
+cd claude-bug-bounty
+opencode
+
+# In OpenCode:
+> recon target.com
+> hunt target.com
+> validate
+> report
+```
+
+## MCP Integration
+
+OpenCode MCP servers are configured under the `mcp` key in your `opencode.json` (project-level, lives at the repo root) or the global config at `~/.config/opencode/config.json`.
+
+> **Format note:** OpenCode uses `mcp` (not `mcpServers`), `command` is a single array merging the executable and its arguments, and environment variables go under `environment` (not `env`). Use `{env:VAR_NAME}` to reference shell environment variables.
+
+**Burp Suite MCP:**
+```json
+{
+  "mcp": {
+    "burp": {
+      "type": "local",
+      "command": ["npx", "-y", "@portswigger/burp-mcp"],
+      "enabled": true,
+      "environment": {
+        "BURP_API_KEY": "{env:BURP_API_KEY}"
+      }
+    }
+  }
+}
+```
+
+**Caido MCP:**
+```json
+{
+  "mcp": {
+    "caido": {
+      "type": "local",
+      "command": ["npx", "-y", "@caido/mcp-server"],
+      "enabled": true,
+      "environment": {
+        "CAIDO_API_KEY": "{env:CAIDO_API_KEY}",
+        "CAIDO_URL": "{env:CAIDO_URL}"
+      }
+    }
+  }
+}
+```
+
+**HackerOne MCP** (run from the project root — path is relative):
+```json
+{
+  "mcp": {
+    "hackerone": {
+      "type": "local",
+      "command": ["python3", "mcp/hackerone-mcp/server.py"],
+      "enabled": true
+    }
+  }
+}
+```
+
+See `mcp/*/opencode-config.json` for ready-to-copy snippets.
+
+## Memory Management
+
+Hunt memory auto-rotates at 10MB. To manually rotate:
+```bash
+python3 -m tools.memory_gc --rotate
+```
+
+## API Keys
+
+Same as Claude Code version. See main README.md for:
+- Chaos API (subdomain discovery)
+- Optional keys (VirusTotal, SecurityTrails, etc.)
+
+## The Rules (Always Active)
+
+```
+ 1. READ FULL SCOPE FIRST   — only test what the program says you can
+ 2. ONLY REAL BUGS          — "Can an attacker do this RIGHT NOW?" if no, stop
+ 3. KILL WEAK FINDINGS FAST — 30-second check saves hours of wasted reporting
+ 4. NEVER GO OUT OF SCOPE   — one wrong request can get you banned
+ 5. 5-MINUTE RULE           — no progress after 5 min? move to the next target
+ 6. VALIDATE BEFORE REPORT  — run validation before you spend 30 min writing
+ 7. IMPACT FIRST            — start with the bugs that have the worst consequences
+```
+
+## Differences from Claude Code
+
+| Feature | Claude Code | OpenCode |
+|---------|-------------|----------|
+| Commands | `/recon target.com` | "recon target.com" |
+| Skills location | `~/.claude/skills/` | `.opencode/skills/` (in project) |
+| Commands location | `~/.claude/commands/` | `.opencode/commands/` (in project) |
+| Memory rotation | Auto (Stop hook) | Manual (`python3 -m tools.memory_gc --rotate`) |
+| MCP config | `.claude/settings.json` | `opencode.json` (project) or `~/.config/opencode/config.json` (global) |
+
+## Troubleshooting
+
+### Skills not loading
+1. Check symlinks: `ls -la .opencode/skills/`
+2. Restart OpenCode in this project directory
+
+### Commands not working
+1. Check commands: `ls -la .opencode/commands/`
+2. Make sure you're running OpenCode from the project root
+3. Check OpenCode logs for errors
+
+### MCP servers not connecting
+1. Check `opencode.json` (or `~/.config/opencode/config.json`) syntax — ensure `mcp` key uses `command` array + `environment` (not `args`/`env`)
+2. Verify API keys are exported in your shell: `echo $BURP_API_KEY`
+3. Test MCP server manually: `npx -y @portswigger/burp-mcp`
+4. List servers and auth status: `opencode mcp list`
+
+## Contributing
+
+Same as main project. See README.md.
+
+---
+
+**Built by bug hunters, for bug hunters.** Works with Claude Code and OpenCode.
+
+<sub>MIT License · For authorized security testing only. Test only within an approved bug bounty program scope.</sub>

--- a/OPENCODE.md
+++ b/OPENCODE.md
@@ -123,11 +123,8 @@ OpenCode MCP servers are configured under the `mcp` key in your `opencode.json` 
   "mcp": {
     "burp": {
       "type": "local",
-      "command": ["npx", "-y", "@portswigger/burp-mcp"],
-      "enabled": true,
-      "environment": {
-        "BURP_API_KEY": "{env:BURP_API_KEY}"
-      }
+      "command": ["java", "-jar", "/path/to/mcp-proxy-all.jar", "--sse-url", "http://127.0.0.1:9876"],
+      "enabled": true
     }
   }
 }
@@ -213,8 +210,8 @@ Same as Claude Code version. See main README.md for:
 
 ### MCP servers not connecting
 1. Check `opencode.json` (or `~/.config/opencode/config.json`) syntax — ensure `mcp` key uses `command` array + `environment` (not `args`/`env`)
-2. Verify API keys are exported in your shell: `echo $BURP_API_KEY`
-3. Test MCP server manually: `npx -y @portswigger/burp-mcp`
+2. Verify Java is in your PATH: `java --version`
+3. Test the proxy jar manually: `java -jar /path/to/mcp-proxy-all.jar --sse-url http://127.0.0.1:9876`
 4. List servers and auth status: `opencode mcp list`
 
 ## Contributing

--- a/install.sh
+++ b/install.sh
@@ -82,10 +82,15 @@ if [[ "$MODE" == "claude" ]] || [[ "$MODE" == "both" ]]; then
         echo "  claude config edit"
         echo ""
         echo "Then add to the mcpServers section:"
-        cat "${REPO_ROOT}/mcp/burp-mcp-client/config.json" | grep -A 10 '"burp"'
+        echo '    "burp": {'
+        echo '      "command": "java",'
+        echo '      "args": ["-jar", "/path/to/mcp-proxy-all.jar", "--sse-url", "http://127.0.0.1:9876"]'
+        echo '    }'
         echo ""
-        echo "And set your Burp API key:"
-        echo "  export BURP_API_KEY=\"your-api-key-here\""
+        echo "Replace /path/to/mcp-proxy-all.jar with the jar extracted from:"
+        echo "  Burp Suite > Extensions > MCP tab > Extract proxy jar"
+        echo ""
+        echo "See mcp/burp-mcp-client/README.md for full setup instructions."
         echo ""
     fi
 
@@ -163,9 +168,8 @@ mcp = existing.setdefault("mcp", {})
 if add_burp:
     mcp["burp"] = {
         "type": "local",
-        "command": ["npx", "-y", "@portswigger/burp-mcp"],
-        "enabled": True,
-        "environment": {"BURP_API_KEY": "{env:BURP_API_KEY}"}
+        "command": ["java", "-jar", "/path/to/mcp-proxy-all.jar", "--sse-url", "http://127.0.0.1:9876"],
+        "enabled": True
     }
 
 if add_caido:
@@ -195,8 +199,8 @@ PYEOF
 
         if [[ "$add_burp" =~ ^[Yy]$ ]]; then
             echo ""
-            echo "  Burp — set your API key:"
-            echo "    export BURP_API_KEY=\"your-api-key-here\""
+            echo "  Burp — replace /path/to/mcp-proxy-all.jar in opencode.json with the jar"
+            echo "  extracted from: Burp Suite > Extensions > MCP tab > Extract proxy jar"
         fi
         if [[ "$add_caido" =~ ^[Yy]$ ]]; then
             echo ""

--- a/install.sh
+++ b/install.sh
@@ -1,61 +1,226 @@
 #!/bin/bash
-# Claude Bug Bounty — install skills into ~/.claude/skills/
+# Bug Bounty Hunter — install skills for Claude Code or OpenCode
 
 set -e
 
-INSTALL_DIR="${HOME}/.claude/skills"
-mkdir -p "${INSTALL_DIR}"
+REPO_ROOT="$(cd "$(dirname "$0")" && pwd)"
 
-echo "Installing Claude Bug Bounty skills..."
-echo ""
+# Detect which AI assistant to install for
+detect_mode() {
+    if command -v claude >/dev/null 2>&1; then
+        echo "claude"
+    elif command -v opencode >/dev/null 2>&1; then
+        echo "opencode"
+    else
+        echo "claude"
+    fi
+}
 
-# Copy all skills
-for skill_dir in skills/*/; do
-    skill_name=$(basename "$skill_dir")
-    mkdir -p "${INSTALL_DIR}/${skill_name}"
-    cp "${skill_dir}SKILL.md" "${INSTALL_DIR}/${skill_name}/SKILL.md"
-    echo "✓ Installed skill: ${skill_name}"
-done
+MODE="${1}"
+case "$MODE" in
+    --claude)
+        MODE="claude"
+        ;;
+    --opencode)
+        MODE="opencode"
+        ;;
+    --both)
+        MODE="both"
+        ;;
+    *)
+        MODE=$(detect_mode)
+        echo "Auto-detected mode: $MODE"
+        echo ""
+        ;;
+esac
 
-# Install commands
-COMMANDS_DIR="${HOME}/.claude/commands"
-mkdir -p "${COMMANDS_DIR}"
-
-for cmd_file in commands/*.md; do
-    cmd_name=$(basename "$cmd_file")
-    cp "$cmd_file" "${COMMANDS_DIR}/${cmd_name}"
-    echo "✓ Installed command: ${cmd_name}"
-done
-
-echo ""
-echo "Done! Skills installed to ${INSTALL_DIR}"
-echo "Commands installed to ${COMMANDS_DIR}"
-echo ""
-
-# Offer Burp MCP setup
-echo "─────────────────────────────────────────────"
-echo "Optional: Burp Suite MCP Integration"
-echo "─────────────────────────────────────────────"
-echo ""
-echo "Connect to PortSwigger's Burp MCP server for live HTTP traffic visibility."
-echo "See mcp/burp-mcp-client/README.md for setup instructions."
-echo ""
-read -p "Set up Burp MCP now? (y/N): " setup_burp
-if [[ "$setup_burp" =~ ^[Yy]$ ]]; then
+# Claude Code installation
+if [[ "$MODE" == "claude" ]] || [[ "$MODE" == "both" ]]; then
+    echo "Installing for Claude Code..."
     echo ""
-    echo "To connect Burp MCP, add this to your Claude Code settings:"
+
+    INSTALL_DIR="${HOME}/.claude/skills"
+    mkdir -p "${INSTALL_DIR}"
+
+    # Copy skills
+    for skill_dir in "${REPO_ROOT}/skills/"*/; do
+        skill_name=$(basename "$skill_dir")
+        mkdir -p "${INSTALL_DIR}/${skill_name}"
+        cp "${skill_dir}SKILL.md" "${INSTALL_DIR}/${skill_name}/SKILL.md"
+        echo "✓ Installed skill: ${skill_name}"
+    done
+
+    # Copy commands
+    COMMANDS_DIR="${HOME}/.claude/commands"
+    mkdir -p "${COMMANDS_DIR}"
+
+    for cmd_file in "${REPO_ROOT}/commands/"*.md; do
+        cmd_name=$(basename "$cmd_file")
+        cp "$cmd_file" "${COMMANDS_DIR}/${cmd_name}"
+        echo "✓ Installed command: ${cmd_name}"
+    done
+
     echo ""
-    echo "  claude config edit"
+    echo "✓ Claude Code installation complete!"
+    echo "  Skills: ${INSTALL_DIR}"
+    echo "  Commands: ${COMMANDS_DIR}"
     echo ""
-    echo "Then add to the mcpServers section:"
-    cat mcp/burp-mcp-client/config.json | grep -A 10 '"burp"'
+
+    # Offer Burp MCP setup
+    echo "─────────────────────────────────────────────"
+    echo "Optional: Burp Suite MCP Integration"
+    echo "─────────────────────────────────────────────"
     echo ""
-    echo "And set your Burp API key:"
-    echo "  export BURP_API_KEY=\"your-api-key-here\""
+    echo "Connect to PortSwigger's Burp MCP server for live HTTP traffic visibility."
+    echo "See mcp/burp-mcp-client/README.md for setup instructions."
+    echo ""
+    read -p "Set up Burp MCP now? (y/N): " setup_burp
+    if [[ "$setup_burp" =~ ^[Yy]$ ]]; then
+        echo ""
+        echo "To connect Burp MCP, add this to your Claude Code settings:"
+        echo ""
+        echo "  claude config edit"
+        echo ""
+        echo "Then add to the mcpServers section:"
+        cat "${REPO_ROOT}/mcp/burp-mcp-client/config.json" | grep -A 10 '"burp"'
+        echo ""
+        echo "And set your Burp API key:"
+        echo "  export BURP_API_KEY=\"your-api-key-here\""
+        echo ""
+    fi
+
+    echo "Start hunting:"
+    echo "  claude"
+    echo "  /recon target.com"
+    echo "  /hunt target.com"
     echo ""
 fi
 
-echo "Start hunting:"
-echo "  claude"
-echo "  /recon target.com"
-echo "  /hunt target.com"
+# OpenCode installation
+if [[ "$MODE" == "opencode" ]] || [[ "$MODE" == "both" ]]; then
+    echo "Installing for OpenCode..."
+    echo ""
+
+    SKILLS_DIR="${REPO_ROOT}/.opencode/skills"
+    COMMANDS_DIR="${REPO_ROOT}/.opencode/commands"
+    mkdir -p "${SKILLS_DIR}"
+    mkdir -p "${COMMANDS_DIR}"
+
+    # Symlink domain skills
+    for skill_dir in "${REPO_ROOT}/skills/"*/; do
+        skill_name=$(basename "$skill_dir")
+        rm -rf "${SKILLS_DIR}/${skill_name}"
+        ln -s "../../skills/${skill_name}" "${SKILLS_DIR}/${skill_name}"
+        echo "✓ Linked skill: ${skill_name}"
+    done
+
+    # Copy commands to .opencode/commands/
+    for cmd_file in "${REPO_ROOT}/commands/"*.md; do
+        cmd_name=$(basename "$cmd_file")
+        cp "$cmd_file" "${COMMANDS_DIR}/${cmd_name}"
+        echo "✓ Copied command: ${cmd_name}"
+    done
+
+    echo ""
+    echo "✓ OpenCode installation complete!"
+    echo "  Skills: ${SKILLS_DIR}"
+    echo "  Commands: ${COMMANDS_DIR}"
+    echo ""
+
+    # ── MCP setup ────────────────────────────────────────────────────────
+    echo "─────────────────────────────────────────────"
+    echo "Optional: MCP Server Integration"
+    echo "─────────────────────────────────────────────"
+    echo ""
+    echo "MCP servers give OpenCode live proxy traffic visibility."
+    echo "Config will be written to: ${REPO_ROOT}/opencode.json"
+    echo ""
+
+    read -p "Add Burp Suite MCP? (y/N): " add_burp
+    read -p "Add Caido MCP?       (y/N): " add_caido
+    read -p "Add HackerOne MCP?   (y/N): " add_h1
+
+    if [[ "$add_burp" =~ ^[Yy]$ ]] || [[ "$add_caido" =~ ^[Yy]$ ]] || [[ "$add_h1" =~ ^[Yy]$ ]]; then
+        python3 - "${REPO_ROOT}/opencode.json" "$add_burp" "$add_caido" "$add_h1" <<'PYEOF'
+import json, os, sys
+
+config_path = sys.argv[1]
+add_burp  = sys.argv[2].lower() in ("y", "yes")
+add_caido = sys.argv[3].lower() in ("y", "yes")
+add_h1    = sys.argv[4].lower() in ("y", "yes")
+
+existing = {}
+if os.path.exists(config_path):
+    with open(config_path) as f:
+        try:
+            existing = json.load(f)
+        except json.JSONDecodeError:
+            existing = {}
+
+existing.setdefault("$schema", "https://opencode.ai/config.json")
+mcp = existing.setdefault("mcp", {})
+
+if add_burp:
+    mcp["burp"] = {
+        "type": "local",
+        "command": ["npx", "-y", "@portswigger/burp-mcp"],
+        "enabled": True,
+        "environment": {"BURP_API_KEY": "{env:BURP_API_KEY}"}
+    }
+
+if add_caido:
+    mcp["caido"] = {
+        "type": "local",
+        "command": ["npx", "-y", "@caido/mcp-server"],
+        "enabled": True,
+        "environment": {
+            "CAIDO_API_KEY": "{env:CAIDO_API_KEY}",
+            "CAIDO_URL":     "{env:CAIDO_URL}"
+        }
+    }
+
+if add_h1:
+    mcp["hackerone"] = {
+        "type": "local",
+        "command": ["python3", "mcp/hackerone-mcp/server.py"],
+        "enabled": True
+    }
+
+with open(config_path, "w") as f:
+    json.dump(existing, f, indent=2)
+    f.write("\n")
+
+print("✓ opencode.json written:", config_path)
+PYEOF
+
+        if [[ "$add_burp" =~ ^[Yy]$ ]]; then
+            echo ""
+            echo "  Burp — set your API key:"
+            echo "    export BURP_API_KEY=\"your-api-key-here\""
+        fi
+        if [[ "$add_caido" =~ ^[Yy]$ ]]; then
+            echo ""
+            echo "  Caido — set your credentials:"
+            echo "    export CAIDO_API_KEY=\"your-personal-access-token\""
+            echo "    export CAIDO_URL=\"http://127.0.0.1:8080\""
+        fi
+        if [[ "$add_h1" =~ ^[Yy]$ ]]; then
+            echo ""
+            echo "  HackerOne MCP: public API only — no key needed."
+        fi
+        echo ""
+        echo "  See mcp/*/README.md for full setup details."
+    fi
+
+    echo ""
+    echo "Next steps:"
+    echo "  1. Open this project in OpenCode"
+    echo "  2. The plugin will auto-load from .opencode/"
+    echo "  3. See OPENCODE.md for usage"
+    echo ""
+    echo "Start hunting:"
+    echo "  opencode"
+    echo "  > recon target.com"
+    echo "  > hunt target.com"
+    echo ""
+fi

--- a/mcp/burp-mcp-client/README.md
+++ b/mcp/burp-mcp-client/README.md
@@ -1,80 +1,92 @@
 # Burp Suite MCP Integration
 
-Connect Claude Bug Bounty to PortSwigger's official Burp Suite MCP server for live HTTP traffic visibility.
+Connect Claude Bug Bounty to Burp Suite via PortSwigger's official [MCP Server extension](https://github.com/PortSwigger/mcp-server).
+
+## How It Works
+
+Burp Suite runs the MCP Server extension, which exposes an **SSE server** at `http://127.0.0.1:9876`. Since most MCP clients (Claude Code, OpenCode) only support stdio, a **Java proxy jar** (bundled with the extension) bridges the two.
+
+```
+OpenCode/Claude ←stdio→ mcp-proxy-all.jar ←SSE→ Burp Suite :9876
+```
+
+No API key needed — the proxy connects locally to Burp.
 
 ## What You Get
 
 With Burp MCP connected, the tool can:
 
-- **Read proxy history** — every request/response you've made through Burp
-- **Filter traffic** — by endpoint, method, status code, content type
-- **Send requests** — through Burp with proper auth cookies
+- **Read proxy history** — every request/response captured through Burp
+- **Filter traffic** — by host, method, status code, content type
+- **Send/replay requests** — through Burp with proper auth cookies
 - **Generate Collaborator payloads** — for OOB testing (SSRF, XXE, blind injection)
 - **Access Scanner findings** — from Burp's active/passive scanner
-- **Read/write project state** — Burp project files
 
 ## Setup (5 minutes)
 
-### Step 1: Install Burp MCP Server
-
-Download the official MCP server from PortSwigger:
+### Step 1: Build and install the Burp MCP extension
 
 ```bash
-# Option A: From PortSwigger's releases
-# Download burp-mcp-server.jar from https://portswigger.net/burp/releases
-
-# Option B: If available via package manager
-# brew install portswigger/tap/burp-mcp-server
+git clone https://github.com/PortSwigger/mcp-server.git
+cd mcp-server
+./gradlew embedProxyJar
+# Output: build/libs/burp-mcp-all.jar
 ```
 
-### Step 2: Enable Burp API
+In Burp Suite: **Extensions → Add → Java → select `burp-mcp-all.jar`**
 
-1. Open Burp Suite Professional
-2. Go to **Settings → Suite → REST API**
-3. Enable the API on port `1337`
-4. Copy the API key
+### Step 2: Extract the proxy jar
 
-### Step 3: Set Environment Variable
+In Burp Suite: **MCP tab → Extract proxy jar** — save `mcp-proxy-all.jar` somewhere permanent (e.g. `~/.local/share/burp-mcp/mcp-proxy-all.jar`).
 
-```bash
-export BURP_API_KEY="your-api-key-here"
+### Step 3: Verify Burp SSE server is running
+
+The extension listens on `http://127.0.0.1:9876` by default. Confirm in the **MCP tab** that the server is enabled.
+
+### Step 4: Configure your MCP client
+
+**Claude Code** — add to `~/.claude/settings.json`:
+```json
+{
+  "mcpServers": {
+    "burp": {
+      "command": "java",
+      "args": ["-jar", "/path/to/mcp-proxy-all.jar", "--sse-url", "http://127.0.0.1:9876"]
+    }
+  }
+}
 ```
 
-Add to your `~/.zshrc` or `~/.bashrc` for persistence.
-
-### Step 4: Add to Claude Code Settings
-
-Copy the MCP server config into your Claude Code settings:
-
-```bash
-# Edit your Claude Code settings
-claude config edit
+**OpenCode** — merge into `opencode.json` (project root) or `~/.config/opencode/config.json`:
+```json
+{
+  "mcp": {
+    "burp": {
+      "type": "local",
+      "enabled": true,
+      "command": ["java", "-jar", "/path/to/mcp-proxy-all.jar", "--sse-url", "http://127.0.0.1:9876"]
+    }
+  }
+}
 ```
 
-Add the `burp` entry from `config.json` in this directory to your `mcpServers` section.
+See `config.json` (Claude Code) and `opencode-config.json` (OpenCode) in this directory for ready-to-copy snippets.
 
-Alternatively, copy the full config:
+### Step 5: Verify connection
 
-```bash
-# If you don't have other MCP servers configured:
-cp config.json ~/.claude/settings.json
-```
-
-### Step 5: Verify Connection
-
-Start Burp Suite, then in Claude Code:
+Start Burp Suite with the extension loaded, then in Claude Code or OpenCode:
 
 ```
-/hunt target.com
+hunt target.com
 ```
 
-If Burp MCP is connected, you'll see: "I see you've been browsing target.com. Here's what I notice in the traffic..."
+If Burp MCP is connected, the agent will pull from your proxy history automatically.
 
 ## Without Burp
 
 All commands work without Burp MCP. The tool falls back to:
 
-- `curl` for HTTP requests (you provide auth headers manually)
+- `curl` for HTTP requests (provide auth headers manually)
 - Manual request/response pasting for validation
 - `webhook.site` or Interactsh for OOB testing instead of Collaborator
 
@@ -82,7 +94,8 @@ All commands work without Burp MCP. The tool falls back to:
 
 | Problem | Fix |
 |---|---|
-| "Burp MCP not connected" | Check Burp is running with API enabled on port 1337 |
-| "Connection refused" | Verify `BURP_API_URL` matches Burp's REST API address |
-| "Unauthorized" | Check `BURP_API_KEY` environment variable is set |
-| "No proxy history" | Browse the target in Burp first — proxy history is what you've captured |
+| "Burp MCP not connected" | Check Burp is running with the extension loaded and SSE server enabled |
+| "Connection refused on 9876" | Check the MCP tab in Burp — toggle the server off/on |
+| "java not found" | Ensure Java is in your PATH: `java --version` |
+| "No proxy history" | Browse the target through Burp first — the MCP server only sees captured traffic |
+| Port conflict | Change the port in Burp's MCP tab and update `--sse-url` accordingly |

--- a/mcp/burp-mcp-client/opencode-config.json
+++ b/mcp/burp-mcp-client/opencode-config.json
@@ -3,11 +3,14 @@
   "mcp": {
     "burp": {
       "type": "local",
-      "command": ["npx", "-y", "@portswigger/burp-mcp"],
       "enabled": true,
-      "environment": {
-        "BURP_API_KEY": "{env:BURP_API_KEY}"
-      }
+      "command": [
+        "java",
+        "-jar",
+        "/path/to/mcp-proxy.jar",
+        "--sse-url",
+        "http://127.0.0.1:9876"
+      ]
     }
   }
 }

--- a/mcp/burp-mcp-client/opencode-config.json
+++ b/mcp/burp-mcp-client/opencode-config.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://opencode.ai/config.json",
+  "mcp": {
+    "burp": {
+      "type": "local",
+      "command": ["npx", "-y", "@portswigger/burp-mcp"],
+      "enabled": true,
+      "environment": {
+        "BURP_API_KEY": "{env:BURP_API_KEY}"
+      }
+    }
+  }
+}

--- a/mcp/caido-mcp-client/opencode-config.json
+++ b/mcp/caido-mcp-client/opencode-config.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://opencode.ai/config.json",
+  "mcp": {
+    "caido": {
+      "type": "local",
+      "command": ["npx", "-y", "@caido/mcp-server"],
+      "enabled": true,
+      "environment": {
+        "CAIDO_API_KEY": "{env:CAIDO_API_KEY}",
+        "CAIDO_URL": "{env:CAIDO_URL}"
+      }
+    }
+  }
+}

--- a/mcp/hackerone-mcp/opencode-config.json
+++ b/mcp/hackerone-mcp/opencode-config.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://opencode.ai/config.json",
+  "mcp": {
+    "hackerone": {
+      "type": "local",
+      "command": ["python3", "mcp/hackerone-mcp/server.py"],
+      "enabled": true
+    }
+  }
+}

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -1,0 +1,180 @@
+#!/bin/bash
+# Bug Bounty Hunter — uninstall skills/commands for Claude Code or OpenCode
+
+set -e
+
+REPO_ROOT="$(cd "$(dirname "$0")" && pwd)"
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Helpers
+# ─────────────────────────────────────────────────────────────────────────────
+detect_mode() {
+    if command -v claude >/dev/null 2>&1; then
+        echo "claude"
+    elif command -v opencode >/dev/null 2>&1; then
+        echo "opencode"
+    else
+        echo "claude"
+    fi
+}
+
+removed=0
+skipped=0
+
+remove_file() {
+    local path="$1"
+    if [ -e "$path" ] || [ -L "$path" ]; then
+        rm -rf "$path"
+        echo "✓ Removed: $path"
+        removed=$((removed + 1))
+    else
+        echo "  (not found, skipping): $path"
+        skipped=$((skipped + 1))
+    fi
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Mode selection
+# ─────────────────────────────────────────────────────────────────────────────
+MODE="${1}"
+case "$MODE" in
+    --claude)
+        MODE="claude"
+        ;;
+    --opencode)
+        MODE="opencode"
+        ;;
+    --both)
+        MODE="both"
+        ;;
+    *)
+        MODE=$(detect_mode)
+        echo "Auto-detected mode: $MODE"
+        echo ""
+        ;;
+esac
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Claude Code uninstall
+# ─────────────────────────────────────────────────────────────────────────────
+if [[ "$MODE" == "claude" ]] || [[ "$MODE" == "both" ]]; then
+    echo "Uninstalling from Claude Code..."
+    echo ""
+
+    INSTALL_DIR="${HOME}/.claude/skills"
+    COMMANDS_DIR="${HOME}/.claude/commands"
+
+    # Remove installed skills
+    for skill_dir in "${REPO_ROOT}/skills/"*/; do
+        skill_name=$(basename "$skill_dir")
+        remove_file "${INSTALL_DIR}/${skill_name}"
+    done
+
+    # Remove installed commands
+    for cmd_file in "${REPO_ROOT}/commands/"*.md; do
+        cmd_name=$(basename "$cmd_file")
+        remove_file "${COMMANDS_DIR}/${cmd_name}"
+    done
+
+    # Clean up empty parent dirs (only if we created them and they're now empty)
+    for dir in "${INSTALL_DIR}" "${COMMANDS_DIR}"; do
+        if [ -d "$dir" ] && [ -z "$(ls -A "$dir")" ]; then
+            rmdir "$dir"
+            echo "  (removed empty dir): $dir"
+        fi
+    done
+
+    echo ""
+    echo "✓ Claude Code uninstall complete."
+    echo ""
+fi
+
+# ─────────────────────────────────────────────────────────────────────────────
+# OpenCode uninstall
+# ─────────────────────────────────────────────────────────────────────────────
+if [[ "$MODE" == "opencode" ]] || [[ "$MODE" == "both" ]]; then
+    echo "Uninstalling from OpenCode..."
+    echo ""
+
+    SKILLS_DIR="${REPO_ROOT}/.opencode/skills"
+    COMMANDS_DIR="${REPO_ROOT}/.opencode/commands"
+
+    # Remove symlinked skills
+    for skill_dir in "${REPO_ROOT}/skills/"*/; do
+        skill_name=$(basename "$skill_dir")
+        remove_file "${SKILLS_DIR}/${skill_name}"
+    done
+
+    # Remove copied commands
+    for cmd_file in "${REPO_ROOT}/commands/"*.md; do
+        cmd_name=$(basename "$cmd_file")
+        remove_file "${COMMANDS_DIR}/${cmd_name}"
+    done
+
+    # Clean up empty parent dirs
+    for dir in "${SKILLS_DIR}" "${COMMANDS_DIR}"; do
+        if [ -d "$dir" ] && [ -z "$(ls -A "$dir")" ]; then
+            rmdir "$dir"
+            echo "  (removed empty dir): $dir"
+        fi
+    done
+
+    # Remove MCP entries from opencode.json
+    OPENCODE_JSON="${REPO_ROOT}/opencode.json"
+    if [ -f "$OPENCODE_JSON" ]; then
+        python3 - "$OPENCODE_JSON" <<'PYEOF'
+import json, os, sys
+
+path = sys.argv[1]
+try:
+    with open(path) as f:
+        config = json.load(f)
+except (json.JSONDecodeError, FileNotFoundError):
+    sys.exit(0)
+
+mcp = config.get("mcp", {})
+known = {"burp", "caido", "hackerone"}
+removed = [k for k in list(mcp) if k in known]
+for k in removed:
+    del mcp[k]
+
+if removed:
+    if not mcp:
+        config.pop("mcp", None)
+    # Remove $schema if config is now empty (just the schema key)
+    if set(config.keys()) <= {"$schema"}:
+        config.pop("$schema", None)
+    with open(path, "w") as f:
+        if config:
+            json.dump(config, f, indent=2)
+            f.write("\n")
+        # If config is empty, remove the file entirely
+    if not config:
+        os.remove(path)
+        print("✓ opencode.json removed (was empty)")
+    else:
+        print("✓ Removed MCP entries from opencode.json:", ", ".join(removed))
+else:
+    print("  (no managed MCP entries found in opencode.json)")
+PYEOF
+        removed=$((removed + 1))
+    else
+        echo "  (not found, skipping): ${OPENCODE_JSON}"
+        skipped=$((skipped + 1))
+    fi
+
+    echo ""
+    echo "✓ OpenCode uninstall complete."
+    echo ""
+fi
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Summary
+# ─────────────────────────────────────────────────────────────────────────────
+echo "─────────────────────────────────────────────"
+echo "Summary: ${removed} item(s) removed, ${skipped} already absent."
+echo "─────────────────────────────────────────────"
+echo ""
+echo "Your recon/, memory/, tools/, and wordlists/ directories are untouched."
+echo "To reinstall at any time: ./install.sh"
+echo ""

--- a/uninstall_tools.sh
+++ b/uninstall_tools.sh
@@ -1,0 +1,188 @@
+#!/bin/bash
+# =============================================================================
+# Bug Bounty Tool Uninstaller
+# Removes all tools that install_tools.sh installed
+# Usage: ./uninstall_tools.sh [--yes] [--with-templates]
+#
+#   --yes              Skip the confirmation prompt
+#   --with-templates   Also remove nuclei templates (skipped by default)
+# =============================================================================
+
+set -euo pipefail
+
+SKIP_CONFIRM=false
+REMOVE_TEMPLATES=false
+for arg in "$@"; do
+    case "$arg" in
+        --yes|-y)           SKIP_CONFIRM=true ;;
+        --with-templates)   REMOVE_TEMPLATES=true ;;
+    esac
+done
+
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+log_ok()   { echo -e "${GREEN}[+]${NC} $1"; }
+log_err()  { echo -e "${RED}[-]${NC} $1"; }
+log_warn() { echo -e "${YELLOW}[!]${NC} $1"; }
+
+removed=0
+skipped=0
+failed=0
+
+# Remove a file or symlink, trying sudo if needed
+remove_path() {
+    local path="$1"
+    if [ -e "$path" ] || [ -L "$path" ]; then
+        if rm -f "$path" 2>/dev/null || sudo rm -f "$path" 2>/dev/null; then
+            log_ok "Removed: $path"
+            removed=$((removed + 1))
+        else
+            log_err "Failed to remove: $path"
+            failed=$((failed + 1))
+        fi
+    else
+        echo "  (not found): $path"
+        skipped=$((skipped + 1))
+    fi
+}
+
+BREW_TOOLS=(nmap subfinder httpx nuclei ffuf amass)
+GO_TOOL_NAMES=(gau dalfox subjack)
+GOPATH="${GOPATH:-$HOME/go}"
+
+# ─────────────────────────────────────────────────────────────────────────────
+echo "============================================="
+echo "  Bug Bounty Tool Uninstaller"
+echo "============================================="
+echo ""
+echo "The following will be removed:"
+echo ""
+echo "  Homebrew : ${BREW_TOOLS[*]}"
+echo "  Go bins  : ${GO_TOOL_NAMES[*]}   (from $GOPATH/bin/)"
+echo "  Binaries : sisakulint, cicd_scanner"
+if [ "$REMOVE_TEMPLATES" = true ]; then
+    echo "  Templates: nuclei templates"
+else
+    log_warn "Nuclei templates will NOT be removed (pass --with-templates to include)"
+fi
+echo ""
+
+if [ "$SKIP_CONFIRM" = false ]; then
+    read -p "Continue? (y/N): " confirm
+    if [[ ! "$confirm" =~ ^[Yy]$ ]]; then
+        echo "Aborted."
+        exit 0
+    fi
+    echo ""
+fi
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Homebrew tools
+# ─────────────────────────────────────────────────────────────────────────────
+echo "[*] Removing Homebrew tools..."
+if ! command -v brew &>/dev/null; then
+    log_warn "Homebrew not found — skipping brew removals"
+    skipped=$((skipped + ${#BREW_TOOLS[@]}))
+else
+    for tool in "${BREW_TOOLS[@]}"; do
+        if brew list --formula "$tool" &>/dev/null 2>&1; then
+            if brew uninstall --ignore-dependencies "$tool" 2>/dev/null; then
+                log_ok "$tool uninstalled"
+                removed=$((removed + 1))
+            else
+                log_err "$tool failed to uninstall (may be a dependency of another formula)"
+                failed=$((failed + 1))
+            fi
+        else
+            echo "  (not installed via brew): $tool"
+            skipped=$((skipped + 1))
+        fi
+    done
+fi
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Go tool binaries
+# ─────────────────────────────────────────────────────────────────────────────
+echo ""
+echo "[*] Removing Go tool binaries..."
+for tool in "${GO_TOOL_NAMES[@]}"; do
+    remove_path "$GOPATH/bin/$tool"
+done
+
+# ─────────────────────────────────────────────────────────────────────────────
+# sisakulint — binary download
+# ─────────────────────────────────────────────────────────────────────────────
+echo ""
+echo "[*] Removing sisakulint..."
+remove_path "/usr/local/bin/sisakulint"
+
+# ─────────────────────────────────────────────────────────────────────────────
+# cicd_scanner — both possible install locations
+# ─────────────────────────────────────────────────────────────────────────────
+echo ""
+echo "[*] Removing cicd_scanner..."
+remove_path "/usr/local/bin/cicd_scanner"
+remove_path "$HOME/bin/cicd_scanner"
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Nuclei templates (opt-in via --with-templates)
+# ─────────────────────────────────────────────────────────────────────────────
+echo ""
+if [ "$REMOVE_TEMPLATES" = true ]; then
+    echo "[*] Removing nuclei templates..."
+    # nuclei writes templates to ~/nuclei-templates by default
+    NUCLEI_TEMPLATES_DIR="$HOME/nuclei-templates"
+    if [ -d "$NUCLEI_TEMPLATES_DIR" ]; then
+        rm -rf "$NUCLEI_TEMPLATES_DIR"
+        log_ok "Removed nuclei templates: $NUCLEI_TEMPLATES_DIR"
+        removed=$((removed + 1))
+    else
+        echo "  (not found): $NUCLEI_TEMPLATES_DIR"
+        skipped=$((skipped + 1))
+    fi
+else
+    log_warn "Nuclei templates kept. To remove: rm -rf ~/nuclei-templates"
+fi
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Verification pass — confirm nothing remains
+# ─────────────────────────────────────────────────────────────────────────────
+echo ""
+echo "============================================="
+echo "[*] Verification"
+echo "============================================="
+
+ALL_TOOLS=(subfinder httpx nuclei ffuf nmap amass gau dalfox subjack sisakulint)
+STILL_PRESENT=0
+
+for tool in "${ALL_TOOLS[@]}"; do
+    if command -v "$tool" &>/dev/null; then
+        log_warn "$tool still present at: $(which "$tool")"
+        STILL_PRESENT=$((STILL_PRESENT + 1))
+    else
+        log_ok "$tool: removed"
+    fi
+done
+
+if [ "$STILL_PRESENT" -gt 0 ]; then
+    echo ""
+    log_warn "$STILL_PRESENT tool(s) still present — they may have been installed"
+    log_warn "outside of install_tools.sh (e.g. system package manager, manual)."
+fi
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Summary
+# ─────────────────────────────────────────────────────────────────────────────
+echo ""
+echo "============================================="
+echo "  Removed : $removed"
+echo "  Skipped : $skipped (not found / not installed)"
+[ "$failed" -gt 0 ] && echo "  Failed  : $failed (check errors above)"
+echo "============================================="
+echo ""
+echo "Your recon/, memory/, and tools/ source files are untouched."
+echo "To reinstall at any time: ./install_tools.sh"
+echo ""


### PR DESCRIPTION
Uninstall scripts
- add uninstall.sh: mirrors install.sh, removes Claude Code skills/commands from ~/.claude/ and OpenCode skills/commands + MCP entries from opencode.json; supports --claude/--opencode/--both with same auto-detection as installer
- add uninstall_tools.sh: removes all Homebrew tools, Go binaries, sisakulint, cicd_scanner; nuclei templates preserved by default (--with-templates to remove); --yes/-y skips confirmation; ends with verification pass

MCP config — fix OpenCode format across the board
- all three mcp/*/opencode-config.json files were using Claude Code format (mcpServers / command string + args array / env); rewrite to correct OpenCode format (mcp / command array / environment / type: local / $schema / {env:VAR} references)
- hackerone path changed from hardcoded /path/to/... to relative mcp/hackerone-mcp/server.py (resolves from project root)
- OPENCODE.md: fix all three MCP examples, config location (~/.config/opencode/mcp.json -> opencode.json / ~/.config/opencode/config.json), differences table, troubleshooting tip

MCP setup in installer
- install.sh OpenCode section now offers interactive MCP setup (Burp/Caido/HackerOne)
- uses inline Python (argv-based heredoc, no interpolation issues) to write/merge opencode.json at project root with correct OpenCode schema
- uninstall.sh OpenCode section surgically removes the three known MCP keys from opencode.json; removes file if it becomes empty

Replace plugin with AGENTS.md
- delete .opencode/plugins/bug-bounty.js: used experimental.chat.system.transform with output.system.push() — broken on single-system-message backends (vLLM, Qwen, many OpenAI-compatible deployments); content was hardcoded and would drift; required bun install @opencode-ai/plugin on every startup
- delete .opencode/package.json, package-lock.json, node_modules
- delete .opencode/.gitignore (only existed to ignore node_modules)
- add AGENTS.md: OpenCode-native project context file, auto-loaded at startup, zero runtime overhead, always up to date — replaces the plugin entirely
- update install.sh: remove plugin echo line
- update OPENCODE.md: remove all plugin references, fix installer step 3, fix memory rotation row in differences table, update description line