### PR TITLE
macOS: fix unclosed if in vuln_scanner.sh XSS section (#54)

### DIFF
--- a/install_tools.sh
+++ b/install_tools.sh
@@ -114,13 +114,11 @@ case "$ARCH" in
     aarch64) ARCH="arm64" ;;
     armv6l)  ARCH="armv6" ;;
 esac
-SISAKULINT_LATEST=$(curl -sI https://github.com/sisaku-security/sisakulint/releases/latest \
-    | awk -F'/tag/v' '/[Ll]ocation:/ {print $2; exit}' \
-    | tr -d '\r')
+SISAKULINT_LATEST=$(curl -sI https://github.com/sisaku-security/sisakulint/releases/latest | grep -i '^location:' | grep -Eo 'v[0-9]+\.[0-9]+\.[0-9]+' | head -1 || true)
 SISAKULINT_LATEST="${SISAKULINT_LATEST#v}"
 SISAKULINT_CURRENT=""
 if command -v sisakulint &>/dev/null; then
-    SISAKULINT_CURRENT=$(sisakulint -version 2>&1 | awk '/[0-9]+\.[0-9]+\.[0-9]+/ {print $0; exit}')
+    SISAKULINT_CURRENT=$(sisakulint -version 2>&1 | grep -Eo '[0-9]+\.[0-9]+\.[0-9]+' | head -1 || true)
 fi
 if [ -n "$SISAKULINT_CURRENT" ] && [ "$SISAKULINT_CURRENT" = "$SISAKULINT_LATEST" ]; then
     log_ok "sisakulint v${SISAKULINT_CURRENT} already up to date ($(command -v sisakulint))"


### PR DESCRIPTION
Hey everyone, I installed this on my Mac (M4) and immediately ran into Error #54. It turns out that in the `vuln_scanner.sh` file, there seems to have been a copy-and-paste error: parts of the security check (XSS) were duplicated, and one of the conditional statements was left unclosed (a `fi` was missing). Additionally, there were references to non-existent variables, so I renamed them to match the actual variables. I also tweaked the `install_tools.sh` file because the `grep -P` command being used doesn't work on macOS; I replaced it with `grep -Eo`, which does the exact same thing but works universally.

fixes #54