### PR TITLE
perf: speed up nuclei, httpx, subfinder, katana, dalfox, gau, arjun

### DIFF
--- a/brain.py
+++ b/brain.py
@@ -334,6 +334,9 @@ class LLMClient:
         return ""
 
     def _chat_ollama(self, model, system, user, max_tokens, temperature) -> str:
+        if not model:
+            available = self.list_models()
+            model = available[0] if available else "qwen2.5:14b"
         resp = self._ollama.chat(
             model=model,
             messages=[{"role": "system", "content": system},

--- a/tools/cve_scan.sh
+++ b/tools/cve_scan.sh
@@ -69,6 +69,9 @@ log "nuclei CVE sweep on $TARGET ${YEAR:+(year=$YEAR)}..."
 nuclei "${INPUT_ARG[@]}" \
   "${TEMPLATE_FILTER[@]}" \
   -severity high,critical \
+  -rl "${NUC_RATE_LIMIT:-300}" \
+  -c "${NUC_CONCURRENCY:-50}" \
+  -bs "${NUC_BULK_SIZE:-50}" \
   -silent -stats \
   -jsonl -o "$OUT_DIR/nuclei_cve.jsonl" 2>/dev/null || true
 

--- a/tools/param_discovery.sh
+++ b/tools/param_discovery.sh
@@ -46,9 +46,9 @@ print_banner "Parameter Discovery · Hidden HTTP params" "${URL:-$LIST}" \
 if _have arjun; then
   log "arjun discovery..."
   if [ -n "$URL" ]; then
-    arjun -u "$URL" -oJ "$OUT_DIR/arjun.json" 2>/dev/null || true
+    arjun -u "$URL" -t 10 -oJ "$OUT_DIR/arjun.json" 2>/dev/null || true
   else
-    arjun -i "$LIST" -oJ "$OUT_DIR/arjun.json" 2>/dev/null || true
+    arjun -i "$LIST" -t 10 -oJ "$OUT_DIR/arjun.json" 2>/dev/null || true
   fi
   if [ -s "$OUT_DIR/arjun.json" ]; then
     python3 -c "

--- a/tools/recon_engine.sh
+++ b/tools/recon_engine.sh
@@ -42,8 +42,8 @@ fi
 
 RECON_DIR="${RECON_OUT_DIR:-$BASE_DIR/recon/$TARGET}"
 TIMESTAMP=$(date +%Y%m%d_%H%M%S)
-THREADS=20
-RATE_LIMIT=50  # requests per second
+THREADS="${BB_THREADS:-50}"
+RATE_LIMIT="${BB_RATE_LIMIT:-150}"  # requests per second
 
 # shellcheck source=tools/banner.sh
 . "$(dirname "$0")/banner.sh"
@@ -234,7 +234,7 @@ else
 # Subfinder (passive, fast)
 if command -v subfinder &>/dev/null; then
     log_step "Running subfinder..."
-    subfinder -d "$TARGET" -silent -all -o "$RECON_DIR/subdomains/subfinder.txt" 2>/dev/null || true
+    subfinder -d "$TARGET" -silent -all -t 50 -o "$RECON_DIR/subdomains/subfinder.txt" 2>/dev/null || true
     log_done "subfinder: $(wc -l < "$RECON_DIR/subdomains/subfinder.txt" 2>/dev/null || echo 0) subdomains"
 else
     log_warn "subfinder not installed — skipping"
@@ -357,7 +357,7 @@ log_info "Phase 4: URL Collection"
 # GAU - Get All URLs (wayback, commoncrawl, otx, urlscan)
 if command -v gau &>/dev/null; then
     log_step "Running gau (historical URLs)..."
-    echo "$TARGET" | gau --threads 5 --o "$RECON_DIR/urls/gau.txt" 2>/dev/null || \
+    echo "$TARGET" | gau --threads 20 --o "$RECON_DIR/urls/gau.txt" 2>/dev/null || \
     echo "$TARGET" | gau > "$RECON_DIR/urls/gau.txt" 2>/dev/null || true
     log_done "gau: $(wc -l < "$RECON_DIR/urls/gau.txt" 2>/dev/null || echo 0) URLs"
 else
@@ -375,6 +375,7 @@ if command -v katana &>/dev/null && [ -s "$RECON_DIR/live/urls.txt" ]; then
     timeout 300 katana \
         -list "$RECON_DIR/urls/katana_targets.txt" \
         -d 3 -jc -kf all -silent \
+        -c 50 -p 20 \
         ${BB_AUTH_ARGS[@]+"${BB_AUTH_ARGS[@]}"} \
         -o "$RECON_DIR/urls/katana.txt" 2>/dev/null || true
     log_done "katana: $(wc -l < "$RECON_DIR/urls/katana.txt" 2>/dev/null || echo 0) URLs"
@@ -613,9 +614,16 @@ if command -v nuclei &>/dev/null && [ -s "$RECON_DIR/live/urls.txt" ]; then
     head -"$NUC_LIMIT" "$RECON_DIR/live/urls.txt" > "$NUCLEI_OUT/targets.txt"
     log_step "nuclei on $(wc -l < "$NUCLEI_OUT/targets.txt" | tr -d ' ') hosts (severity=$NUC_SEV, timeout=${NUC_TIMEOUT}s)..."
 
+    NUC_RL="${NUC_RATE_LIMIT:-300}"
+    NUC_C="${NUC_CONCURRENCY:-50}"
+    NUC_BS="${NUC_BULK_SIZE:-50}"
+
     timeout "$NUC_TIMEOUT" nuclei \
         -l "$NUCLEI_OUT/targets.txt" \
         -severity "$NUC_SEV" \
+        -rl "$NUC_RL" \
+        -c "$NUC_C" \
+        -bs "$NUC_BS" \
         -silent \
         -stats \
         ${BB_AUTH_ARGS[@]+"${BB_AUTH_ARGS[@]}"} \

--- a/tools/vuln_scanner.sh
+++ b/tools/vuln_scanner.sh
@@ -318,8 +318,7 @@ PYEOF
             timeout "$DAL_MAX_TIME" dalfox pipe \
             --silence \
             --no-color \
-            --worker 5 \
-            --delay 100 \
+            --worker 20 \
             --timeout 10 \
             ${BB_AUTH_ARGS[@]+"${BB_AUTH_ARGS[@]}"} \
             --output "$FINDINGS_DIR/xss/dalfox_results.txt" 2>/dev/null || true


### PR DESCRIPTION
## Summary

- **nuclei** (`recon_engine.sh` + `cve_scan.sh`): `-rl 300 -c 50 -bs 50` — was running on defaults (150 req/s / 25 concurrent / 25 bulk), now 2× faster; all three values are env-overridable (`NUC_RATE_LIMIT`, `NUC_CONCURRENCY`, `NUC_BULK_SIZE`)
- **httpx + ffuf** (`recon_engine.sh`): `THREADS` 20→**50**, `RATE_LIMIT` 50→**150 req/s**; both are env-overridable via `BB_THREADS` / `BB_RATE_LIMIT`
- **subfinder**: added `-t 50` (was default 10 goroutines)
- **katana**: added `-c 50 -p 20` (concurrency per host + parallel hosts; was no flags)
- **gau**: `--threads 5` → `--threads 20`
- **dalfox** (`vuln_scanner.sh`): `--worker 5 --delay 100` → `--worker 20`, `--delay` removed — the 100ms delay was capping XSS scan to ~50 req/s total
- **arjun** (`param_discovery.sh`): added `-t 10` (was default 3 threads)
- **brain.py**: fall back to first available ollama model when none specified

## Override without editing

```bash
BB_THREADS=100 BB_RATE_LIMIT=300 ./tools/recon_engine.sh target.com
NUC_RATE_LIMIT=500 NUC_CONCURRENCY=100 ./tools/recon_engine.sh target.com
```

## Test plan

- [ ] Run `./tools/recon_engine.sh <test-target> --quick` and confirm faster httpx + nuclei phases
- [ ] Run `./tools/vuln_scanner.sh` and confirm dalfox completes faster with no `--delay` regression
- [ ] Run `./tools/param_discovery.sh <url>` and confirm arjun uses 10 threads
- [ ] Run `./tools/cve_scan.sh <url>` and confirm nuclei flags are applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)