### PR TITLE
fix(uninstall): remove installed agents on uninstall

### DIFF
--- a/uninstall.sh
+++ b/uninstall.sh
@@ -63,6 +63,7 @@ if [[ "$MODE" == "claude" ]] || [[ "$MODE" == "both" ]]; then
 
     INSTALL_DIR="${HOME}/.claude/skills"
     COMMANDS_DIR="${HOME}/.claude/commands"
+    AGENTS_DIR="${HOME}/.claude/agents"
 
     # Remove installed skills
     for skill_dir in "${REPO_ROOT}/skills/"*/; do
@@ -76,8 +77,14 @@ if [[ "$MODE" == "claude" ]] || [[ "$MODE" == "both" ]]; then
         remove_file "${COMMANDS_DIR}/${cmd_name}"
     done
 
+    # Remove installed agents
+    for agent_file in "${REPO_ROOT}/agents/"*.md; do
+        agent_name=$(basename "$agent_file")
+        remove_file "${AGENTS_DIR}/${agent_name}"
+    done
+
     # Clean up empty parent dirs (only if we created them and they're now empty)
-    for dir in "${INSTALL_DIR}" "${COMMANDS_DIR}"; do
+    for dir in "${INSTALL_DIR}" "${COMMANDS_DIR}" "${AGENTS_DIR}"; do
         if [ -d "$dir" ] && [ -z "$(ls -A "$dir")" ]; then
             rmdir "$dir"
             echo "  (removed empty dir): $dir"
@@ -98,6 +105,7 @@ if [[ "$MODE" == "opencode" ]] || [[ "$MODE" == "both" ]]; then
 
     SKILLS_DIR="${REPO_ROOT}/.opencode/skills"
     COMMANDS_DIR="${REPO_ROOT}/.opencode/commands"
+    AGENTS_DIR="${REPO_ROOT}/.opencode/agents"
 
     # Remove symlinked skills
     for skill_dir in "${REPO_ROOT}/skills/"*/; do
@@ -111,8 +119,14 @@ if [[ "$MODE" == "opencode" ]] || [[ "$MODE" == "both" ]]; then
         remove_file "${COMMANDS_DIR}/${cmd_name}"
     done
 
+    # Remove copied agents
+    for agent_file in "${REPO_ROOT}/agents/"*.md; do
+        agent_name=$(basename "$agent_file")
+        remove_file "${AGENTS_DIR}/${agent_name}"
+    done
+
     # Clean up empty parent dirs
-    for dir in "${SKILLS_DIR}" "${COMMANDS_DIR}"; do
+    for dir in "${SKILLS_DIR}" "${COMMANDS_DIR}" "${AGENTS_DIR}"; do
         if [ -d "$dir" ] && [ -z "$(ls -A "$dir")" ]; then
             rmdir "$dir"
             echo "  (removed empty dir): $dir"


### PR DESCRIPTION
## Problem

`install.sh` installs agent definitions into the agents directory in both modes:

- **claude**: `copy_files "agents/*.md" "$root/agents"` → `~/.claude/agents/`
- **opencode**: `copy_files "agents/*.md" "$root/agents"`

But `uninstall.sh` only iterates `skills/` and `commands/`, so the 9 installed agent files (`autopilot.md`, `chain-builder.md`, `credential-hunter.md`, `recon-agent.md`, `recon-ranker.md`, `report-writer.md`, `token-auditor.md`, `validator.md`, `web3-auditor.md`) are left orphaned after a clean uninstall.

## Fix

Add an agent-removal loop to both the `claude` and `opencode` blocks, mirroring the existing skill/command loops, and include the agents directory in the empty-parent-dir cleanup.

## Testing

- `bash -n uninstall.sh` passes.
- Verified against a real install: before this change, `~/.claude/agents/` retained all 9 files after `./uninstall.sh`; the loop removes them by name (only the files this repo installs, so user-owned agents are untouched).

No change to the skill/command removal behavior.