### PR TITLE
[codex] fix OpenCode agent tools frontmatter schema

### DIFF
--- a/agents/autopilot.md
+++ b/agents/autopilot.md
@@ -1,7 +1,12 @@
 ---
 name: autopilot
 description: Autonomous hunt loop agent. Runs the full hunt cycle (scope → recon → rank → hunt → validate → report) without stopping for approval at each step. Configurable checkpoints (--paranoid, --normal, --yolo). Uses scope_checker.py for deterministic scope safety on every outbound request. Logs all requests to audit.jsonl. Use when you want systematic coverage of a target's attack surface.
-tools: Bash, Read, Write, Glob, Grep
+tools:
+  bash: true
+  read: true
+  write: true
+  glob: true
+  grep: true
 model: claude-sonnet-4-6
 ---
 

--- a/agents/chain-builder.md
+++ b/agents/chain-builder.md
@@ -1,7 +1,10 @@
 ---
 name: chain-builder
 description: Exploit chain builder. Given bug A, identifies B and C candidates to chain for higher severity and payout. Knows all major chain patterns — IDOR→auth bypass, SSRF→cloud metadata, XSS→ATO, open redirect→OAuth theft, S3→bundle→secret→OAuth, prompt injection→IDOR, subdomain takeover→OAuth redirect. Use when you have a low/medium finding that needs a chain to be submittable.
-tools: Read, Bash, WebFetch
+tools:
+  read: true
+  bash: true
+  webfetch: true
 model: claude-sonnet-4-6
 ---
 

--- a/agents/credential-hunter.md
+++ b/agents/credential-hunter.md
@@ -1,7 +1,11 @@
 ---
 name: credential-hunter
 description: Autonomous credential-attack pipeline runner. Chains /wordlist-gen + /osint-employees + /breach-check (data-prep stages, runs without prompts) then HARD STOPS before /spray (live attack stage requires human go/no-go). Designed so the user only types the target once instead of orchestrating four separate commands. Reports back with stats at each stage and a structured go/no-go decision package before spray.
-tools: Bash, Read, Write, AskUserQuestion
+tools:
+  bash: true
+  read: true
+  write: true
+  question: true
 model: claude-sonnet-4-6
 ---
 

--- a/agents/recon-agent.md
+++ b/agents/recon-agent.md
@@ -1,7 +1,12 @@
 ---
 name: recon-agent
 description: Subdomain enumeration and live host discovery specialist. Runs Chaos API (ProjectDiscovery), subfinder, assetfinder, dnsx, httpx, katana, waybackurls, gau, and nuclei. Produces prioritized attack surface for a target. Use when starting recon on a new target domain.
-tools: Bash, Read, Write, Glob, Grep
+tools:
+  bash: true
+  read: true
+  write: true
+  glob: true
+  grep: true
 model: claude-haiku-4-5-20251001
 ---
 

--- a/agents/recon-ranker.md
+++ b/agents/recon-ranker.md
@@ -1,7 +1,11 @@
 ---
 name: recon-ranker
 description: Attack surface ranking agent. Takes recon output and hunt memory, produces a prioritized attack plan. Ranks by IDOR likelihood, API surface, tech stack match with past successes, feature age, and nuclei findings. Use after recon to decide what to test first.
-tools: Read, Bash, Glob, Grep
+tools:
+  read: true
+  bash: true
+  glob: true
+  grep: true
 model: claude-haiku-4-5-20251001
 ---
 

--- a/agents/report-writer.md
+++ b/agents/report-writer.md
@@ -1,7 +1,10 @@
 ---
 name: report-writer
 description: Bug bounty report writer. Generates professional H1/Bugcrowd/Intigriti/Immunefi reports. Impact-first writing, human tone, no theoretical language, CVSS 4.0 calculation included. Use after a finding has passed the 7-Question Gate and 4 validation gates. Never generates reports with "could potentially" language.
-tools: Read, Write, Bash
+tools:
+  read: true
+  write: true
+  bash: true
 model: claude-opus-4-7
 ---
 

--- a/agents/token-auditor.md
+++ b/agents/token-auditor.md
@@ -1,7 +1,11 @@
 ---
 name: token-auditor
 description: Fast meme coin and token security auditor. Checks 8 token-specific bug classes (hidden mint, honeypot, fee manipulation, LP lock bypass, bonding curve exploits, authority retention, fake renounce, sandwich/MEV amplification). Runs token_scanner.py for automated red flag detection. Covers EVM (Solidity) and Solana (Rust/Anchor) tokens. Use for any token audit, rug pull assessment, or pre-investment security check.
-tools: Read, Bash, Glob, Grep
+tools:
+  read: true
+  bash: true
+  glob: true
+  grep: true
 model: claude-sonnet-4-6
 ---
 

--- a/agents/validator.md
+++ b/agents/validator.md
@@ -1,7 +1,10 @@
 ---
 name: validator
 description: Finding validator. Runs the 7-Question Gate and 4-gate checklist on a described finding. Kills weak/theoretical findings fast before report writing. Prevents N/A submissions. Use before writing any report — describe the finding and this agent decides PASS, KILL, or DOWNGRADE with explanation.
-tools: Read, Bash, WebFetch
+tools:
+  read: true
+  bash: true
+  webfetch: true
 model: claude-sonnet-4-6
 ---
 

--- a/agents/web3-auditor.md
+++ b/agents/web3-auditor.md
@@ -1,7 +1,11 @@
 ---
 name: web3-auditor
 description: Smart contract security auditor. Checks 10 bug classes in order of frequency (accounting desync 28%, access control 19%, incomplete path 17%, off-by-one 22% of Highs, oracle errors, ERC4626 attacks, reentrancy, flash loan oracle manipulation, signature replay, proxy/upgrade issues). Applies pre-dive kill signals first. Use for any Solidity/Rust contract audit or to check if a DeFi target is worth hunting.
-tools: Read, Bash, Glob, Grep
+tools:
+  read: true
+  bash: true
+  glob: true
+  grep: true
 model: claude-sonnet-4-6
 ---
 

--- a/tests/test_opencode_agent_frontmatter.py
+++ b/tests/test_opencode_agent_frontmatter.py
@@ -1,0 +1,47 @@
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+AGENTS_DIR = REPO_ROOT / "agents"
+
+
+def _frontmatter_lines(path: Path) -> list[str]:
+    lines = path.read_text(encoding="utf-8").splitlines()
+    assert lines[0] == "---"
+    end = lines.index("---", 1)
+    return lines[1:end]
+
+
+def _tools_mapping(path: Path) -> dict[str, bool]:
+    lines = _frontmatter_lines(path)
+    tools_index = lines.index("tools:")
+    tools = {}
+
+    for line in lines[tools_index + 1 :]:
+        if not line.startswith("  "):
+            break
+        name, value = line.strip().split(":", 1)
+        assert value.strip() in {"true", "false"}
+        tools[name] = value.strip() == "true"
+
+    return tools
+
+
+def test_agent_tools_use_opencode_mapping_schema():
+    agent_files = [
+        path
+        for path in sorted(AGENTS_DIR.glob("*.md"))
+        if path.read_text(encoding="utf-8").startswith("---\n")
+    ]
+    assert agent_files
+
+    for path in agent_files:
+        tools = _tools_mapping(path)
+        assert tools, f"{path.name} must define tools as a mapping"
+        assert all(name == name.lower() for name in tools)
+
+
+def test_credential_hunter_uses_opencode_question_tool():
+    tools = _tools_mapping(AGENTS_DIR / "credential-hunter.md")
+    assert tools["question"] is True
+    assert "askuserquestion" not in tools


### PR DESCRIPTION
## Summary

- Replace comma-separated `tools` strings in all agent frontmatter with the boolean mapping required by current OpenCode releases.
- Map Claude Code's `AskUserQuestion` capability to OpenCode's `question` tool for `credential-hunter`.
- Add regression tests that enforce mapping-shaped, lowercase OpenCode tool definitions.

## Type

- [x] Bug fix
- [ ] New feature / scanner module
- [ ] Methodology improvement
- [ ] Documentation
- [ ] False positive reduction

## Root Cause

Current OpenCode validates agent `tools` as an object. The existing scalar values such as `tools: Read, Bash, Glob, Grep` cause configuration bootstrap to fail with `SchemaError: Expected object | undefined`, preventing provider, agent, and config startup requests from completing.

## Test Plan

- [x] Focused regression test passes: `uv run --with pytest --with requests pytest -q tests/test_opencode_agent_frontmatter.py` (`2 passed`).
- [ ] Full `pytest tests/` passes locally. Current result: `371 passed, 1 failed`; the unrelated existing failure is `tests/test_brain_auto_detect.py::test_openai_and_grok_keys_both_front_nothing_available`, whose expected provider order omits the currently probed Groq and DeepSeek providers.
- [x] No hardcoded targets, API keys, or real domain names.
- [x] New functionality has regression coverage.

## Related Issue

No matching open issue or pull request was found before implementation.