### PR TITLE
fix(vuln_scanner): repair orphaned if-block in XSS check

### DIFF
--- a/tools/vuln_scanner.sh
+++ b/tools/vuln_scanner.sh
@@ -288,18 +288,8 @@ fi
 # ── Check 3: XSS ────────────────────────────────────────────────────────
 if ! skip_has xss; then
     log_info "Check 3: XSS (dalfox + URL dedup + global timeout)"
-    PARAMS_FILE="$RECON_DIR/urls/with_params.txt"
-    if tool_ok dalfox && [ -s "$PARAMS_FILE" ]; then
-LIVE_COUNT=$(wc -l < "$LIVE_URLS" 2>/dev/null || echo 0)
-log_info "Scanning $LIVE_COUNT live hosts"
-
-# ============================================================
-# Check 1: XSS (Cross-Site Scripting)
-# ============================================================
-log_info "Check 1: XSS Detection"
-
-# Dalfox — automated XSS scanner (with global timeout + URL dedup)
-if command -v dalfox &>/dev/null && [ -s "$PARAM_URLS" ]; then
+    PARAM_URLS="$RECON_DIR/urls/with_params.txt"
+    if command -v dalfox &>/dev/null && [ -s "$PARAM_URLS" ]; then
     DAL_LIMIT=$([ "$QUICK_MODE" = "--quick" ] && echo 30 || echo 100)
     DAL_MAX_TIME=$([ "$QUICK_MODE" = "--quick" ] && echo 300 || echo 900)
     # Deduplicate by base-URL + sorted param keys to avoid scanning the same


### PR DESCRIPTION
The XSS check at line 287 opens an `if tool_ok dalfox && [ -s "$PARAMS_FILE" ]; then` that is never closed, and is immediately followed by what looks like leftover code from a prior refactor (an unindented duplicate dalfox check that references a different variable name, `$PARAM_URLS`).

```
$ bash -n tools/vuln_scanner.sh
tools/vuln_scanner.sh: line 538: syntax error: unexpected end of file
```

Bug 1 in PR #45 was masking this — the unbound-variable abort at line 79 prevented the script from ever reaching the broken structure.

The fix collapses the broken opener into the correct one beneath it, keeps `$PARAM_URLS` as the variable name used by the rest of the dalfox section, and drops the dead duplicate header. `bash -n` returns clean after the change.

A `bash -n tools/*.sh` step in CI would catch this class of issue automatically — happy to send that as a separate small PR if useful.