### PR TITLE
feat: standalone engine — run bughunter without any AI subscription

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v4.3.2 — AI Hunt Playbook (Jun 2026)
+
+### Added
+- AI-assisted hunt guidance in `skills/bb-methodology/SKILL.md` and `skills/bug-bounty/SKILL.md`: use the model for feature decomposition, sibling-endpoint diffing, role matrices, and chain planning, while keeping proof requirements anchored to live requests and cross-account deltas.
+- AI-assisted planning signals in `tools/mindmap.py` so generated hunt checklists now surface hypothesis expansion and validation-gate reminders alongside the traditional vuln-class checklist.
+
 ## v4.3.1 — Bug Fixes + Hardening (Jun 2026)
 
 ### Fixed

--- a/agents/report-writer.md
+++ b/agents/report-writer.md
@@ -2,7 +2,7 @@
 name: report-writer
 description: Bug bounty report writer. Generates professional H1/Bugcrowd/Intigriti/Immunefi reports. Impact-first writing, human tone, no theoretical language, CVSS 4.0 calculation included. Use after a finding has passed the 7-Question Gate and 4 validation gates. Never generates reports with "could potentially" language.
 tools: Read, Write, Bash
-model: claude-opus-4-6
+model: claude-opus-4-7
 ---
 
 # Report Writer Agent

--- a/brain.py
+++ b/brain.py
@@ -10,7 +10,7 @@ Provider selection (in order of precedence):
   2. Auto-detect: uses first provider whose API key / server is available
 
 API keys (env vars):
-  ANTHROPIC_API_KEY   — Claude (claude-opus-4-6, claude-sonnet-4-6, etc.)
+  ANTHROPIC_API_KEY   — Claude (claude-opus-4-7, claude-sonnet-4-6, etc.)
   OPENAI_API_KEY      — OpenAI (gpt-4o, o1, etc.)
   XAI_API_KEY         — Grok (grok-2-latest, grok-3-mini, etc.)
   OLLAMA_HOST         — Ollama base URL (default: http://localhost:11434)
@@ -246,7 +246,7 @@ class LLMClient:
             except Exception:
                 return []
         elif self.provider == "claude":
-            return ["claude-opus-4-6", "claude-sonnet-4-6", "claude-haiku-4-5-20251001"]
+            return ["claude-opus-4-7", "claude-sonnet-4-6", "claude-haiku-4-5-20251001"]
         elif self.provider == "openai":
             return ["gpt-4o", "gpt-4o-mini", "o1", "o3-mini"]
         elif self.provider == "grok":

--- a/brain.py
+++ b/brain.py
@@ -71,22 +71,31 @@ OLLAMA_HOST = os.environ.get("OLLAMA_HOST", "http://localhost:11434")
 
 class LLMClient:
     """
-    Unified chat interface for Ollama, Claude, OpenAI, and Grok.
+    Unified chat interface for Ollama, Groq, DeepSeek, Claude, OpenAI, and Grok.
 
     Usage:
         client = LLMClient()          # auto-detect provider
+        client = LLMClient("groq")    # force Groq (free tier)
         client = LLMClient("claude")  # force Claude API
         reply  = client.chat(model, system_prompt, user_prompt, max_tokens=2000)
+
+    Free providers:
+        ollama   — local, zero cost (default: http://localhost:11434)
+        groq     — cloud free tier, GROQ_API_KEY    (https://console.groq.com)
+        deepseek — very cheap,      DEEPSEEK_API_KEY (https://platform.deepseek.com)
     """
 
-    PROVIDER_PRIORITY = ["ollama", "claude", "openai", "grok"]
+    # Priority: free-local first, free-cloud second, paid last
+    PROVIDER_PRIORITY = ["ollama", "groq", "deepseek", "claude", "openai", "grok"]
 
     # Default models per provider
     DEFAULT_MODELS = {
-        "claude":  "claude-sonnet-4-6",
-        "openai":  "gpt-4o",
-        "grok":    "grok-2-latest",
-        "ollama":  None,  # resolved dynamically
+        "claude":   "claude-sonnet-4-6",
+        "openai":   "gpt-4o",
+        "grok":     "grok-2-latest",
+        "groq":     "llama-3.3-70b-versatile",
+        "deepseek": "deepseek-chat",
+        "ollama":   None,  # resolved dynamically
     }
 
     def __init__(self, provider: str | None = None):
@@ -103,9 +112,11 @@ class LLMClient:
 
     # Env var a provider's API key is read from; keyed for quick lookup.
     PROVIDER_KEY_ENV = {
-        "claude": "ANTHROPIC_API_KEY",
-        "openai": "OPENAI_API_KEY",
-        "grok":   "XAI_API_KEY",
+        "claude":   "ANTHROPIC_API_KEY",
+        "openai":   "OPENAI_API_KEY",
+        "grok":     "XAI_API_KEY",
+        "groq":     "GROQ_API_KEY",
+        "deepseek": "DEEPSEEK_API_KEY",
     }
 
     def _auto_detect(self) -> str:
@@ -164,9 +175,9 @@ class LLMClient:
             self._http = requests.Session()
             self._http.headers.update({"Authorization": f"Bearer {key}",
                                        "Content-Type": "application/json"})
-            self._openai_base = "https://api.openai.com/v1"
-            self.available    = True
-            self.description  = "OpenAI API"
+            self._api_base   = "https://api.openai.com/v1"
+            self.available   = True
+            self.description = "OpenAI API"
 
         elif provider == "grok":
             key = os.environ.get("XAI_API_KEY", "")
@@ -176,9 +187,33 @@ class LLMClient:
             self._http = requests.Session()
             self._http.headers.update({"Authorization": f"Bearer {key}",
                                        "Content-Type": "application/json"})
-            self._grok_base  = "https://api.x.ai/v1"
+            self._api_base   = "https://api.x.ai/v1"
             self.available   = True
             self.description = "Grok API (xAI)"
+
+        elif provider == "groq":
+            key = os.environ.get("GROQ_API_KEY", "")
+            if not key:
+                return
+            import requests
+            self._http = requests.Session()
+            self._http.headers.update({"Authorization": f"Bearer {key}",
+                                       "Content-Type": "application/json"})
+            self._api_base   = "https://api.groq.com/openai/v1"
+            self.available   = True
+            self.description = "Groq API (free tier — llama-3.3-70b)"
+
+        elif provider == "deepseek":
+            key = os.environ.get("DEEPSEEK_API_KEY", "")
+            if not key:
+                return
+            import requests
+            self._http = requests.Session()
+            self._http.headers.update({"Authorization": f"Bearer {key}",
+                                       "Content-Type": "application/json"})
+            self._api_base   = "https://api.deepseek.com/v1"
+            self.available   = True
+            self.description = "DeepSeek API (deepseek-chat / deepseek-reasoner)"
 
     def chat(self, model: str | None, system: str, user: str,
              max_tokens: int = 4000, temperature: float = 0.1) -> str:
@@ -190,7 +225,7 @@ class LLMClient:
                 return self._chat_ollama(model, system, user, max_tokens, temperature)
             elif self.provider == "claude":
                 return self._chat_claude(model, system, user, max_tokens, temperature)
-            elif self.provider in ("openai", "grok"):
+            elif self.provider in ("openai", "grok", "groq", "deepseek"):
                 return self._chat_openai_compat(model, system, user, max_tokens, temperature)
         except Exception as e:
             print(f"{YELLOW}[Brain/{self.provider}] chat error: {e}{NC}", flush=True)
@@ -228,7 +263,7 @@ class LLMClient:
 
     def _chat_openai_compat(self, model, system, user, max_tokens, temperature) -> str:
         import json as _json
-        base = self._grok_base if self.provider == "grok" else self._openai_base
+        base = self._api_base
         m    = model or self.DEFAULT_MODELS[self.provider]
         body = {"model": m, "max_tokens": max_tokens, "temperature": temperature,
                 "messages": [{"role": "system", "content": system},
@@ -251,6 +286,10 @@ class LLMClient:
             return ["gpt-4o", "gpt-4o-mini", "o1", "o3-mini"]
         elif self.provider == "grok":
             return ["grok-2-latest", "grok-3-mini", "grok-3"]
+        elif self.provider == "groq":
+            return ["llama-3.3-70b-versatile", "llama-3.1-8b-instant", "mixtral-8x7b-32768", "gemma2-9b-it"]
+        elif self.provider == "deepseek":
+            return ["deepseek-chat", "deepseek-reasoner"]
         return []
 
 # Model preference order — first available wins

--- a/engine.py
+++ b/engine.py
@@ -1,0 +1,662 @@
+#!/usr/bin/env python3
+"""
+engine.py — Standalone BugHunter CLI
+Works WITHOUT Claude Code or any AI subscription.
+
+Providers (auto-detected, first available wins):
+  FREE:  ollama   — local model, zero cost
+                    install: curl -fsSL https://ollama.ai/install.sh | sh
+                    then:    ollama pull qwen2.5:14b
+         groq     — cloud free tier (fast), set GROQ_API_KEY
+                    get key: https://console.groq.com
+         deepseek — very cheap cloud,       set DEEPSEEK_API_KEY
+                    get key: https://platform.deepseek.com
+  PAID:  claude   — set ANTHROPIC_API_KEY
+         openai   — set OPENAI_API_KEY
+         grok     — set XAI_API_KEY
+
+Usage:
+  ./engine.py setup                        one-time config wizard
+  ./engine.py recon  <target>              recon + AI surface analysis
+  ./engine.py hunt   <target>              full hunt pipeline
+  ./engine.py validate "<finding>"         7-Question Gate on a finding
+  ./engine.py report [--findings-dir DIR]  write submission-ready report
+  ./engine.py chain  [--findings-dir DIR]  build A->B->C exploit chain
+  ./engine.py triage "<finding>"           fast triage (pass/kill/downgrade)
+  ./engine.py chat                         interactive Q&A shell
+  ./engine.py models                       list available models
+  ./engine.py status                       show hunt status
+  ./engine.py providers                    show all providers + API key status
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+# ── Paths ──────────────────────────────────────────────────────────────────────
+HERE     = Path(__file__).resolve().parent  # resolve symlink first so /usr/local/bin/bughunter -> repo dir
+AGENTS   = HERE / "agents"
+TOOLS    = HERE / "tools"
+RECON    = HERE / "recon"
+FINDINGS = HERE / "findings"
+REPORTS  = HERE / "reports"
+CONFIG   = Path.home() / ".bughunter" / "config.json"
+
+# ── Colors ─────────────────────────────────────────────────────────────────────
+GREEN  = "\033[0;32m"
+CYAN   = "\033[0;36m"
+YELLOW = "\033[1;33m"
+RED    = "\033[0;31m"
+BOLD   = "\033[1m"
+DIM    = "\033[2m"
+NC     = "\033[0m"
+
+
+def ok(msg):   print(f"{GREEN}{BOLD}[+]{NC} {msg}")
+def info(msg): print(f"{CYAN}{BOLD}[*]{NC} {msg}")
+def warn(msg): print(f"{YELLOW}{BOLD}[!]{NC} {msg}")
+def err(msg):  print(f"{RED}{BOLD}[-]{NC} {msg}")
+
+
+def header(title: str):
+    width = max(len(title) + 4, 60)
+    print(f"\n{BOLD}{'═' * width}{NC}")
+    print(f"{BOLD}  {title}{NC}")
+    print(f"{BOLD}{'═' * width}{NC}\n")
+
+
+def load_config() -> dict:
+    if CONFIG.exists():
+        try:
+            return json.loads(CONFIG.read_text())
+        except Exception:
+            pass
+    return {}
+
+
+def save_config(cfg: dict):
+    CONFIG.parent.mkdir(parents=True, exist_ok=True)
+    CONFIG.write_text(json.dumps(cfg, indent=2))
+
+
+def load_agent_prompt(agent_name: str) -> str:
+    """Read agents/<name>.md, strip YAML frontmatter, return body as system prompt."""
+    md = AGENTS / f"{agent_name}.md"
+    if not md.exists():
+        return ""
+    text = md.read_text()
+    if text.startswith("---"):
+        end = text.find("---", 3)
+        if end != -1:
+            text = text[end + 3:].lstrip()
+    return text.strip()
+
+
+def _import_brain():
+    """Import Brain and LLMClient from brain.py."""
+    sys.path.insert(0, str(HERE))
+    try:
+        from brain import Brain, LLMClient  # noqa: PLC0415
+        return Brain, LLMClient
+    except ImportError as e:
+        err(f"Could not import brain.py: {e}")
+        sys.exit(1)
+
+
+def _get_client(provider: str | None = None):
+    """Return an LLMClient, applying saved config if no env override."""
+    _, LLMClient = _import_brain()
+    cfg = load_config()
+    if not provider and not os.environ.get("BRAIN_PROVIDER"):
+        provider = cfg.get("provider")
+    if provider:
+        os.environ["BRAIN_PROVIDER"] = provider
+    return LLMClient(provider)
+
+
+def _get_brain(provider: str | None = None):
+    """Return a Brain instance."""
+    Brain, _ = _import_brain()
+    cfg = load_config()
+    if not provider and not os.environ.get("BRAIN_PROVIDER"):
+        provider = cfg.get("provider")
+    if provider:
+        os.environ["BRAIN_PROVIDER"] = provider
+    return Brain()
+
+
+def _run_shell(cmd: str, cwd: str | None = None, timeout: int = 3600) -> tuple[bool, str]:
+    """Run a shell command with live output, return (success, combined_output)."""
+    try:
+        proc = subprocess.Popen(
+            cmd, shell=True, cwd=cwd or str(HERE),
+            stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True,
+        )
+        lines = []
+        for line in proc.stdout:
+            print(line, end="", flush=True)
+            lines.append(line)
+        proc.wait(timeout=timeout)
+        return proc.returncode == 0, "".join(lines)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+        return False, "timed out"
+    except Exception as e:
+        return False, str(e)
+
+
+# ── Commands ───────────────────────────────────────────────────────────────────
+
+def cmd_setup(args):
+    """Interactive setup wizard."""
+    header("BugHunter Setup")
+
+    providers = {
+        "1": ("ollama",   "Ollama  (local, FREE)       — needs ollama running locally"),
+        "2": ("groq",     "Groq    (cloud, FREE tier)  — needs GROQ_API_KEY"),
+        "3": ("deepseek", "DeepSeek (cloud, very cheap)— needs DEEPSEEK_API_KEY"),
+        "4": ("claude",   "Claude  (paid)              — needs ANTHROPIC_API_KEY"),
+        "5": ("openai",   "OpenAI  (paid)              — needs OPENAI_API_KEY"),
+        "6": ("grok",     "Grok/xAI (paid)             — needs XAI_API_KEY"),
+    }
+
+    print("Choose your AI backend:\n")
+    for k, (_, desc) in providers.items():
+        print(f"  {k}) {desc}")
+    print()
+
+    choice = input("Enter number [1]: ").strip() or "1"
+    provider = providers.get(choice, ("ollama", ""))[0]
+
+    cfg = load_config()
+    cfg["provider"] = provider
+
+    env_map = {
+        "groq":     "GROQ_API_KEY",
+        "deepseek": "DEEPSEEK_API_KEY",
+        "claude":   "ANTHROPIC_API_KEY",
+        "openai":   "OPENAI_API_KEY",
+        "grok":     "XAI_API_KEY",
+    }
+
+    if provider in env_map:
+        env_var = env_map[provider]
+        existing = os.environ.get(env_var, "")
+        print(f"\nEnter {env_var} (blank = keep existing): ", end="")
+        api_key = input().strip()
+        if api_key:
+            cfg[env_var] = api_key
+            os.environ[env_var] = api_key
+        elif existing:
+            info(f"Using existing {env_var} from environment")
+        else:
+            warn(f"No {env_var} set — provider may not work")
+
+    save_config(cfg)
+    ok(f"Config saved to {CONFIG}")
+
+    # Test connection
+    info("Testing connection...")
+    _, LLMClient = _import_brain()
+    if provider in env_map and cfg.get(env_map[provider]):
+        os.environ[env_map[provider]] = cfg[env_map[provider]]
+
+    client = LLMClient(provider)
+    if client.available:
+        ok(f"Connected: {client.description}")
+        reply = client.chat(None, "You are a helpful assistant.",
+                            "Reply with exactly: READY", max_tokens=10)
+        ok(f"Model responded: {reply.strip()}" if reply else "Connected (no reply — pull a model if using Ollama)")
+    else:
+        err(f"Provider '{provider}' not available")
+        if provider == "ollama":
+            print(f"\n  {YELLOW}Install Ollama:{NC}")
+            print("    curl -fsSL https://ollama.ai/install.sh | sh")
+            print("    ollama pull qwen2.5:14b")
+        elif provider in env_map:
+            print(f"\n  {YELLOW}Set API key:{NC}  export {env_map[provider]}=your_key_here")
+
+
+def cmd_providers(args):
+    """Show all providers and API key status."""
+    _, LLMClient = _import_brain()
+    cfg = load_config()
+    saved = cfg.get("provider", "")
+
+    env_map = {
+        "ollama":   None,
+        "groq":     "GROQ_API_KEY",
+        "deepseek": "DEEPSEEK_API_KEY",
+        "claude":   "ANTHROPIC_API_KEY",
+        "openai":   "OPENAI_API_KEY",
+        "grok":     "XAI_API_KEY",
+    }
+    tier = {
+        "ollama": "FREE (local)", "groq": "FREE tier",
+        "deepseek": "cheap",      "claude": "paid",
+        "openai": "paid",         "grok": "paid",
+    }
+
+    print(f"\n  {'PROVIDER':<12} {'TIER':<16} {'STATUS':<20} {'NOTE'}")
+    print(f"  {'─'*12} {'─'*16} {'─'*20} {'─'*30}")
+
+    for prov, env_var in env_map.items():
+        if env_var:
+            key_set = bool(os.environ.get(env_var) or cfg.get(env_var))
+            status  = f"{GREEN}key set{NC}" if key_set else f"{RED}no key{NC}"
+            note    = env_var if not key_set else ""
+        else:
+            try:
+                import urllib.request
+                urllib.request.urlopen("http://localhost:11434", timeout=1)
+                status = f"{GREEN}running{NC}"
+                note   = ""
+            except Exception:
+                status = f"{YELLOW}not running{NC}"
+                note   = "ollama serve"
+
+        marker = f" {BOLD}<- active{NC}" if prov == saved else ""
+        print(f"  {BOLD}{prov:<12}{NC} {tier[prov]:<16} {status:<30} {DIM}{note}{NC}{marker}")
+
+    print(f"\n  Config: {CONFIG}")
+    print(f"  Change: ./engine.py setup\n")
+
+
+def cmd_models(args):
+    """List available models for the active provider."""
+    cfg = load_config()
+    provider = getattr(args, "provider", None) or cfg.get("provider")
+    client = _get_client(provider)
+    if not client.available:
+        err(f"Provider '{client.provider}' not available. Run: ./engine.py setup")
+        return
+    models = client.list_models()
+    info(f"Provider: {client.description}")
+    if models:
+        for m in models:
+            print(f"  {GREEN}•{NC} {m}")
+    else:
+        warn("No models found")
+        if client.provider == "ollama":
+            print("  Pull a model: ollama pull qwen2.5:14b")
+
+
+def cmd_recon(args):
+    """Run recon pipeline then AI surface analysis."""
+    target = args.target
+    header(f"Recon: {target}")
+
+    script = TOOLS / "recon_engine.sh"
+    if script.exists():
+        info("Running recon pipeline...")
+        success, _ = _run_shell(f'bash "{script}" "{target}"')
+        if not success:
+            warn("Recon had issues — continuing with AI analysis")
+    else:
+        warn("recon_engine.sh not found — skipping to AI analysis")
+
+    recon_dir = RECON / target
+    info("Running AI surface analysis...")
+    brain = _get_brain()
+    result = brain.analyze_recon(str(recon_dir) if recon_dir.exists() else target)
+    if result:
+        print(f"\n{result}")
+    else:
+        warn("AI analysis returned no output — check provider with: ./engine.py providers")
+
+
+def cmd_hunt(args):
+    """Full hunt pipeline: recon + vuln scan + AI analysis."""
+    target = args.target
+    header(f"Hunt: {target}")
+
+    # Run recon
+    script = TOOLS / "recon_engine.sh"
+    if script.exists():
+        info("Phase 1: Recon...")
+        _run_shell(f'bash "{script}" "{target}"')
+
+    # Run vuln scan
+    vuln_script = TOOLS / "vuln_scanner.sh"
+    recon_dir = RECON / target
+    if vuln_script.exists() and recon_dir.exists():
+        info("Phase 2: Vuln scan...")
+        _run_shell(f'bash "{vuln_script}" "{recon_dir}"')
+
+    # AI analysis
+    info("Phase 3: AI analysis...")
+    brain = _get_brain()
+    findings_dir = FINDINGS / target
+    if findings_dir.exists():
+        brain.interpret_scan(str(findings_dir))
+    elif recon_dir.exists():
+        brain.analyze_recon(str(recon_dir))
+    else:
+        warn(f"No data for {target} — run recon first")
+
+
+def cmd_validate(args):
+    """Run 7-Question Gate on a finding description."""
+    finding = getattr(args, "finding", "") or ""
+    if not finding:
+        finding = _read_stdin_or_prompt("Paste your finding description (Ctrl+D when done):\n")
+
+    header("7-Question Gate")
+    info(f"Finding: {finding[:120]}{'...' if len(finding) > 120 else ''}")
+
+    brain = _get_brain()
+    decision, explanation = brain.triage_finding(finding)
+
+    print(f"\n{BOLD}{'─'*60}{NC}")
+    if decision.startswith("PASS"):
+        color = GREEN
+    elif "DOWNGRADE" in decision or "CHAIN" in decision:
+        color = YELLOW
+    else:
+        color = RED
+    print(f"{color}{BOLD}DECISION: {decision}{NC}")
+    if explanation:
+        print(f"\n{explanation}")
+    print(f"{BOLD}{'─'*60}{NC}\n")
+
+
+def cmd_triage(args):
+    """Alias for validate."""
+    cmd_validate(args)
+
+
+def cmd_report(args):
+    """Generate a submission-ready bug report."""
+    findings_dir = getattr(args, "findings_dir", "") or ""
+    if not findings_dir:
+        targets = sorted(FINDINGS.glob("*/")) if FINDINGS.exists() else []
+        if targets:
+            findings_dir = str(targets[-1])
+            info(f"Using findings dir: {findings_dir}")
+        else:
+            err("No findings dir found. Use: ./engine.py report --findings-dir findings/<target>")
+            sys.exit(1)
+
+    header("Report Writer")
+    brain = _get_brain()
+
+    recon_dir = ""
+    target_name = Path(findings_dir).name
+    candidate = RECON / target_name
+    if candidate.exists():
+        recon_dir = str(candidate)
+
+    result = brain.write_report(findings_dir, recon_dir)
+    if result:
+        print(f"\n{result}")
+        ok("Report written.")
+    else:
+        warn("No report output — ensure findings directory has data")
+
+
+def cmd_chain(args):
+    """Build A->B->C exploit chain."""
+    findings_dir = getattr(args, "findings_dir", "") or ""
+    finding = getattr(args, "finding", "") or ""
+
+    if not findings_dir:
+        targets = sorted(FINDINGS.glob("*/")) if FINDINGS.exists() else []
+        if targets:
+            findings_dir = str(targets[-1])
+
+    header("Chain Builder")
+
+    if findings_dir and Path(findings_dir).exists():
+        brain = _get_brain()
+        result = brain.build_chains(findings_dir)
+        if result:
+            print(f"\n{result}")
+            return
+
+    # Fallback: agent-prompt mode with finding description
+    if not finding:
+        finding = _read_stdin_or_prompt("Describe the bug to chain from:\n")
+
+    system = load_agent_prompt("chain-builder")
+    client = _get_client()
+    if not client.available:
+        err("No AI provider available. Run: ./engine.py setup")
+        sys.exit(1)
+    sys.path.insert(0, str(HERE))
+    from brain import BRAIN_SYSTEM  # noqa: PLC0415
+    result = client.chat(None, system or BRAIN_SYSTEM,
+                         f"Build an exploit chain starting from this bug:\n\n{finding}")
+    if result:
+        print(f"\n{result}")
+
+
+def cmd_chat(args):
+    """Interactive Q&A shell."""
+    header("BugHunter Chat")
+    client = _get_client()
+    if not client.available:
+        err("No AI provider available. Run: ./engine.py setup")
+        sys.exit(1)
+
+    sys.path.insert(0, str(HERE))
+    from brain import BRAIN_SYSTEM  # noqa: PLC0415
+
+    ok(f"Connected: {client.description}")
+    print(f"{DIM}Type 'exit' or Ctrl+C to quit{NC}\n")
+
+    history: list[dict] = []
+    while True:
+        try:
+            user_input = input(f"{CYAN}{BOLD}you>{NC} ").strip()
+        except (KeyboardInterrupt, EOFError):
+            print()
+            break
+
+        if user_input.lower() in ("exit", "quit", "q"):
+            break
+        if not user_input:
+            continue
+
+        ctx_parts = []
+        for turn in history[-4:]:
+            ctx_parts.append(f"[you] {turn['user']}")
+            ctx_parts.append(f"[assistant] {turn['assistant']}")
+        prompt = ("\n".join(ctx_parts) + "\n\n" if ctx_parts else "") + f"[you] {user_input}"
+
+        reply = client.chat(None, BRAIN_SYSTEM, prompt, max_tokens=2000)
+        if reply:
+            print(f"\n{reply}\n")
+            history.append({"user": user_input, "assistant": reply})
+        else:
+            warn("No response — check provider with: ./engine.py providers")
+
+
+def cmd_status(args):
+    """Show pipeline status."""
+    header("Hunt Status")
+
+    recon_targets = sorted(RECON.glob("*/")) if RECON.exists() else []
+    print(f"  {BOLD}Recon completed:{NC} {len(recon_targets)} target(s)")
+    for t in recon_targets[:5]:
+        subs = t / "subdomains" / "all.txt"
+        live = t / "live" / "urls.txt"
+        n_subs = sum(1 for _ in subs.open()) if subs.exists() else 0
+        n_live = sum(1 for _ in live.open()) if live.exists() else 0
+        print(f"    {GREEN}•{NC} {t.name}: {n_subs} subdomains, {n_live} live hosts")
+
+    finding_targets = sorted(FINDINGS.glob("*/")) if FINDINGS.exists() else []
+    print(f"\n  {BOLD}Findings:{NC} {len(finding_targets)} target(s)")
+    for t in finding_targets[:5]:
+        summary = t / "summary.txt"
+        if summary.exists():
+            m = re.search(r"TOTAL FINDINGS:\s*(\d+)", summary.read_text())
+            count = m.group(1) if m else "?"
+            print(f"    {GREEN}•{NC} {t.name}: {count} findings")
+
+    report_targets = sorted(REPORTS.glob("*/")) if REPORTS.exists() else []
+    print(f"\n  {BOLD}Reports:{NC} {len(report_targets)} target(s)")
+    for t in report_targets[:5]:
+        print(f"    {GREEN}•{NC} {t.name}: {len(list(t.glob('*.md')))} report(s)")
+
+    print(f"\n  {BOLD}Provider:{NC} ", end="")
+    client = _get_client()
+    if client.available:
+        print(f"{GREEN}{client.description}{NC}")
+    else:
+        print(f"{RED}not configured{NC} — run: ./engine.py setup")
+    print()
+
+
+# ── Utility ────────────────────────────────────────────────────────────────────
+
+def _read_stdin_or_prompt(prompt_text: str) -> str:
+    if not sys.stdin.isatty():
+        return sys.stdin.read().strip()
+    print(prompt_text, end="", flush=True)
+    lines = []
+    try:
+        while True:
+            lines.append(input())
+    except EOFError:
+        pass
+    return "\n".join(lines).strip()
+
+
+def _print_banner():
+    G1  = "\033[1;32m"   # bright green
+    G2  = "\033[0;32m"   # normal green
+    G3  = "\033[2;32m"   # dim green
+    W   = "\033[1;37m"   # white bold
+    LINES = [
+        ("  ██████╗ ██╗   ██╗ ██████╗ ",                         G1),
+        ("  ██╔══██╗██║   ██║██╔════╝ ",                         G2),
+        ("  ██████╔╝██║   ██║██║  ███╗",                         G1),
+        ("  ██╔══██╗██║   ██║██║   ██║",                         G2),
+        ("  ██████╔╝╚██████╔╝╚██████╔╝",                         G1),
+        ("  ╚═════╝  ╚═════╝  ╚═════╝ ",                         G3),
+        ("  ██╗  ██╗██╗   ██╗███╗   ██╗████████╗███████╗██████╗ ", G1),
+        ("  ██║  ██║██║   ██║████╗  ██║╚══██╔══╝██╔════╝██╔══██╗", G2),
+        ("  ███████║██║   ██║██╔██╗ ██║   ██║   █████╗  ██████╔╝", G1),
+        ("  ██╔══██║██║   ██║██║╚██╗██║   ██║   ██╔══╝  ██╔══██╗", G2),
+        ("  ██║  ██║╚██████╔╝██║ ╚████║   ██║   ███████╗██║  ██║",  G1),
+        ("  ╚═╝  ╚═╝ ╚═════╝ ╚═╝  ╚═══╝   ╚═╝   ╚══════╝╚═╝  ╚═╝", G3),
+    ]
+    print()
+    for line, color in LINES:
+        print(f"{color}{line}{NC}")
+    print()
+    print(f"  {G3}by {W}shuvonsec{NC}  {G3}·{NC}  {G2}shuvonsec.me{NC}  {G3}·{NC}  {G1}bughunter.fun{NC}")
+    print(f"  {G3}github.com/{G2}shuvonsec{G3}/claude-bug-bounty{NC}")
+    print(f"  {G3}free · open · no subscription required{NC}")
+    print()
+
+
+# ── CLI entry point ────────────────────────────────────────────────────────────
+
+def main():
+    parser = argparse.ArgumentParser(
+        prog="engine.py",
+        description="Standalone BugHunter Engine — works without Claude Code",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=textwrap.dedent("""
+        Free setup (zero subscription):
+          curl -fsSL https://ollama.ai/install.sh | sh
+          ollama pull qwen2.5:14b
+          ./engine.py setup
+          ./engine.py recon target.com
+
+        Free cloud (Groq — very fast):
+          export GROQ_API_KEY=gsk_...
+          ./engine.py recon target.com
+
+        Switch providers anytime:
+          ./engine.py setup
+        """),
+    )
+    parser.add_argument("--provider", "-p",
+                        help="Force provider: ollama / groq / deepseek / claude / openai / grok")
+    parser.add_argument("--no-banner", action="store_true", help="Suppress banner")
+
+    sub = parser.add_subparsers(dest="command", metavar="COMMAND")
+
+    sub.add_parser("setup",     help="One-time config wizard")
+    sub.add_parser("providers", help="Show all providers + API key status")
+    sub.add_parser("models",    help="List available models for active provider")
+    sub.add_parser("status",    help="Show hunt pipeline status")
+    sub.add_parser("chat",      help="Interactive AI shell")
+
+    p_recon = sub.add_parser("recon", help="Recon + AI surface analysis")
+    p_recon.add_argument("target", help="Target domain or IP")
+
+    p_hunt = sub.add_parser("hunt", help="Full hunt pipeline")
+    p_hunt.add_argument("target", help="Target domain or IP")
+    p_hunt.add_argument("--quick", action="store_true", help="Quick mode (fewer checks)")
+
+    p_val = sub.add_parser("validate", help="7-Question Gate on a finding")
+    p_val.add_argument("finding", nargs="?", default="", help="Finding description (or pipe via stdin)")
+
+    p_triage = sub.add_parser("triage", help="Fast triage (alias for validate)")
+    p_triage.add_argument("finding", nargs="?", default="", help="Finding description")
+
+    p_rep = sub.add_parser("report", help="Write submission-ready bug report")
+    p_rep.add_argument("--findings-dir", default="", help="Path to findings/<target> directory")
+
+    p_chain = sub.add_parser("chain", help="Build A->B->C exploit chain")
+    p_chain.add_argument("--findings-dir", default="", help="Path to findings/<target> directory")
+    p_chain.add_argument("finding", nargs="?", default="", help="Bug A description (or pipe via stdin)")
+
+    args = parser.parse_args()
+
+    # Apply provider override
+    if getattr(args, "provider", None):
+        os.environ["BRAIN_PROVIDER"] = args.provider
+
+    # Load saved API keys into environment before any LLM call
+    cfg = load_config()
+    for env_var in ("GROQ_API_KEY", "DEEPSEEK_API_KEY", "ANTHROPIC_API_KEY",
+                    "OPENAI_API_KEY", "XAI_API_KEY"):
+        if not os.environ.get(env_var) and cfg.get(env_var):
+            os.environ[env_var] = cfg[env_var]
+
+    quiet_cmds = {"status", "providers", "models", None}
+    if not getattr(args, "no_banner", False) and args.command not in quiet_cmds:
+        _print_banner()
+
+    dispatch = {
+        "setup":     cmd_setup,
+        "providers": cmd_providers,
+        "models":    cmd_models,
+        "recon":     cmd_recon,
+        "hunt":      cmd_hunt,
+        "validate":  cmd_validate,
+        "triage":    cmd_triage,
+        "report":    cmd_report,
+        "chain":     cmd_chain,
+        "chat":      cmd_chat,
+        "status":    cmd_status,
+    }
+
+    if not args.command:
+        parser.print_help()
+        print(f"\n{YELLOW}Quick start:{NC}")
+        print("  ./engine.py setup              # configure your AI provider")
+        print("  ./engine.py providers          # see what's available")
+        print("  ./engine.py recon target.com   # start hunting")
+        return
+
+    fn = dispatch.get(args.command)
+    if fn:
+        fn(args)
+    else:
+        parser.print_help()
+
+
+if __name__ == "__main__":
+    main()

--- a/install.sh
+++ b/install.sh
@@ -9,22 +9,28 @@ SETUP_BURP="ask"
 
 usage() {
     cat <<'EOF'
-Usage: ./install.sh [--agent claude|opencode|pi|codex|agents|all] [--global|--project]
+Usage: ./install.sh [--agent claude|opencode|pi|codex|agents|standalone|all] [--global|--project]
 
 Defaults:
-  ./install.sh                 Install for Claude Code globally
+  ./install.sh                    Install for Claude Code globally
+
+Standalone (no subscription needed):
+  ./install.sh --agent standalone Install 'bughunter' system command
+                                  After install, type from anywhere:
+                                    bughunter setup
+                                    bughunter recon target.com
 
 Examples:
-  ./install.sh --agent opencode Install OpenCode skills + commands globally
-  ./install.sh --agent pi       Install Pi skills + prompt templates globally
-  ./install.sh --agent agents   Install shared Agent Skills to ~/.agents/skills
-  ./install.sh --agent all      Install every supported global target
+  ./install.sh --agent opencode   Install OpenCode skills + commands globally
+  ./install.sh --agent pi         Install Pi skills + prompt templates globally
+  ./install.sh --agent agents     Install shared Agent Skills to ~/.agents/skills
+  ./install.sh --agent all        Install every supported global target
   ./install.sh --agent opencode --project
-                               Install into .opencode/ for this repo
+                                  Install into .opencode/ for this repo
 
 Options:
-  --no-burp                    Skip Claude Code Burp MCP setup prompt
-  --yes-burp                   Print Claude Code Burp MCP setup instructions
+  --no-burp                       Skip Claude Code Burp MCP setup prompt
+  --yes-burp                      Print Claude Code Burp MCP setup instructions
 EOF
 }
 
@@ -214,7 +220,92 @@ install_agents() {
     echo "OpenCode and Pi both discover .agents/skills or ~/.agents/skills."
 }
 
+install_standalone() {
+    echo ""
+    echo "════════════════════════════════════════════════════"
+    echo "  BugHunter Standalone Engine (no subscription)"
+    echo "════════════════════════════════════════════════════"
+    echo ""
+
+    REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    ENGINE="$REPO_DIR/engine.py"
+
+    # Make engine.py executable
+    chmod +x "$ENGINE"
+
+    # ── Install bughunter system command ──────────────────────────────────────
+    # Try /usr/local/bin first (needs sudo on some systems), fall back to ~/.local/bin
+    BIN_DIR=""
+    if [ -w /usr/local/bin ]; then
+        BIN_DIR="/usr/local/bin"
+    elif sudo -n true 2>/dev/null; then
+        BIN_DIR="/usr/local/bin"
+        SUDO="sudo"
+    else
+        BIN_DIR="$HOME/.local/bin"
+        mkdir -p "$BIN_DIR"
+    fi
+
+    SUDO="${SUDO:-}"
+    TARGET="$BIN_DIR/bughunter"
+
+    # Remove old symlink/file if exists
+    $SUDO rm -f "$TARGET" 2>/dev/null || true
+    $SUDO ln -sf "$ENGINE" "$TARGET"
+
+    if [ -f "$TARGET" ] || [ -L "$TARGET" ]; then
+        echo "[+] Installed: bughunter -> $TARGET"
+    else
+        echo "[!] Could not install to $BIN_DIR — try: sudo ./install.sh --agent standalone"
+        echo "    Or add this to ~/.bashrc / ~/.zshrc:"
+        echo "    alias bughunter='python3 $ENGINE'"
+    fi
+
+    # ── Check PATH ────────────────────────────────────────────────────────────
+    if ! echo "$PATH" | tr ':' '\n' | grep -q "$BIN_DIR"; then
+        echo ""
+        echo "[!] $BIN_DIR is not in your PATH. Add it:"
+        if echo "$SHELL" | grep -q zsh; then
+            echo "    echo 'export PATH=\"$BIN_DIR:\$PATH\"' >> ~/.zshrc && source ~/.zshrc"
+        else
+            echo "    echo 'export PATH=\"$BIN_DIR:\$PATH\"' >> ~/.bashrc && source ~/.bashrc"
+        fi
+    fi
+
+    # ── Optional: Ollama ──────────────────────────────────────────────────────
+    echo ""
+    if ! command -v ollama &>/dev/null; then
+        echo "Ollama not found. For free local AI:"
+        echo "  curl -fsSL https://ollama.ai/install.sh | sh"
+        echo "  ollama pull qwen2.5:14b"
+    else
+        echo "[+] Ollama detected: $(ollama --version 2>/dev/null || echo 'installed')"
+    fi
+
+    # ── Optional Python deps ──────────────────────────────────────────────────
+    if command -v pip3 &>/dev/null; then
+        echo "Installing optional Python deps (requests, ollama)..."
+        pip3 install --quiet requests ollama 2>/dev/null || true
+    fi
+
+    echo ""
+    echo "════════════════════════════════════════════════════"
+    echo "  Done! Type from anywhere:"
+    echo ""
+    echo "    bughunter setup"
+    echo "    bughunter recon target.com"
+    echo "    bughunter hunt  target.com"
+    echo "    bughunter validate \"<finding>\""
+    echo "    bughunter chat"
+    echo "════════════════════════════════════════════════════"
+    echo ""
+}
+
 case "$AGENT" in
+    standalone|engine)
+        SETUP_BURP="no"
+        install_standalone
+        ;;
     claude)
         install_claude
         ;;

--- a/skills/bb-methodology/SKILL.md
+++ b/skills/bb-methodology/SKILL.md
@@ -78,6 +78,25 @@ Before touching any tool:
 - **Intuition engineering**: Log why something "feels wrong." Verify later. Update mental DB.
 - **Unknown management**: Can't understand something? Add to "investigate later" list. Just-in-Time Learning.
 
+#### 5. AI-Assisted Thinking (model as a second analyst)
+
+Use AI to expand hypotheses, not to declare verdicts. The model is a fast adversarial planner; the browser, proxy, and live requests are the proof layer.
+
+- **Decompose the feature**: ask for actors, assets, entry points, state transitions, and trust boundaries.
+- **Generate sibling paths**: versioned endpoints, mobile routes, legacy APIs, alternate roles, and admin-only variants.
+- **Build a role matrix**: anonymous, user A, user B, stale session, fresh session, admin, service account.
+- **Ask for dev shortcuts**: "Where would a tired developer skip a check or reuse a helper?"
+- **Ask for chains**: "If this bug is real, what bug B and C sit next to it?"
+- **Turn ideas into requests**: every AI suggestion must become a single reproducible HTTP experiment.
+- **Kill weak signals fast**: if AI cannot point to a concrete request, response diff, or cross-account delta, the idea stays as a hypothesis.
+
+High-signal prompts:
+- "Given this endpoint and feature, list the 10 most likely trust-boundary mistakes."
+- "What sibling endpoints, methods, or roles should I test next?"
+- "Which bug class would a rushed implementation likely miss here?"
+- "What does the smallest proof request look like?"
+- "What would make this become a real report instead of a scanner hit?"
+
 ### Amateur vs Pro: 7-Phase Comparison
 
 | Phase | Amateur | Pro |

--- a/skills/bug-bounty/SKILL.md
+++ b/skills/bug-bounty/SKILL.md
@@ -297,6 +297,24 @@ ffuf -w subs.txt -u https://FUZZ.target.com -ac
 ## AI-Assisted Tools
 - **strix** (usestrix.com) -- open-source AI scanner for automated initial sweep
 
+## AI-ASSISTED HUNT LOOP
+
+Use AI as a second analyst, not as the authority.
+
+1. **Decompose the feature** — ask for actors, assets, trust boundaries, hidden state, and sibling endpoints.
+2. **Generate the test matrix** — anonymous vs authenticated, user A vs user B, fresh vs stale session, web vs mobile, legacy vs current API.
+3. **Ask for developer shortcuts** — where a rushed implementation would likely skip a check, reuse a helper, or trust a client-side value.
+4. **Ask for adjacent bugs** — if A is real, what B and C are likely nearby?
+5. **Convert every idea into one request** — the output must be a concrete HTTP experiment or it stays speculation.
+6. **Proof first, report later** — AI can rank hypotheses, but only live request/response diffs and cross-account deltas can promote a finding.
+
+Good prompt shapes:
+- "Given this feature, list the 10 most likely trust-boundary mistakes."
+- "What sibling routes, methods, or roles should I test next?"
+- "What would a tired developer probably reuse here?"
+- "What is the smallest reproducible request that could prove impact?"
+- "What evidence would downgrade this to N/A?"
+
 ---
 
 # PHASE 1: RECON

--- a/tools/mindmap.py
+++ b/tools/mindmap.py
@@ -64,6 +64,15 @@ API_CHECKS = [
     ("LOW",  "API key in URL — logs exposure of credentials", "manual review"),
 ]
 
+AI_CHECKS = [
+    ("HIGH", "AI-assisted feature decomposition — actors, assets, trust boundaries, state changes", "second analyst"),
+    ("HIGH", "AI-assisted sibling diffing — versioned routes, alternate roles, mobile vs web, legacy paths", "second analyst"),
+    ("HIGH", "AI-assisted chain planning — turn weak signals into A→B→C impact hypotheses", "second analyst"),
+    ("MED",  "AI-assisted dev shortcut search — where a rushed helper or reused check might fail", "second analyst"),
+    ("MED",  "AI-assisted test matrix — anonymous vs auth, user A vs user B, fresh vs stale session", "second analyst"),
+    ("LOW",  "AI-generated ideas still need live proof — requests, diffs, and cross-account evidence", "validation gate"),
+]
+
 MOBILE_CHECKS = [
     ("HIGH", "WebView JS injection — `addJavascriptInterface` without origin check", "bug-bounty-hunt → SDK/Client-Library section"),
     ("HIGH", "Deep link hijack — register same URI scheme, steal OAuth codes", "manual + AndroidManifest review"),
@@ -127,6 +136,8 @@ def build_mermaid(target: str, target_type: str, techs: list[str]) -> str:
 
     if target_type == "website":
         lines += [
+            "      AI-assisted planning",
+            '        "Feature decomposition / sibling diffing"',
             "      Auth flow",
             '        "IDOR / ATO"',
             '        "CSRF"',
@@ -147,6 +158,8 @@ def build_mermaid(target: str, target_type: str, techs: list[str]) -> str:
         ]
     elif target_type == "opensrc":
         lines += [
+            "      AI-assisted planning",
+            '        "Feature decomposition / sibling diffing"',
             "      Hash/token comparisons",
             '        "Timing side-channel"',
             "      JWT handling",
@@ -164,6 +177,8 @@ def build_mermaid(target: str, target_type: str, techs: list[str]) -> str:
         ]
     elif target_type == "api":
         lines += [
+            "      AI-assisted planning",
+            '        "Feature decomposition / sibling diffing"',
             "      All endpoints",
             '        "Auth bypass on undocumented routes"',
             "      ID parameters",
@@ -179,6 +194,8 @@ def build_mermaid(target: str, target_type: str, techs: list[str]) -> str:
         ]
     elif target_type == "mobile":
         lines += [
+            "      AI-assisted planning",
+            '        "Feature decomposition / sibling diffing"',
             "      WebView",
             '        "JS bridge injection"',
             "      Deep links",
@@ -217,6 +234,7 @@ def build_checklist(target_type: str, techs: list[str]) -> str:
     checks = list(type_map.get(target_type, WEBSITE_CHECKS))
 
     # Add tech-specific checks
+    checks.extend(AI_CHECKS)
     for tech in techs:
         tech_lower = tech.lower().strip()
         if tech_lower in TECH_CHECKS:
@@ -328,6 +346,7 @@ def main():
         "mobile":  MOBILE_CHECKS,
     }
     checks = list(type_map.get(target_type, WEBSITE_CHECKS))
+    checks.extend(AI_CHECKS)
     for tech in techs:
         if tech.lower() in TECH_CHECKS:
             checks.extend(TECH_CHECKS[tech.lower()])


### PR DESCRIPTION
## Summary

Adds **engine.py**, a fully standalone CLI that lets anyone run BugHunter from the terminal **without Claude Code or any paid AI subscription**. After a one-time install, users type `bughunter` from any directory.

This opens the toolkit to students, new hunters, and anyone who can't or doesn't want to pay for an AI subscription — while keeping full Claude/OpenAI/Grok support for those who do.

## What's new

### `engine.py` — Standalone BugHunter CLI
- New entry point: `bughunter setup / recon / hunt / validate / report / chain / chat / status / providers / models`
- Auto-detects the best available AI provider (free-first order)
- Full green hacker-vibe ASCII banner with author info + links
- Reuses `agents/*.md` as system prompts — same hunting logic, no Claude Code needed
- Config persisted to `~/.bughunter/config.json`

### Free AI providers (zero subscription)
- **Ollama** — local models, fully offline (`ollama pull qwen2.5:14b`)
- **Groq** — cloud free tier, `llama-3.3-70b-versatile` (set `GROQ_API_KEY`)
- **DeepSeek** — cheap cloud reasoning (set `DEEPSEEK_API_KEY`)
- **Claude / OpenAI / Grok** — still supported for paid users; switch anytime with `bughunter setup`

### `brain.py` — added Groq + DeepSeek providers
- Provider priority: `ollama → groq → deepseek → claude → openai → grok`
- Unified `_api_base` field across all OpenAI-compatible providers
- Also bumps `claude-opus-4-6` → `claude-opus-4-7` in model list + docstring

### `install.sh` — new standalone install mode
- `./install.sh --agent standalone` creates a system-wide `bughunter` command
- Symlinks `engine.py` into `/usr/local/bin` or `~/.local/bin` automatically
- PATH check + shell-specific setup hints

## Quick start (zero cost)

```bash
curl -fsSL https://ollama.ai/install.sh | sh
ollama pull qwen2.5:14b
./install.sh --agent standalone
bughunter setup
bughunter recon target.com
```

## How it helps

People who want AI like Claude can still plug in their own API key and switch models freely. People who can't, get a free local/cloud path. One toolkit, zero lock-in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)