### PR TITLE
feat(arsenal): add compatibility for kimchi and freebuff

### DIFF
--- a/tools/external_arsenal.sh
+++ b/tools/external_arsenal.sh
@@ -104,6 +104,9 @@ ARSENAL_TOOLS=(
   "qsreplace|filter|GOBIN=\$HOME/go/bin go install github.com/tomnomnom/qsreplace@latest|github.com/tomnomnom/qsreplace"
   "anew|filter|GOBIN=\$HOME/go/bin go install github.com/tomnomnom/anew@latest|github.com/tomnomnom/anew"
   "interactsh-client|oob|GOBIN=\$HOME/go/bin go install github.com/projectdiscovery/interactsh/cmd/interactsh-client@latest|github.com/projectdiscovery/interactsh"
+  # ── AI Coding Assistants ────────────────────────────────────────────────
+  "kimchi|ai|curl -fsSL https://kimchi.dev/install.sh -o kimchi_install.sh && sh kimchi_install.sh|kimchi.dev"
+  "freebuff|ai|npm install -g freebuff|freebuff.com"
 )
 
 # `_have <tool>` — true when the binary is on PATH. Source this file from other


### PR DESCRIPTION
This pull request adds support for detecting kimchi and freebuff as active AI/agentic engines in the external tool registry (tools/external_arsenal.sh). This allows recon and scanning workflows to check for these local assistants correctly.