### PR TITLE
feat(vuln-classes): add error disclosure & framework debug endpoints

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,7 +11,7 @@ This repo is a Claude Code plugin for professional bug bounty hunting across Hac
 | `skills/bug-bounty/` | Master workflow — recon to report, all vuln classes, LLM testing, chains |
 | `skills/bb-methodology/` | **Hunting mindset + 5-phase non-linear workflow + tool routing + session discipline** |
 | `skills/web2-recon/` | Subdomain enum, live host discovery, URL crawling, nuclei |
-| `skills/web2-vuln-classes/` | 18 bug classes with bypass tables (SSRF, open redirect, file upload, Agentic AI) |
+| `skills/web2-vuln-classes/` | 21 bug classes with bypass tables (SSRF, open redirect, file upload, Agentic AI) |
 | `skills/security-arsenal/` | Payloads, bypass tables, gf patterns, always-rejected list |
 | `skills/web3-audit/` | 10 smart contract bug classes, Foundry PoC template, pre-dive kill signals |
 | `skills/meme-coin-audit/` | Meme coin rug pull detection, token authority checks, bonding curve exploits, LP attacks |

--- a/skills/bug-bounty/SKILL.md
+++ b/skills/bug-bounty/SKILL.md
@@ -359,7 +359,7 @@ curl -s "https://hackerone.com/graphql" \
 - [ ] CORS misconfig (test `Origin: https://evil.com` + credentials)
 - [ ] S3/cloud buckets
 - [ ] GraphQL introspection enabled
-- [ ] Spring actuators (`/actuator/env`, `/actuator/heapdump`)
+- [ ] Spring actuators (`/actuator/env`, `/actuator/heapdump`) — for full framework debug surface + triggering techniques → web2-vuln-classes "Error Disclosure / Debug Endpoints"
 - [ ] Firebase open read (`https://TARGET.firebaseio.com/.json`)
 
 ## Technology Fingerprinting
@@ -372,6 +372,8 @@ curl -s "https://hackerone.com/graphql" \
 | Response: `wp-json`/`wp-content` | WordPress |
 | Response: `{"errors":[{"message":` | GraphQL |
 | Header: `X-Powered-By: Next.js` | Next.js |
+
+> **After any stack is identified:** immediately check its debug surface — probe the framework-specific paths from web2-vuln-classes "Error Disclosure / Debug Endpoints", then grep all 4xx/5xx response bodies for the framework regex patterns there before moving to Phase 3.
 
 ## Framework Quick Wins
 
@@ -481,6 +483,8 @@ HIGHEST PRIORITY (crown jewel x easiest entry):
 ## Interesting Leads (not confirmed bugs yet)
 - [14:22] /api/v2/invoices/{id} -- no auth check visible in source, testing...
 
+> **Before closing any 4xx/5xx:** grep the response body for the 8 framework trace patterns in web2-vuln-classes "Error Disclosure / Debug Endpoints". A 502 body containing a Node.js stack trace is not a dead end — it is a chain entry point.
+
 ## Dead Ends (don't revisit)
 - /admin -> IP restricted, confirmed by trying 15+ bypass headers
 
@@ -501,6 +505,7 @@ HIGHEST PRIORITY (crown jewel x easiest entry):
 - **api/api-v2**: Enumerate with kiterunner, check older unprotected versions
 - **auth/sso**: OAuth misconfigs, open redirect in `redirect_uri`
 - **upload/cdn**: CORS, path traversal, stored XSS
+- **403/blocked sensitive paths** (`/.env 403`, `/.git 403`, `/admin 403`): pivot to "Error Disclosure / Debug Endpoints" triggering techniques — malformed input on adjacent API endpoints (`/api/user/abc`, `{"id": null}`, `?page=9999999999`) to elicit framework stack traces without needing direct path access.
 
 ## CVE-Seeded Audit Approach
 1. **Build a CVE eval set** -- collect 5-10 prior CVEs for the target codebase

--- a/skills/web2-recon/SKILL.md
+++ b/skills/web2-recon/SKILL.md
@@ -274,10 +274,10 @@ curl -sI https://target.com | grep -iE "server|x-powered-by|x-aspnet|x-runtime|x
 | Django | IDOR (ModelViewSet, no object perms) | SSTI (mark_safe) |
 | Flask | SSTI (render_template_string) | SSRF (requests lib) |
 | Laravel | Mass assignment ($fillable) | IDOR (Eloquent, no ownership) |
-| Express (Node.js) | Prototype pollution | Path traversal |
-| Spring Boot | Actuator endpoints (/actuator/env) | SSTI (Thymeleaf) |
+| Express (Node.js) | Prototype pollution | Path traversal + debug surface (`/_debug`, `/__debug__`) → web2-vuln-classes "Error Disclosure / Debug Endpoints" |
+| Spring Boot | Actuator endpoints → web2-vuln-classes "Error Disclosure / Debug Endpoints" for full surface | SSTI (Thymeleaf) |
 | ASP.NET | ViewState deserialization | Open redirect (ReturnUrl) |
-| Next.js | SSRF via Server Actions | Open redirect via redirect() |
+| Next.js | SSRF via Server Actions + `/_next/data/` / `/_next/static/chunks/` → web2-vuln-classes "Error Disclosure / Debug Endpoints" | Open redirect via redirect() |
 | GraphQL | Introspection → auth bypass on mutations | IDOR via node(id:) |
 | WordPress | Plugin SQLi | REST API auth bypass |
 

--- a/skills/web2-vuln-classes/SKILL.md
+++ b/skills/web2-vuln-classes/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: web2-vuln-classes
-description: Complete reference for 20 web2 bug classes with root causes, detection patterns, bypass tables, exploit techniques, and real paid examples. Covers IDOR, auth bypass, XSS, SSRF (11 IP bypass techniques), SQLi, business logic, race conditions, OAuth/OIDC, file upload (10 bypass techniques), GraphQL, LLM/AI (ASI01-ASI10 agentic framework), API misconfig (mass assignment, JWT attacks, prototype pollution, CORS), ATO taxonomy (9 paths), SSTI (Jinja2/Twig/Freemarker/ERB/Spring), subdomain takeover, cloud/infra misconfigs, HTTP smuggling (CL.TE/TE.CL/H2.CL), cache poisoning, MFA bypass (7 patterns), SAML attacks (XSW/comment injection/signature stripping). Use when hunting a specific vuln class or studying what makes bugs pay.
+description: Complete reference for 21 web2 bug classes with root causes, detection patterns, bypass tables, exploit techniques, and real paid examples. Covers IDOR, auth bypass, XSS, SSRF (11 IP bypass techniques), SQLi, business logic, race conditions, OAuth/OIDC, file upload (10 bypass techniques), GraphQL, LLM/AI (ASI01-ASI10 agentic framework), API misconfig (mass assignment, JWT attacks, prototype pollution, CORS), ATO taxonomy (9 paths), SSTI (Jinja2/Twig/Freemarker/ERB/Spring), subdomain takeover, cloud/infra misconfigs, HTTP smuggling (CL.TE/TE.CL/H2.CL), cache poisoning, MFA bypass (7 patterns), SAML attacks (XSW/comment injection/signature stripping), error disclosure / debug endpoints (stack trace regex per framework, chain templates). Use when hunting a specific vuln class or studying what makes bugs pay.
 ---
 
-# WEB2 BUG CLASSES — 18 Classes
+# WEB2 BUG CLASSES — 21 Classes
 
 Root cause, pattern, bypass table, chaining opportunity, real paid examples.
 
@@ -848,4 +848,81 @@ Sig stripping    = Critical (ATO any user)
 Comment injection = High (ATO admin)
 XXE in assertion = High (file read / SSRF)
 NameID manip     = Medium/High (depends on what NameID maps to)
+```
+
+---
+
+## 21. ERROR DISCLOSURE / DEBUG ENDPOINTS
+> Stack traces and framework debug surfaces — chain into secret extraction → ATO. Single bug-bounty/SKILL.md already lists `/actuator/env`, `/.env`, `/server-status`, Laravel `/horizon` / `/telescope`, WordPress `/wp-json/wp/v2/users`, etc. This section covers the **detection signatures** and **triggering techniques** that turn those paths into payable chains.
+
+### Framework Stack Trace Regex
+Grep response bodies (4xx and 5xx) for these — each implies a known exploitation playbook.
+
+```
+Django           Traceback \(most recent call last\)              → check DEBUG=True page → DB creds, SECRET_KEY → forge sessions
+Spring/Java      at \S+\(.*\.java:\d+\)|NestedServletException   → look for /actuator/* → /env → secrets / JWT key
+Symfony (PHP)    Whoops\\Run|\\\\Symfony\\\\.*\\\\Exception        → check /_profiler/ → request tokens → replay/auth bypass
+Rails            /app/controllers/|/gems/.*\.rb:\d+:in            → check dev mode → web-console RCE
+ASP.NET (YSOD)   \[\w+Exception:|Server Error in '.+' Application  → check trace.axd, elmah.axd → request replay
+PHP              (Warning|Fatal error|Notice):.*on line \d+        → path disclosure → LFI / config leak
+Node.js          Error: .*\n\s+at \S+ \(.*:\d+:\d+\)               → look for /__debug__/, source maps
+Go               goroutine \d+ \[running\]:|runtime/panic\.go      → expvar at /debug/vars, /debug/pprof
+```
+
+### Framework Debug Surfaces — Not Yet Listed Elsewhere
+> `/.env` / `/.env.local` / `/.env.production` / `/actuator/*` / `/server-status` / `/server-info` / `elmah.axd` / `trace.axd` / `/.git/config` / Laravel `/horizon` / `/telescope` / WordPress `/wp-json/wp/v2/users` — **already covered** in bug-bounty/SKILL.md and wordlists/sensitive-files.txt. Don't re-probe.
+
+```
+Symfony          /_profiler/             → list every request + tokens → replay user requests
+Symfony          /_profiler/phpinfo      → environment dump
+Django           /__debug__/             → django-debug-toolbar panels (SQL, settings)
+Django           /admin/                 → defaults to /admin/ if not renamed
+Next.js          /_next/data/            → SSR payload leak (server-rendered JSON exposed)
+Next.js          /_next/static/chunks/   → JS chunks with hardcoded secrets
+Go expvar        /debug/vars             → leaks memstats, cmdline, env vars
+Go pprof         /debug/pprof/           → goroutine stacks (memory layout, secrets in flight)
+Spring Boot      /actuator/heapdump      → full JVM heap → grep secrets out
+Spring Boot      /actuator/mappings      → endpoint list including hidden internal routes
+Spring Boot      /actuator/loggers       → modify log level to leak more data
+GraphQL          ?debug=1 / ?debug=true  → some servers expand errors with debug flag
+Java             /META-INF/MANIFEST.MF   → dependency versions → CVE chain
+```
+
+### Triggering Stack Traces (when no debug endpoint exposed)
+Inject malformed input on existing parameters — many apps still leak traces on unexpected types.
+
+```
+Numeric ID → string         /api/user/abc                       → ORM error with column names
+Numeric ID → negative       /api/user/-1                        → unhandled signed overflow
+Numeric ID → boundary       /api/user/9999999999999999999       → int overflow / type cast error
+JSON null where object      {"user": null}                      → NullPointerException
+JSON array where object     {"user": []}                        → ClassCastException
+Truncated/malformed JSON    {"user":                            → parser stack trace
+%00 in path                 /api/user/1%00.json                 → path normalisation difference
+Oversized page param        ?page=99999999                      → OOM or query timeout trace
+Wrong content-type          POST JSON as Content-Type: text/xml → XML parser dump
+Empty multipart boundary    Content-Type: multipart/form-data;  → Busboy / Undici stack trace
+Unicode normalisation       /api/user/admin​               → diff path between sanitiser and DB
+```
+
+### Chains That Pay
+```
+Stack trace -> framework version -> public CVE -> RCE             High–Critical
+/actuator/env -> spring.datasource.password -> DB access           Critical
+/actuator/env -> JWT signing key -> forge admin token              Critical (ATO)
+/actuator/heapdump -> grep secrets -> AWS access keys              Critical
+/_profiler/ -> capture victim session token -> account takeover    Critical
+/_next/data/ -> SSR-rendered API responses -> IDOR without auth    High
+DEBUG=True (Django) -> SECRET_KEY leak -> session forgery          Critical
+PHP path disclosure -> LFI parameter discovered earlier -> RCE     Critical
+Stack trace alone (no chain)                                       Low → likely N/A
+```
+
+### Triage
+```
+Secrets visible (DB creds, JWT key, API keys)        = Critical (chain to ATO/data)
+Framework version + public CVE matching              = High–Critical (verify with PoC)
+PII / internal IP / hostname in stack trace          = Medium (information disclosure)
+Path disclosure only (no secrets)                    = Low/Info (chain to LFI to upgrade)
+"Yellow page" / "Internal Server Error" generic      = N/A — no signal
 ```


### PR DESCRIPTION
## What this adds

A new section (Section 21) in `web2-vuln-classes/SKILL.md` covering **error disclosure and framework debug endpoint exploitation** — a class the existing 20 sections didn't explicitly cover, despite the plugin already probing several debug paths (`/actuator/env`, `/.env`, etc.) in scattered places.

### Section contents
- **8 framework stack-trace regex patterns** (Django/Spring/Symfony/Rails/ASP.NET/PHP/Node.js/Go) — grep on any 4xx/5xx response body
- **Debug surfaces not yet listed**: Symfony `/_profiler/`, Django `/__debug__/`, Next.js `/_next/data/` + `/_next/static/chunks/`, Go `/debug/vars` + `/debug/pprof`, additional Spring actuator endpoints (`heapdump`/`mappings`/`loggers`), GraphQL `?debug=1`, Java `/META-INF/MANIFEST.MF`
- **11 stack-trace triggering techniques** for when no debug endpoint is directly exposed (type juggling, malformed JSON, `%00`, oversized params, content-type mismatch, etc.)
- **Chain templates** in the same shape as the existing `security-arsenal/SKILL.md` line-1300 conditionally-valid table
- **Triage table** (Critical → N/A) consistent with the existing always-rejected list

### Workflow hooks
Cross-references added at four natural decision points so the new class actually fires during a hunt rather than sitting as static reference:

| Where | What |
|---|---|
| `web2-recon` stack→bug class table | Express/Spring Boot/Next.js rows point here for full surface |
| `bug-bounty` after tech fingerprinting | "Immediately check debug surface" prompt before Phase 3 |
| `bug-bounty` 4xx/5xx triage | "Grep response body for the 8 patterns before closing" |
| `bug-bounty` 403 dead-ends | Pivot to triggering techniques on adjacent API endpoints |

### Why this matters
Several real paths the plugin already lists (`/actuator/env`, `/horizon`, `/.env`) but doesn't tie to a coherent extraction → exploitation playbook. With the new section:
- `/actuator/env` → grep `spring.datasource.password` or JWT key → DB access / forge admin token (Critical)
- Symfony `/_profiler/` → capture victim session token → replay (Critical)
- Django `DEBUG=True` → extract `SECRET_KEY` → session forgery (Critical)
- Plain 502 with Node.js stack trace → framework version → public CVE → RCE chain (High–Critical)

### Non-changes
- No new commands
- No new skills
- No new tool scripts
- No external dependencies

### File-level changes
- `skills/web2-vuln-classes/SKILL.md` — +79 lines (new section, header count fix, frontmatter description extension)
- `skills/bug-bounty/SKILL.md` — +5 lines (workflow hooks at 4 sites)
- `skills/web2-recon/SKILL.md` — 3 rows extended in stack→bug class table
- `CLAUDE.md` — 1-character count update (18 → 21)