### PR TITLE
fix(vuln_scanner): remove mkdir referencing $FINDINGS_DIR before assignment

### DIFF
--- a/tools/vuln_scanner.sh
+++ b/tools/vuln_scanner.sh
@@ -76,8 +76,6 @@ if ! command -v timeout &>/dev/null; then
     fi
 fi
 
-mkdir -p "$FINDINGS_DIR"/{xss,sqli,takeover,misconfig,exposure,ssrf,cves,redirects,ssti,manual_review}
-
 if [ "$(basename "$(dirname "$RECON_DIR")")" = "sessions" ]; then
     SESSION_ID=$(basename "$RECON_DIR")
     TARGET=$(basename "$(dirname "$(dirname "$RECON_DIR")")")


### PR DESCRIPTION
The `mkdir -p "$FINDINGS_DIR"/...` at line 79 runs before `FINDINGS_DIR` is assigned (line 91). Under strict mode this aborts the script immediately:

```
$ bash -uo pipefail tools/vuln_scanner.sh /path/to/recon
tools/vuln_scanner.sh: line 79: FINDINGS_DIR: unbound variable
```

The mkdir at line 98 already creates a superset of those subdirectories (the second list adds `upload`, `idor`, `auth_bypass`, `lfi`, `graphql`, `cors`, `jwt`, `smuggling`, `cloud`, `metasploit`, `.tmp`) once the variable is properly set, so line 79 is dead.

Hit this running `/hunt` against a local OWASP Juice Shop instance.