### PR TITLE
Add eol_check.py — lifecycle / End-of-Life intel tool (endoflife.date, pure-stdlib)

### DIFF
--- a/tests/test_eol_check.py
+++ b/tests/test_eol_check.py
@@ -1,0 +1,593 @@
+"""Regression tests for tools/eol_check.py (lifecycle / EOL intel).
+
+Network is mocked (fetch_product_cycles), so CI needs no outbound access and the
+tests are deterministic. Dates are built relative to "today" so no test can rot.
+
+The central contract these tests lock down: a lifecycle checker must prefer
+"indeterminate" over guessing. It must NEVER classify a detected install from an
+unrelated release, and must not overstate a standard EOL as "no security fixes"
+when extended/ESM support still applies.
+"""
+import io
+import os
+import sys
+from datetime import date, timedelta
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "tools"))
+
+import eol_check  # noqa: E402
+
+# Capture the real fetch BEFORE the autouse fixture monkeypatches it, so the
+# fetch-path test can exercise the genuine function (not the network mock).
+_REAL_FETCH = eol_check.fetch_product_cycles
+
+
+def _d(days_from_today):
+    return (date.today() + timedelta(days=days_from_today)).strftime("%Y-%m-%d")
+
+
+# Canned endoflife.date /api/<slug>.json payloads (relative dates → never rot).
+def _php_cycles():
+    return [
+        {"cycle": "8.3", "support": _d(+400), "eol": _d(+900), "latest": "8.3.10"},
+        {"cycle": "8.2", "support": _d(-30), "eol": _d(+300), "latest": "8.2.20"},   # security-only
+        {"cycle": "7.4", "support": _d(-1200), "eol": _d(-900), "latest": "7.4.33"},  # long past EOL
+    ]
+
+
+@pytest.fixture(autouse=True)
+def _no_network(monkeypatch):
+    """Default: unknown slug returns empty. Individual tests override."""
+    monkeypatch.setattr(eol_check, "fetch_product_cycles", lambda slug, refresh=False: [])
+
+
+def _use(monkeypatch, cycles):
+    monkeypatch.setattr(eol_check, "fetch_product_cycles", lambda slug, refresh=False: cycles)
+
+
+# ── No-fabrication contract (grok P0-1 / agy / codex #1) ─────────────────────
+def test_past_eol_matched_is_confirmed(monkeypatch):
+    _use(monkeypatch, _php_cycles())
+    r = eol_check.lookup("php", "7.4")
+    assert r["status"] == "expired"
+    assert r["tag"] == eol_check.TAG_CONFIRMED
+    assert r["matched_cycle"] == "7.4"
+
+
+def test_supported_matched_is_informational(monkeypatch):
+    _use(monkeypatch, _php_cycles())
+    r = eol_check.lookup("php", "8.3")
+    assert r["status"] == "supported"
+    assert r["tag"] == eol_check.TAG_INFORMATIONAL
+
+
+def test_unmatched_version_is_unknown_not_guessed(monkeypatch):
+    # Version supplied but not present → MUST be unknown, never classified from
+    # another cycle. This is the core anti-fabrication guarantee.
+    _use(monkeypatch, _php_cycles())
+    r = eol_check.lookup("php", "5.6")            # 5.6 not in the payload
+    assert r["status"] == "unknown"
+    assert r["matched_cycle"] is None
+    assert r["tag"] == eol_check.TAG_INFORMATIONAL
+
+
+def test_garbage_version_is_unknown(monkeypatch):
+    _use(monkeypatch, _php_cycles())
+    r = eol_check.lookup("php", "garbage")
+    assert r["status"] == "unknown"
+    assert r["tag"] == eol_check.TAG_INFORMATIONAL
+
+
+def test_no_version_never_confirmed_even_if_newest_expired(monkeypatch):
+    # If the newest cycle is itself EOL, a version-less lookup must still NOT
+    # emit a CONFIRMED finding — we don't know what is deployed.
+    _use(monkeypatch, [{"cycle": "1.0", "eol": True, "latest": "1.0.0"}])
+    r = eol_check.lookup("nginx")                 # no version
+    assert r["status"] == "unknown"
+    assert r["tag"] != eol_check.TAG_CONFIRMED
+
+
+# ── Version normalization / matching (grok P0-2 / codex #2) ──────────────────
+def test_v_prefixed_version_matches(monkeypatch):
+    _use(monkeypatch, _php_cycles())
+    r = eol_check.lookup("php", "v7.4")           # banner-style 'v' prefix
+    assert r["status"] == "expired"
+    assert r["matched_cycle"] == "7.4"
+
+
+def test_banner_form_version_matches(monkeypatch):
+    _use(monkeypatch, _php_cycles())
+    r = eol_check.lookup("php", "7.4.33")         # patch-level version
+    assert r["matched_cycle"] == "7.4"
+
+
+def test_longest_prefix_wins(monkeypatch):
+    _use(monkeypatch, [
+        {"cycle": "8", "eol": False, "latest": "8.9"},
+        {"cycle": "8.1", "eol": _d(-500), "latest": "8.1.7"},
+    ])
+    r = eol_check.lookup("tomcat", "8.1.5")
+    assert r["matched_cycle"] == "8.1"            # not the bare "8"
+
+
+def test_boundary_prevents_8_3_matching_8_30(monkeypatch):
+    # "8.30" must NOT be treated as cycle "8.3".
+    _use(monkeypatch, [{"cycle": "8.3", "eol": _d(-500), "latest": "8.3.9"}])
+    r = eol_check.lookup("php", "8.30")
+    assert r["status"] == "unknown"
+    assert r["matched_cycle"] is None
+
+
+def test_mixed_identifier_cycles_do_not_cross_match(monkeypatch):
+    # AWS-Lambda-style cycles: 'nodejs18.x' must never match 'ruby4.0'.
+    _use(monkeypatch, [
+        {"cycle": "ruby4.0", "eol": _d(-100), "latest": "ruby4.0"},
+        {"cycle": "nodejs18.x", "eol": _d(-100), "latest": "nodejs18.x"},
+    ])
+    r = eol_check.lookup("aws lambda", "nodejs18.x")
+    assert r["matched_cycle"] in (None, "nodejs18.x")
+    if r["matched_cycle"] == "nodejs18.x":
+        assert r["status"] == "expired"           # matched the RIGHT one
+    else:
+        assert r["status"] == "unknown"           # or honestly unknown
+
+
+def test_eol_boolean_true_is_expired(monkeypatch):
+    _use(monkeypatch, [{"cycle": "5.6", "eol": True, "latest": "5.6.40"}])
+    r = eol_check.lookup("php", "5.6")
+    assert r["status"] == "expired"
+    assert r["tag"] == eol_check.TAG_CONFIRMED
+
+
+# ── Extended / active support semantics (codex #4 / #5) ──────────────────────
+def test_extended_support_softens_confirmed(monkeypatch):
+    # Standard EOL passed but ESM/extended support is still in the future →
+    # must NOT be a bare CONFIRMED "no security fixes".
+    _use(monkeypatch, [{"cycle": "20.04", "support": _d(-800),
+                        "eol": _d(-30), "extendedSupport": _d(+1000),
+                        "latest": "20.04.6"}])
+    r = eol_check.lookup("ubuntu", "20.04")
+    assert r["status"] == "extended"
+    assert r["tag"] == eol_check.TAG_POSSIBLE      # not CONFIRMED
+
+
+def test_extended_support_in_past_is_still_expired(monkeypatch):
+    _use(monkeypatch, [{"cycle": "16.04", "support": _d(-2000),
+                        "eol": _d(-1000), "extendedSupport": _d(-100),
+                        "latest": "16.04.7"}])
+    r = eol_check.lookup("ubuntu", "16.04")
+    assert r["status"] == "expired"
+    assert r["tag"] == eol_check.TAG_CONFIRMED
+
+
+def test_active_support_ended_is_security_only(monkeypatch):
+    # eol still in the future but active support ended → security-maintenance.
+    _use(monkeypatch, _php_cycles())
+    r = eol_check.lookup("php", "8.2")
+    assert r["status"] == "security_only"
+    assert r["tag"] == eol_check.TAG_INFORMATIONAL
+
+
+def test_eol_within_window_is_soon(monkeypatch):
+    _use(monkeypatch, [{"cycle": "1.0", "support": _d(-10), "eol": _d(+30),
+                        "latest": "1.0.9"}])
+    r = eol_check.lookup("nginx", "1.0")
+    assert r["status"] == "soon"
+    assert r["tag"] == eol_check.TAG_POSSIBLE
+    assert 0 <= r["days_to_eol"] <= eol_check.EOL_SOON_DAYS
+    # active support already ended → that secondary fact must not be silently
+    # dropped just because 'soon' is the primary severity.
+    assert "support" in r["note"].lower()
+
+
+def test_eol_yesterday_reports_one_day(monkeypatch):
+    # Date-based math (codex #13): EOL yesterday → 1 day ago, not 2.
+    _use(monkeypatch, [{"cycle": "1.0", "eol": _d(-1), "latest": "1.0.0"}])
+    r = eol_check.lookup("nginx", "1.0")
+    assert r["status"] == "expired"
+    assert r["days_to_eol"] == -1
+
+
+# ── Slug map correctness (grok P0-5 / codex #3, primary-source verified) ─────
+def test_all_product_slugs_are_slug_shaped():
+    # Guards against typos / accidental bad slugs on future edits.
+    import re
+    pat = re.compile(r"^[a-z0-9][a-z0-9-]*$")
+    bad = [v for v in set(eol_check.PRODUCT_MAP.values()) if not pat.match(v)]
+    assert bad == [], f"non-slug-shaped values: {bad}"
+
+
+def test_fixed_slugs_are_corrected():
+    # openshift was live-verified as renamed; iis/powershell have no single product.
+    assert eol_check._resolve_slug("openshift") == "red-hat-openshift"
+    assert eol_check._resolve_slug("iis") is None          # dropped, not fabricated
+    assert eol_check._resolve_slug("powershell") is None   # ambiguous 5.1 vs 7.x
+
+
+def test_generic_java_is_unresolved_vendor_specific_resolves():
+    # A bare 'java'/'openjdk' fingerprint cannot be placed on one vendor's
+    # timeline (Oracle vs Temurin vs Corretto diverge) → unresolved, not guessed.
+    assert eol_check._resolve_slug("java") is None
+    assert eol_check._resolve_slug("openjdk") is None
+    # Vendor-specific fingerprints DO resolve.
+    assert eol_check._resolve_slug("temurin") == "eclipse-temurin"
+    assert eol_check._resolve_slug("amazon corretto") == "amazon-corretto"
+    assert eol_check._resolve_slug("azul zulu") == "azul-zulu"
+    assert eol_check._resolve_slug("oracle jdk") == "oracle-jdk"
+
+
+def test_tolerant_slug_resolution():
+    assert eol_check._resolve_slug("Node.JS") == "nodejs"
+    assert eol_check._resolve_slug("spring-boot") == "spring-boot"
+
+
+def test_unknown_product_is_no_data():
+    r = eol_check.lookup("definitelynotarealproduct")
+    assert r["slug"] is None
+    assert r["status"] == "no_data"
+    assert r["tag"] == eol_check.TAG_INFORMATIONAL
+
+
+# ── Robustness / never-crash (grok P1-6 / agy #3 / codex #6-7) ───────────────
+def test_network_outage_degrades_to_unknown(monkeypatch):
+    monkeypatch.setattr(eol_check, "fetch_product_cycles", lambda slug, refresh=False: None)
+    r = eol_check.lookup("nginx", "1.18")
+    assert r["status"] == "unknown"
+
+
+def test_non_list_payload_does_not_crash(monkeypatch):
+    # A dict / string top-level (rate-limit body, schema change) must not crash.
+    for bad in ({"message": "rate limited"}, "oops", [None, "x", 5]):
+        monkeypatch.setattr(eol_check, "fetch_product_cycles",
+                            lambda slug, refresh=False, _b=bad: _b)
+        r = eol_check.lookup("php", "7.4")
+        assert r["status"] in ("unknown", "no_data")   # degraded, no exception
+
+
+def test_cache_path_rejects_traversal():
+    # Path-traversal slug must not escape CACHE_DIR (grok/agy/codex/me).
+    p = eol_check._cache_path("../../../etc/passwd")
+    assert p is None or os.path.realpath(p).startswith(
+        os.path.realpath(eol_check.CACHE_DIR) + os.sep)
+
+
+def test_fetch_rejects_bad_slug():
+    # A bad slug must be refused before any URL/filesystem use. fetch_product_cycles
+    # gates on _sanitize_slug (the autouse fixture mocks the fetch itself, so we
+    # assert the real guard directly).
+    assert eol_check._sanitize_slug("../evil") is None
+    assert eol_check._sanitize_slug("../../etc/passwd") is None
+    assert eol_check._sanitize_slug("red-hat-openshift") == "red-hat-openshift"
+
+
+# ── Output safety (grok P3 / agy / codex #9) ─────────────────────────────────
+def test_report_strips_control_characters(monkeypatch):
+    _use(monkeypatch, _php_cycles())
+    r = eol_check.lookup("php", "7.4\x1b[2Jinjected\n")
+    out = eol_check.format_eol_report("target", [r], color=False)
+    assert "\x1b" not in out
+    assert "\n" in out                       # newlines between lines are fine
+    assert "injected" in out                 # text kept, control chars gone
+
+
+def test_no_color_output_has_no_ansi(monkeypatch):
+    _use(monkeypatch, _php_cycles())
+    r = eol_check.lookup("php", "7.4")
+    out = eol_check.format_eol_report("t", [r], color=False)
+    assert "\033[" not in out
+
+
+# ── Dedup / memoize (codex #10) ──────────────────────────────────────────────
+def test_check_eol_dedups_repeated_lookups(monkeypatch):
+    calls = {"n": 0}
+
+    def counting(slug, refresh=False):
+        calls["n"] += 1
+        return _php_cycles()
+    monkeypatch.setattr(eol_check, "fetch_product_cycles", counting)
+    results = eol_check.check_eol("php=7.4,php=7.4,php=8.3")
+    assert len(results) == 3
+    assert calls["n"] == 1                   # one fetch for the single 'php' slug
+
+
+# ── CLI exit codes (codex #8) ────────────────────────────────────────────────
+def _run_main(monkeypatch, argv, cycles):
+    monkeypatch.setattr(sys, "argv", ["eol_check.py"] + argv)
+    monkeypatch.setattr(eol_check, "fetch_product_cycles", lambda slug, refresh=False: cycles)
+    monkeypatch.setattr(sys, "stdout", io.StringIO())
+    return eol_check.main()
+
+
+def test_exit_2_when_confirmed_present(monkeypatch):
+    rc = _run_main(monkeypatch, ["--tech", "php=7.4", "--no-color"], _php_cycles())
+    assert rc == 2
+
+
+def test_exit_0_when_all_supported(monkeypatch):
+    rc = _run_main(monkeypatch, ["--tech", "php=8.3", "--no-color"], _php_cycles())
+    assert rc == 0
+
+
+def test_strict_exit_3_on_indeterminate(monkeypatch):
+    # --strict lets a CI gate distinguish "checked, all fine" from "couldn't check".
+    rc = _run_main(monkeypatch, ["--tech", "php=5.6", "--no-color", "--strict"], _php_cycles())
+    assert rc == 3
+
+
+def test_credit_string_is_present():
+    r = eol_check.lookup("nginx")
+    assert "endoflife.date" in r["credit"]
+
+
+# ── Boolean 'support' field (endoflife.date allows bool or date) ─────────────
+def test_boolean_support_false_is_security_only(monkeypatch):
+    # support:false + a future eol → active support ended, security-only.
+    _use(monkeypatch, [{"cycle": "1.0", "support": False, "eol": _d(+300),
+                        "latest": "1.0.0"}])
+    r = eol_check.lookup("nginx", "1.0")
+    assert r["status"] == "security_only"
+    assert r["tag"] == eol_check.TAG_INFORMATIONAL
+
+
+def test_boolean_support_true_is_supported(monkeypatch):
+    _use(monkeypatch, [{"cycle": "2.0", "support": True, "eol": _d(+300),
+                        "latest": "2.0.0"}])
+    r = eol_check.lookup("nginx", "2.0")
+    assert r["status"] == "supported"
+
+
+# ── Exit-code default contract (documents the deliberate lenient default) ────
+def test_default_indeterminate_exits_zero_by_design(monkeypatch):
+    # Without --strict, an unmatched/indeterminate result is NOT an error exit —
+    # a deliberate, documented default (use --strict for a fail-closed CI gate).
+    rc = _run_main(monkeypatch, ["--tech", "php=5.6", "--no-color"], _php_cycles())
+    assert rc == 0
+
+
+# ── --json output must be control-char clean too (not just the terminal) ─────
+def test_json_output_sanitizes_version(monkeypatch, tmp_path):
+    out_json = tmp_path / "out.json"
+    monkeypatch.setattr(sys, "argv",
+                        ["eol_check.py", "--tech", "php=7.4\x1b[2Jx", "--no-color",
+                         "--json", str(out_json)])
+    monkeypatch.setattr(eol_check, "fetch_product_cycles",
+                        lambda slug, refresh=False: _php_cycles())
+    monkeypatch.setattr(sys, "stdout", io.StringIO())
+    eol_check.main()
+    import json as _json
+    parsed = _json.loads(out_json.read_text())          # what a consumer recovers
+    versions = [r.get("version") or "" for r in parsed["results"]]
+    assert all("\x1b" not in v and "\n" not in v for v in versions)
+
+
+def test_report_strips_bidi_override(monkeypatch):
+    # RTL/bidi override chars are terminal-spoofing nuisances — strip them too.
+    _use(monkeypatch, _php_cycles())
+    r = eol_check.lookup("php", "7.4‮gnp.exe")
+    out = eol_check.format_eol_report("t", [r], color=False)
+    assert "‮" not in out
+
+
+# ── Anti-fabrication hardening (codex confirmation pass) ─────────────────────
+def test_control_char_version_is_not_fabricated(monkeypatch):
+    # '7.\n4' must NOT be stripped-and-glued into '7.4' and matched as CONFIRMED.
+    _use(monkeypatch, _php_cycles())
+    r = eol_check.lookup("php", "7.\n4")
+    assert r["status"] == "unknown"
+    assert r["tag"] != eol_check.TAG_CONFIRMED
+    assert r["matched_cycle"] is None
+
+
+def test_non_string_cycle_id_is_ignored(monkeypatch):
+    # A malformed cycle whose id is an int must not be stringified into a match.
+    _use(monkeypatch, [{"cycle": 74, "eol": True, "latest": "7.4"}])
+    r = eol_check.lookup("php", "74")
+    assert r["status"] in ("unknown", "no_data")
+    assert r["tag"] != eol_check.TAG_CONFIRMED
+
+
+def test_malformed_extended_support_is_not_confirmed(monkeypatch):
+    # Past eol + an UNPARSEABLE extendedSupport: we cannot prove ESM is absent,
+    # so we must NOT emit a hard [CONFIRMED] "no security fixes".
+    _use(monkeypatch, [{"cycle": "1.0", "eol": _d(-30),
+                        "extendedSupport": "not-a-date", "latest": "1.0.0"}])
+    r = eol_check.lookup("nginx", "1.0")
+    assert r["tag"] != eol_check.TAG_CONFIRMED
+
+
+def test_case_insensitive_cycle_match(monkeypatch):
+    # Banner form '10-22H2' must match the API's lowercase cycle '10-22h2'.
+    _use(monkeypatch, [{"cycle": "10-22h2", "eol": _d(-30), "latest": "10.0"}])
+    r = eol_check.lookup("windows", "10-22H2")
+    assert r["matched_cycle"] == "10-22h2"
+    assert r["status"] == "expired"
+
+
+def test_strict_with_expired_and_unknown_prioritizes_confirmed(monkeypatch):
+    # A CONFIRMED finding (exit 2) outranks indeterminate (exit 3) — documented.
+    rc = _run_main(monkeypatch, ["--tech", "php=7.4,php=5.6", "--no-color", "--strict"],
+                   _php_cycles())
+    assert rc == 2
+
+
+# ── Real fetch path (mock urlopen, not the whole function) ───────────────────
+def test_fetch_real_path_guards(monkeypatch, tmp_path):
+    import urllib.request
+    monkeypatch.setattr(eol_check, "CACHE_DIR", str(tmp_path))   # never touch real cache
+
+    class _Resp:
+        def __init__(self, body):
+            self._b = body.encode()
+        def read(self, n=-1):
+            return self._b
+        def __enter__(self):
+            return self
+        def __exit__(self, *a):
+            return False
+
+    # non-list top-level body → None (degrade, no crash), never cached as data.
+    monkeypatch.setattr(urllib.request, "urlopen",
+                        lambda *a, **k: _Resp('{"message":"rate limited"}'))
+    assert _REAL_FETCH("nginx", refresh=True) is None
+
+    # malformed JSON → None.
+    monkeypatch.setattr(urllib.request, "urlopen", lambda *a, **k: _Resp("{not json"))
+    assert _REAL_FETCH("nginx", refresh=True) is None
+
+    # a valid list of dicts → returned.
+    monkeypatch.setattr(urllib.request, "urlopen",
+                        lambda *a, **k: _Resp('[{"cycle":"1.0","eol":true}]'))
+    got = _REAL_FETCH("nginx", refresh=True)
+    assert got == [{"cycle": "1.0", "eol": True}]
+
+
+# ── Round-3 hardening (codex final pass) ─────────────────────────────────────
+def test_control_bearing_cycle_id_is_ignored(monkeypatch):
+    # A malformed API/cache cycle id with a control char must not be
+    # strip-normalized into a match (mirror of the version-side guard).
+    _use(monkeypatch, [{"cycle": "7.4\n", "eol": True, "latest": "7.4"}])
+    r = eol_check.lookup("php", "7.4")
+    assert r["status"] in ("unknown", "no_data")
+    assert r["tag"] != eol_check.TAG_CONFIRMED
+
+
+def test_numeric_extended_support_is_not_confirmed(monkeypatch):
+    # extendedSupport as 0/1 (== False/True by value) must use identity checks;
+    # an unrecognized ESM type is indeterminate → NOT a hard CONFIRMED.
+    for weird in (0, 1, [], {}):
+        _use(monkeypatch, [{"cycle": "1.0", "eol": _d(-30),
+                            "extendedSupport": weird, "latest": "1.0.0"}])
+        r = eol_check.lookup("nginx", "1.0")
+        assert r["tag"] != eol_check.TAG_CONFIRMED, f"weird ESM {weird!r} → CONFIRMED"
+
+
+def test_extended_support_ending_today_is_covered(monkeypatch):
+    # ESM ending exactly today is still covered (consistent with eol-today being
+    # not-yet-expired) → 'extended', not 'expired'.
+    _use(monkeypatch, [{"cycle": "1.0", "eol": _d(-30),
+                        "extendedSupport": _d(0), "latest": "1.0.0"}])
+    r = eol_check.lookup("nginx", "1.0")
+    assert r["status"] == "extended"
+    assert r["tag"] != eol_check.TAG_CONFIRMED
+
+
+def test_duplicate_conflicting_cycles_are_ambiguous(monkeypatch):
+    # Two records with the same canonical id but conflicting data → refuse.
+    _use(monkeypatch, [{"cycle": "7.4", "eol": True, "latest": "7.4"},
+                       {"cycle": "7.4", "eol": False, "latest": "7.4"}])
+    r = eol_check.lookup("php", "7.4")
+    assert r["status"] == "unknown"
+    assert r["matched_cycle"] is None
+
+
+def test_incomplete_read_degrades_not_crash(monkeypatch, tmp_path):
+    import http.client
+    import urllib.request
+    monkeypatch.setattr(eol_check, "CACHE_DIR", str(tmp_path))
+
+    class _Resp:
+        def read(self, n=-1):
+            raise http.client.IncompleteRead(b"partial")
+        def __enter__(self):
+            return self
+        def __exit__(self, *a):
+            return False
+    monkeypatch.setattr(urllib.request, "urlopen", lambda *a, **k: _Resp())
+    assert _REAL_FETCH("nginx", refresh=True) is None      # caught, no crash
+
+
+def test_json_sanitizes_api_derived_fields(monkeypatch, tmp_path):
+    out_json = tmp_path / "o.json"
+    _use(monkeypatch, [{"cycle": "1.0", "eol": _d(-30), "latest": "1.0\x1b[2J"}])
+    monkeypatch.setattr(sys, "argv",
+                        ["eol_check.py", "--tech", "nginx=1.0", "--no-color",
+                         "--json", str(out_json)])
+    monkeypatch.setattr(sys, "stdout", io.StringIO())
+    eol_check.main()
+    import json as _json
+    parsed = _json.loads(out_json.read_text())
+    for r in parsed["results"]:
+        for field in ("latest", "matched_cycle", "eol_date"):
+            v = r.get(field)
+            if isinstance(v, str):
+                assert "\x1b" not in v
+
+
+def test_resolve_slug_none_is_safe():
+    # Library-misuse guard: a non-string term must not raise.
+    assert eol_check._resolve_slug(None) is None
+    assert eol_check._resolve_slug(1234) is None
+
+
+def test_unicode_separator_in_cycle_id_is_ignored(monkeypatch):
+    # U+2028 (Zl) is whitespace to str.strip() but must not canonicalize a
+    # malformed cycle '7.4 ' into a '7.4' match.
+    _use(monkeypatch, [{"cycle": "7.4 ", "eol": True, "latest": "7.4"}])
+    r = eol_check.lookup("php", "7.4")
+    assert r["tag"] != eol_check.TAG_CONFIRMED
+    assert r["matched_cycle"] is None
+
+
+def test_unicode_separator_in_version_is_rejected(monkeypatch):
+    _use(monkeypatch, _php_cycles())
+    r = eol_check.lookup("php", "7.4 ")
+    assert r["status"] == "unknown"
+    assert r["tag"] != eol_check.TAG_CONFIRMED
+
+
+def test_cli_trailing_control_version_not_fabricated(monkeypatch):
+    # A control that survives arg-splitting must still be refused, not stripped
+    # into a bare '7.4' match.
+    rc = _run_main(monkeypatch, ["--tech", "php=7.4\n", "--no-color"], _php_cycles())
+    assert rc == 0                       # not exit 2 (no CONFIRMED minted)
+
+
+def test_noncanonical_date_is_not_authoritative(monkeypatch):
+    # date.fromisoformat accepts '20200101' / '2020-W01-1'; a malformed eol in a
+    # non-schema format must NOT substantiate a [CONFIRMED] verdict.
+    _use(monkeypatch, [{"cycle": "1.0", "eol": "20200101", "latest": "1.0.0"}])
+    r = eol_check.lookup("nginx", "1.0")
+    assert r["status"] == "unknown"
+    assert r["tag"] != eol_check.TAG_CONFIRMED
+
+
+def test_oversized_cache_is_rejected(monkeypatch, tmp_path):
+    monkeypatch.setattr(eol_check, "CACHE_DIR", str(tmp_path))
+    monkeypatch.setattr(eol_check, "MAX_BYTES", 2000)
+    big = tmp_path / "nginx.json"
+    big.write_text("[" + ",".join('{"cycle":"1.0"}' for _ in range(500)) + "]")
+    assert eol_check._load_cached("nginx") is None      # over cap → treated as miss
+
+
+def test_nonstring_latest_is_nulled(monkeypatch):
+    # A malformed non-string 'latest' must not be copied through into results.
+    _use(monkeypatch, [{"cycle": "1.0", "eol": _d(+900),
+                        "latest": {"build": "1.0\x1b[2J"}}])
+    r = eol_check.lookup("nginx", "1.0")
+    assert r["latest"] is None
+
+
+def test_cache_write_recursion_degrades_not_crash(monkeypatch, tmp_path):
+    # json.dump of a pathologically nested payload raises RecursionError; the
+    # cache write must fail SOFT (never crash the scan) — mirrors the load path.
+    monkeypatch.setattr(eol_check, "CACHE_DIR", str(tmp_path))
+
+    def boom(*a, **k):
+        raise RecursionError("too deep")
+    monkeypatch.setattr(eol_check.json, "dump", boom)
+    eol_check._store_cached("nginx", [{"cycle": "1.0"}])     # must not raise
+
+
+def test_json_write_failure_returns_one(monkeypatch, tmp_path):
+    # A requested --json artifact that cannot be written must not exit 0.
+    unwritable = tmp_path / "nodir" / "o.json"          # parent doesn't exist
+    monkeypatch.setattr(sys, "argv",
+                        ["eol_check.py", "--tech", "php=8.3", "--no-color",
+                         "--json", str(unwritable)])
+    monkeypatch.setattr(eol_check, "fetch_product_cycles",
+                        lambda slug, refresh=False: _php_cycles())
+    monkeypatch.setattr(sys, "stdout", io.StringIO())
+    monkeypatch.setattr(sys, "stderr", io.StringIO())
+    assert eol_check.main() == 1

--- a/tools/README.md
+++ b/tools/README.md
@@ -20,6 +20,7 @@ Python and shell scanner pipeline (~35 tools). Every tool checks whether its ext
 | `cloud_recon.sh` | S3Scanner · cloud_enum · CloudFail for public bucket exposure |
 | `takeover_scanner.sh` | Subdomain takeover via dnsReaper · subjack |
 | `cve_scan.sh` | Focused nuclei CVE sweep (high/critical) + optional log4j-scan |
+| `eol_check.py` | Lifecycle / End-of-Life status per detected tech via endoflife.date (pure stdlib, offline-cached) |
 | `bypass_403.sh` | Header · method · encoding tricks against 403/401 |
 | `secrets_hunter.sh` | trufflehog · noseyparker · gitleaks across FS/git/JS/GitHub org |
 

--- a/tools/eol_check.py
+++ b/tools/eol_check.py
@@ -1,0 +1,606 @@
+#!/usr/bin/env python3
+"""
+eol_check.py — Lifecycle / End-of-Life intel for a target's tech stack.
+
+Looks up each detected technology against the public endoflife.date API and
+reports whether the deployed software is still supported, in security-only
+maintenance, nearing EOL, or already past it. Past-EOL software is a real,
+verifiable finding (no security patches) — it slots into the recon/intel phase
+and complements CVE lookup.
+
+Design (matches this repo's tool ethos):
+  * PURE STDLIB (urllib/json/ssl) — nothing to install, so it can never be the
+    "missing dependency" that skips a scan.
+  * PREFERS "indeterminate" OVER GUESSING. If a detected version cannot be
+    matched to a specific lifecycle cycle, the result is `unknown` — the tool
+    never classifies an install from an unrelated release, and never emits a
+    [CONFIRMED] finding it cannot substantiate.
+  * Degrades gracefully: outage / unknown product / malformed API or cache data
+    returns `unknown` / `no_data`, never a crash.
+  * No traffic is sent to the target — endoflife.date is a public metadata API.
+  * Distinguishes standard EOL from extended/ESM support: a release past its
+    normal `eol` date but still inside `extendedSupport` is reported as
+    [POSSIBLE] "extended support", not [CONFIRMED] "no security fixes".
+  * Findings carry the repo's confidence tags:
+        past-EOL (no extended support) -> [CONFIRMED]
+        EOL soon / extended-support / EOL-past-but-ESM -> [POSSIBLE]
+        supported / security-only / unknown / no_data -> [INFORMATIONAL]
+
+Credit: all lifecycle data is from https://endoflife.date/ (MIT licensed,
+https://github.com/endoflife-date/endoflife.date). Please retain the credit
+string when redistributing reports that include this output.
+
+Usage:
+    python3 tools/eol_check.py --tech "nginx=1.18,php=7.4,ubuntu=20.04" --target example.com
+    python3 tools/eol_check.py --tech nextjs,tomcat --json out.json
+    python3 tools/eol_check.py --tech "php=7.4" --strict     # exit 3 on indeterminate
+    python3 tools/eol_check.py --list-products
+"""
+from __future__ import annotations
+
+import argparse
+import http.client
+import json
+import os
+import re
+import ssl
+import sys
+import time
+import unicodedata
+import urllib.error
+import urllib.parse
+import urllib.request
+from datetime import date
+
+ENDOFLIFE_BASE = "https://endoflife.date/api"
+ENDOFLIFE_HOMEPAGE = "https://endoflife.date/"
+ENDOFLIFE_CREDIT = (
+    "Lifecycle data courtesy of endoflife.date "
+    f"({ENDOFLIFE_HOMEPAGE}) — MIT licensed, please credit when redistributing."
+)
+CACHE_DIR = os.path.expanduser("~/.cache/bughunter/eol")
+CACHE_TTL = 24 * 3600      # seconds
+HTTP_TIMEOUT = 10          # per-request, seconds
+MAX_BYTES = 4_000_000      # response-size cap (guards against a hostile/huge body)
+EOL_SOON_DAYS = 90         # cycles within this window count as "support ending soon"
+
+# Use the system trust store by default. Overriding it unconditionally with
+# certifi (as an earlier draft did) can break enterprise CAs / TLS inspection —
+# so we don't. On a host with a broken cert store the fetch degrades to
+# `unknown`; operators can point urllib at a bundle via SSL_CERT_FILE.
+_SSL_CTX = ssl.create_default_context()
+
+# ── ANSI ─────────────────────────────────────────────────────────────────────
+RED = "\033[91m"; YELLOW = "\033[93m"; GREEN = "\033[92m"
+CYAN = "\033[96m"; BOLD = "\033[1m"; DIM = "\033[2m"; RESET = "\033[0m"
+
+# ── Confidence tags (repo convention) ────────────────────────────────────────
+TAG_CONFIRMED = "[CONFIRMED]"
+TAG_POSSIBLE = "[POSSIBLE]"
+TAG_INFORMATIONAL = "[INFORMATIONAL]"
+
+# Valid endoflife.date product slugs match this shape (verified against
+# /api/all.json). Used to sanitize any slug before it touches a URL or the
+# filesystem, so a hostile/library-supplied slug can't traverse paths.
+SLUG_RE = re.compile(r"^[a-z0-9][a-z0-9-]*$")
+# Unicode categories that are hostile in a terminal / spoof an identifier:
+# Cc control, Cf format (bidi/zero-width/BOM), Cs surrogate, Zl line-sep (U+2028),
+# Zp para-sep (U+2029). We handle these by CATEGORY (not a char range) so exotic
+# separators like U+2028 can't slip past a narrow regex, and so str.strip()
+# canonicalization can't turn a malformed id into a real one.
+_BAD_CATS = frozenset({"Cc", "Cf", "Cs", "Zl", "Zp"})
+_V_PREFIX_RE = re.compile(r"^[vV](?=\d)")            # leading 'v' before a digit
+_ISO_DATE_RE = re.compile(r"\d{4}-\d{2}-\d{2}")      # strict endoflife.date schema shape
+
+# ── Tech fingerprint → endoflife.date product slug ───────────────────────────
+# Keys are lowercased fingerprint terms (whatweb/httpx/wappalyzer style).
+# Values are valid endoflife.date slugs (verified against /api/all.json).
+# Deliberately omitted because a bare fingerprint is too ambiguous to place on a
+# single product timeline (would risk a wrong-product EOL verdict):
+#   iis          — no endoflife.date product; version space != Windows Server
+#   powershell   — PowerShell 7.x and Windows PowerShell 5.1 are distinct products
+#   java/openjdk — no vendor-neutral Java timeline; Oracle JDK / Temurin / Corretto
+#                  / Zulu diverge, so a bare 'java' hit is left unresolved. Only
+#                  vendor-specific fingerprints (temurin, corretto, zulu, …) resolve.
+PRODUCT_MAP: dict[str, str] = {
+    # Microsoft stack
+    "asp.net": "dotnetfx", "aspnet": "dotnetfx", "asp.net core": "dotnet",
+    "aspnetcore": "dotnet", ".net": "dotnet", ".net framework": "dotnetfx",
+    "dotnet": "dotnet", "dotnetcore": "dotnet", "dotnetfx": "dotnetfx",
+    "dotnetframework": "dotnetfx", "windows": "windows",
+    "windows server": "windows-server", "windows-server": "windows-server",
+    # Web servers
+    "apache": "apache-http-server", "apache httpd": "apache-http-server",
+    "httpd": "apache-http-server", "nginx": "nginx", "tomcat": "tomcat",
+    "apache tomcat": "tomcat", "caddy": "caddy",
+    # Languages / runtimes
+    "php": "php", "python": "python", "node.js": "nodejs", "nodejs": "nodejs",
+    "node": "nodejs", "ruby": "ruby", "perl": "perl", "go": "go", "golang": "go",
+    "rust": "rust", "kotlin": "kotlin", "bun": "bun",
+    # JDKs — vendor-specific only (generic java/openjdk intentionally unmapped)
+    "oracle jdk": "oracle-jdk", "oracle-jdk": "oracle-jdk",
+    "temurin": "eclipse-temurin", "eclipse temurin": "eclipse-temurin",
+    "adoptium": "eclipse-temurin", "adoptopenjdk": "eclipse-temurin",
+    "corretto": "amazon-corretto", "amazon corretto": "amazon-corretto",
+    "zulu": "azul-zulu", "azul": "azul-zulu", "azul zulu": "azul-zulu",
+    "microsoft openjdk": "microsoft-build-of-openjdk",
+    "red hat openjdk": "redhat-build-of-openjdk",
+    # Frameworks / CMS
+    "wordpress": "wordpress", "drupal": "drupal", "phpbb": "phpbb",
+    "phpmyadmin": "phpmyadmin", "rails": "rails", "ruby on rails": "rails",
+    "django": "django", "laravel": "laravel", "symfony": "symfony",
+    "cakephp": "cakephp", "next.js": "nextjs", "nextjs": "nextjs",
+    "angular": "angular", "angularjs": "angularjs", "react": "react",
+    "vue": "vue", "vue.js": "vue", "svelte": "svelte", "spring": "spring-framework",
+    "spring boot": "spring-boot", "spring-boot": "spring-boot",
+    "spring framework": "spring-framework", "spring security": "spring-security",
+    "apache struts": "apache-struts", "struts": "apache-struts",
+    # Databases / caches
+    "mysql": "mysql", "mariadb": "mariadb", "postgresql": "postgresql",
+    "postgres": "postgresql", "mongodb": "mongodb", "mongo": "mongodb",
+    "redis": "redis", "elasticsearch": "elasticsearch", "kibana": "kibana",
+    "logstash": "logstash", "cassandra": "apache-cassandra",
+    "couchdb": "apache-couchdb", "rabbitmq": "rabbitmq", "kafka": "apache-kafka",
+    # Linux distros
+    "ubuntu": "ubuntu", "debian": "debian", "centos": "centos",
+    "centos stream": "centos-stream", "rhel": "rhel", "redhat": "rhel",
+    "red hat": "rhel", "rocky": "rocky-linux", "rocky linux": "rocky-linux",
+    "alma": "almalinux", "almalinux": "almalinux", "alpine": "alpine-linux",
+    "amazon linux": "amazon-linux", "amazon-linux": "amazon-linux",
+    "amzn": "amazon-linux",
+    # Cloud / orchestration / runtime
+    "kubernetes": "kubernetes", "k8s": "kubernetes", "docker": "docker-engine",
+    "openshift": "red-hat-openshift", "amazon eks": "amazon-eks",
+    "azure aks": "azure-kubernetes-service", "amazon rds mysql": "amazon-rds-mysql",
+    "amazon rds postgres": "amazon-rds-postgresql",
+    "amazon aurora postgres": "amazon-aurora-postgresql", "aws lambda": "aws-lambda",
+    # Mobile / desktop
+    "android": "android", "ios": "ios", "macos": "macos",
+}
+
+
+# ── Slug / value sanitizers ──────────────────────────────────────────────────
+def _sanitize_slug(slug):
+    """Return a filesystem/URL-safe slug, or None if it is not a valid slug."""
+    if not isinstance(slug, str):
+        return None
+    slug = slug.strip()
+    if not SLUG_RE.match(slug) or slug != os.path.basename(slug):
+        return None
+    return slug
+
+
+def _has_bad_char(s) -> bool:
+    """True if the string contains any control/format/separator char (a char that
+    str.strip() might canonicalize away, or that could spoof terminal output)."""
+    return any(unicodedata.category(ch) in _BAD_CATS for ch in str(s))
+
+
+def _strip_controls(s) -> str:
+    return "".join(ch for ch in str(s) if unicodedata.category(ch) not in _BAD_CATS)
+
+
+# ── Cache helpers (fail-soft: any cache error just disables caching) ──────────
+def _cache_path(slug):
+    slug = _sanitize_slug(slug)
+    if slug is None:
+        return None
+    try:
+        os.makedirs(CACHE_DIR, exist_ok=True)
+    except OSError:
+        return None
+    return os.path.join(CACHE_DIR, f"{slug}.json")
+
+
+def _load_cached(slug, ttl: int = CACHE_TTL):
+    try:
+        path = _cache_path(slug)
+        if not path or not os.path.exists(path):
+            return None
+        if (time.time() - os.path.getmtime(path)) > ttl:
+            return None
+        if os.path.getsize(path) > MAX_BYTES:      # oversized/poisoned cache → miss
+            return None
+        with open(path) as f:
+            data = json.load(f)
+    except (OSError, ValueError, RecursionError):   # ValueError covers JSONDecodeError
+        return None
+    return data if isinstance(data, list) else None
+
+
+def _store_cached(slug, data) -> None:
+    path = _cache_path(slug)
+    if not path:
+        return
+    try:
+        tmp = f"{path}.{os.getpid()}.tmp"    # per-process temp → no cross-writer race
+        with open(tmp, "w") as f:
+            json.dump(data, f, indent=2)
+        os.replace(tmp, path)                # atomic; no torn reads
+    except (OSError, ValueError, TypeError, RecursionError):
+        # Never let a cache-write failure (incl. json.dump recursing on deeply
+        # nested junk, or a non-serializable value) crash the scan.
+        try:
+            os.path.exists(tmp) and os.remove(tmp)
+        except OSError:
+            pass
+
+
+# ── HTTP fetch (pure stdlib) ─────────────────────────────────────────────────
+def fetch_product_cycles(slug, refresh: bool = False):
+    """Return the lifecycle cycles (list of dicts) for ``slug``, ``[]`` for an
+    unknown product, or ``None`` on a hard network / bad-response error.
+    Cached for CACHE_TTL seconds. Refuses a slug that is not a valid slug."""
+    slug = _sanitize_slug(slug)
+    if slug is None:
+        return None
+    if not refresh:
+        cached = _load_cached(slug)
+        if cached is not None:
+            return cached
+    url = f"{ENDOFLIFE_BASE}/{urllib.parse.quote(slug, safe='')}.json"
+    req = urllib.request.Request(url, headers={
+        "User-Agent": "bughunter-eolcheck/1.0 (+https://endoflife.date credited)",
+        "Accept": "application/json",
+    })
+    try:
+        with urllib.request.urlopen(req, timeout=HTTP_TIMEOUT, context=_SSL_CTX) as resp:
+            raw = resp.read(MAX_BYTES + 1)
+        if len(raw) > MAX_BYTES:
+            return None                # implausibly large — treat as failure
+        data = json.loads(raw.decode("utf-8", "replace"))
+    except urllib.error.HTTPError as e:
+        if e.code == 404:
+            _store_cached(slug, [])    # cache the negative
+            return []
+        return None
+    except (urllib.error.URLError, TimeoutError, OSError, ValueError, RecursionError,
+            http.client.HTTPException):
+        return None                    # HTTPException: e.g. IncompleteRead on a truncated body;
+                                       # RecursionError: pathologically nested JSON
+    if not isinstance(data, list):     # rate-limit body / schema change / junk
+        return None
+    data = [c for c in data if isinstance(c, dict)]
+    _store_cached(slug, data)
+    return data
+
+
+# ── Version matching (string-based; canonical cycle identifiers) ─────────────
+def _clean_version(v) -> str:
+    """Normalize a version for MATCHING. A control-bearing identifier is REFUSED
+    (returns ""), never stripped-and-glued — else '7.\\n4' would masquerade as the
+    real cycle '7.4' and fabricate a finding. Output escaping is a separate step
+    (_strip_controls); normalization must not manufacture a valid identifier."""
+    if not isinstance(v, str) or _has_bad_char(v):
+        return ""                      # malformed / control-bearing → no match → 'unknown'
+    v = _V_PREFIX_RE.sub("", v.strip())   # 'v7.4' -> '7.4'
+    return v.lower()                   # case-insensitive ('22H2' == cycle '22h2')
+
+
+def _match_cycle(cycles, version):
+    """Match ``version`` to a cycle by canonical string, NOT lossy numerics.
+
+    A cycle matches when the cleaned version equals the cycle id or extends it at
+    a boundary ('.' or '-'). The longest matching cycle wins. If two *different*
+    cycles tie on length the match is ambiguous → return None (never guess).
+    Only string cycle ids are considered (a malformed int id is not coerced)."""
+    cv = _clean_version(version)
+    if not isinstance(cycles, list) or not cv:
+        return None
+    matches = []
+    for c in cycles:
+        if not isinstance(c, dict) or not isinstance(c.get("cycle"), str):
+            continue
+        raw = c["cycle"]
+        if _has_bad_char(raw):         # control/separator-bearing id → don't normalize into a match
+            continue
+        cyc = raw.strip().lower()
+        if not cyc:
+            continue
+        if cv == cyc or cv.startswith(cyc + ".") or cv.startswith(cyc + "-"):
+            matches.append((len(cyc), cyc, c))
+    if not matches:
+        return None
+    best_len = max(m[0] for m in matches)
+    top = [m for m in matches if m[0] == best_len]
+    if len(top) > 1:                   # distinct-cycle tie OR duplicate/conflicting ids → refuse
+        return None
+    return top[0][2]
+
+
+# ── Classification ───────────────────────────────────────────────────────────
+def _as_date(v):
+    # date.fromisoformat accepts noncanonical forms ('20200101', ISO week dates);
+    # require the exact endoflife.date 'YYYY-MM-DD' shape so a malformed date can't
+    # substantiate a verdict.
+    if isinstance(v, str) and _ISO_DATE_RE.fullmatch(v):
+        try:
+            return date.fromisoformat(v)
+        except ValueError:
+            return None
+    return None
+
+
+def _support_ended(support, today) -> bool:
+    """True if active support has ended (a past date, or the boolean ``false``
+    endoflife.date uses for 'no active-support phase / ended')."""
+    if support is False:
+        return True
+    if support is True:
+        return False
+    sd = _as_date(support)
+    return sd is not None and sd <= today
+
+
+def _support_status(support, today):
+    return "security_only" if _support_ended(support, today) else "supported"
+
+
+def _classify(cycle: dict, today=None):
+    """Return (status, days_to_eol). status ∈ supported / security_only / soon /
+    extended / expired / unknown.
+
+    Past-EOL degrades to a [POSSIBLE] 'extended' (not [CONFIRMED] 'expired') when
+    extended/ESM support is either still in the future OR present-but-unparseable
+    — we must not assert 'no security fixes' unless we can rule out ESM."""
+    today = today or date.today()
+    eol = cycle.get("eol")
+    ext = cycle.get("extendedSupport")
+    ext_date = _as_date(ext)
+    # Identity checks (NOT ==): numeric 0/1 must not alias False/True. An ESM
+    # value we can't interpret is 'indeterminate' → we can't rule out coverage.
+    ext_indeterminate = (ext is not None and ext is not True and ext is not False
+                         and ext_date is None)
+    # '>= today' mirrors the eol convention (eol == today is not-yet-expired).
+    ext_covers = (ext is True) or (ext_date is not None and ext_date >= today) or ext_indeterminate
+
+    if eol is True:
+        return ("extended", None) if ext_covers else ("expired", None)
+    if eol is False:
+        return (_support_status(cycle.get("support"), today), None)
+    if isinstance(eol, str):
+        eol_date = _as_date(eol)
+        if eol_date is None:
+            return ("unknown", None)
+        days = (eol_date - today).days
+        if days < 0:
+            return ("extended", days) if ext_covers else ("expired", days)
+        if days <= EOL_SOON_DAYS:
+            return ("soon", days)
+        return (_support_status(cycle.get("support"), today), days)
+    return ("unknown", None)
+
+
+def _tag_for_status(status: str) -> str:
+    if status == "expired":
+        return TAG_CONFIRMED
+    if status in ("soon", "extended"):
+        return TAG_POSSIBLE
+    return TAG_INFORMATIONAL
+
+
+def _san_str(v):
+    """Control-strip a string field; any non-string (malformed composite) → None,
+    so junk types can't be copied through into the JSON artifact."""
+    return _strip_controls(v) if isinstance(v, str) else None
+
+
+def _san_eol(v):
+    """eol may legitimately be a bool; keep bools, sanitize strings, drop the rest."""
+    if isinstance(v, bool):
+        return v
+    return _strip_controls(v) if isinstance(v, str) else None
+
+
+def _resolve_slug(tech_term):
+    if not isinstance(tech_term, str):
+        return None
+    key = tech_term.strip().lower()
+    slug = PRODUCT_MAP.get(key)
+    if slug:
+        return slug
+    key2 = re.sub(r"[ ._\-/]", "", key)
+    for k, v in PRODUCT_MAP.items():
+        if re.sub(r"[ ._\-/]", "", k) == key2:
+            return v
+    return None
+
+
+_NOTE = {
+    "extended": "standard support ended; extended/ESM may apply — verify entitlement",
+    "security_only": "active support ended; security-maintenance only",
+    "unknown": "version not matched to a lifecycle cycle",
+}
+
+
+def _base_result(tech, slug, version) -> dict:
+    # Store display-sanitized tech/version so BOTH the report and the --json
+    # artifact are free of control chars a downstream consumer might echo.
+    return {
+        "tech": _strip_controls(tech), "slug": slug,
+        "version": _strip_controls(version) if isinstance(version, str) else version,
+        "status": "no_data", "tag": TAG_INFORMATIONAL, "days_to_eol": None,
+        "latest": None, "eol_date": None, "matched_cycle": None,
+        "note": "", "credit": ENDOFLIFE_CREDIT,
+    }
+
+
+def _result_from_cycles(tech, slug, version, cycles) -> dict:
+    """Core classification for a resolved slug + already-fetched cycles."""
+    out = _base_result(tech, slug, version)
+    if cycles is None:
+        out["status"] = "unknown"
+        out["note"] = "lookup failed (network/response error)"
+        return out
+    if not isinstance(cycles, list) or not cycles:
+        return out                     # no_data
+    if not version:
+        out["status"] = "unknown"
+        out["note"] = "no version supplied — cannot assess a specific release"
+        first = cycles[0] if isinstance(cycles[0], dict) else {}
+        out["latest"] = _san_str(first.get("latest"))
+        return out
+    cycle = _match_cycle(cycles, version)
+    if cycle is None:
+        out["status"] = "unknown"
+        out["note"] = _NOTE["unknown"]
+        return out
+    status, days = _classify(cycle)
+    note = _NOTE.get(status, "")
+    # Preserve the secondary lifecycle fact: if the primary status is soon/extended/
+    # expired but active support ALSO already ended, don't silently drop that.
+    if status in ("soon", "extended") and _support_ended(cycle.get("support"), date.today()):
+        note = (note + "; active support already ended").lstrip("; ")
+    out.update({
+        "status": status, "tag": _tag_for_status(status), "days_to_eol": days,
+        "latest": _san_str(cycle.get("latest")), "eol_date": _san_eol(cycle.get("eol")),
+        "matched_cycle": _san_str(cycle.get("cycle")), "note": note,
+    })
+    return out
+
+
+# ── Public API ───────────────────────────────────────────────────────────────
+def lookup(tech_term: str, version: str | None = None, refresh: bool = False) -> dict:
+    """Resolve a fingerprint term (+optional version) to a lifecycle entry.
+
+    status ∈ {supported, security_only, soon, extended, expired, unknown, no_data}.
+    Never classifies from an unrelated cycle: an unmatched/absent version yields
+    `unknown`, never a fabricated finding."""
+    slug = _resolve_slug(tech_term)
+    if slug is None:
+        return _base_result(tech_term, None, version)
+    cycles = fetch_product_cycles(slug, refresh=refresh)
+    return _result_from_cycles(tech_term, slug, version, cycles)
+
+
+def _parse_tech_arg(tech_arg: str):
+    """'nginx=1.18,php=7.4,tomcat' -> [('nginx','1.18'),('php','7.4'),('tomcat',None)]"""
+    out = []
+    for item in tech_arg.split(","):
+        item = item.strip(" \t")       # trim only ASCII spaces/tabs — NOT newlines /
+        if not item:                   # exotic whitespace, so _clean_version can still
+            continue                   # refuse a control-bearing version rather than
+        if "=" in item:                # silently canonicalize it into a match.
+            name, ver = item.split("=", 1)
+            name = name.strip(" \t")
+            if name:
+                out.append((name, ver.strip(" \t") or None))
+        else:
+            out.append((item, None))
+    return out
+
+
+def check_eol(techs, refresh: bool = False) -> list:
+    """techs: iterable of (name, version) pairs OR a 'name=ver,...' string.
+
+    Fetches each product's cycles at most once per run (dedup by slug), then
+    matches every requested version against the cached cycles."""
+    if isinstance(techs, str):
+        techs = _parse_tech_arg(techs)
+    cycles_by_slug = {}
+    results = []
+    for name, version in techs:
+        slug = _resolve_slug(name)
+        if slug is None:
+            results.append(_base_result(name, None, version))
+            continue
+        if slug not in cycles_by_slug:
+            cycles_by_slug[slug] = fetch_product_cycles(slug, refresh=refresh)
+        results.append(_result_from_cycles(name, slug, version, cycles_by_slug[slug]))
+    return results
+
+
+# ── Reporting ────────────────────────────────────────────────────────────────
+_STATUS_COLOR = {"expired": RED, "extended": YELLOW, "soon": YELLOW,
+                 "security_only": CYAN, "supported": GREEN,
+                 "unknown": DIM, "no_data": DIM}
+_STATUS_ORDER = {"expired": 0, "extended": 1, "soon": 2, "security_only": 3,
+                 "unknown": 4, "supported": 5, "no_data": 6}
+
+
+def _want_color(color) -> bool:
+    if color is None:
+        return bool(getattr(sys.stdout, "isatty", lambda: False)()) \
+            and os.environ.get("NO_COLOR") is None
+    return bool(color)
+
+
+def format_eol_report(target: str, results: list, color=None) -> str:
+    use = _want_color(color)
+
+    def col(code, text):
+        return f"{code}{text}{RESET}" if use else str(text)
+
+    lines = [col(BOLD, "Lifecycle / EOL Status") + f" — {_strip_controls(target)}", ""]
+    for r in sorted(results, key=lambda x: _STATUS_ORDER.get(x["status"], 9)):
+        c = _STATUS_COLOR.get(r["status"], "")
+        tech = _strip_controls(r.get("tech", ""))
+        ver = f" {_strip_controls(r['version'])}" if r.get("version") else ""
+        cyc = f" (cycle {_strip_controls(r['matched_cycle'])})" if r.get("matched_cycle") else ""
+        days = ""
+        d = r.get("days_to_eol")
+        if isinstance(d, int):
+            if r["status"] == "expired" or d < 0:
+                days = f" — EOL {abs(d)}d ago"
+            elif r["status"] in ("soon", "extended"):
+                days = f" — EOL in {d}d"
+        note = f"  [{_strip_controls(r['note'])}]" if r.get("note") else ""
+        lines.append(f"  {r['tag']:<15} {col(c, tech + ver)}{cyc} :: "
+                     f"{col(c, r['status'].upper())}{days}{note}")
+    lines += ["", col(DIM, ENDOFLIFE_CREDIT)]
+    return "\n".join(lines)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Lifecycle / EOL status for a target's tech stack (endoflife.date)")
+    parser.add_argument("--tech", help="comma list, optional =version: 'nginx=1.18,php=7.4,tomcat'")
+    parser.add_argument("--target", default="target", help="target label for the report header")
+    parser.add_argument("--json", help="also write the raw results to this JSON path")
+    parser.add_argument("--refresh", action="store_true", help="bust the 24h cache")
+    parser.add_argument("--strict", action="store_true",
+                        help="exit 3 if any item is indeterminate (unknown/no_data) so a "
+                             "CI gate can tell 'checked, fine' from 'could not check'")
+    parser.add_argument("--no-color", action="store_true", help="disable ANSI colour")
+    parser.add_argument("--list-products", action="store_true",
+                        help="print the fingerprint→endoflife.date slug map and exit")
+    args = parser.parse_args()
+
+    if args.list_products:
+        for k, v in sorted(PRODUCT_MAP.items()):
+            print(f"  {k:<22} -> {v}")
+        return 0
+    if not args.tech:
+        print("No --tech specified. "
+              "Example: python3 tools/eol_check.py --tech nginx=1.18,php=7.4 --target example.com")
+        return 1
+
+    results = check_eol(args.tech, refresh=args.refresh)
+    color = False if args.no_color else None
+    print(format_eol_report(args.target, results, color=color))
+    json_write_failed = False
+    if args.json:
+        safe_path = _strip_controls(args.json)     # never echo a raw control-laden path
+        try:
+            with open(args.json, "w") as f:
+                json.dump({"target": _strip_controls(args.target), "results": results,
+                           "credit": ENDOFLIFE_CREDIT}, f, indent=2)
+            print(f"\nWrote {safe_path}")
+        except (OSError, ValueError, TypeError, RecursionError) as e:
+            json_write_failed = True
+            print(f"Could not write {safe_path}: {e!r}", file=sys.stderr)
+
+    # Exit codes let a caller gate: 2 = a CONFIRMED past-EOL item is present;
+    # 3 = (strict) something was indeterminate so coverage is incomplete;
+    # 1 = a requested --json artifact could not be written; else 0.
+    if any(r["status"] == "expired" for r in results):
+        return 2
+    if args.strict and any(r["status"] in ("unknown", "no_data") for r in results):
+        return 3
+    if json_write_failed:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## What this adds

`tools/eol_check.py` — a small, **pure-stdlib** recon/intel tool that maps a target's
detected tech fingerprints to [endoflife.date](https://endoflife.date/) product slugs and
reports the lifecycle status of each release: supported, security-only, EOL-soon,
extended/ESM support, or past-EOL. Past-EOL software is a factual, verifiable finding
(unsupported = no security patches), so this complements CVE lookup during recon.

```
$ python3 tools/eol_check.py --tech "php=7.4,ubuntu=20.04,php=8.2,nextjs" --target example.com
  [CONFIRMED]     php 7.4 (cycle 7.4)     :: EXPIRED — EOL 1322d ago
  [POSSIBLE]      ubuntu 20.04 (cycle 20.04) :: EXTENDED — EOL 407d ago  [extended/ESM may apply — verify entitlement]
  [INFORMATIONAL] php 8.2 (cycle 8.2)     :: SECURITY_ONLY  [active support ended; security-maintenance only]
  [INFORMATIONAL] nextjs                  :: UNKNOWN  [no version supplied]
```

## Why it fits the repo

- **Pure stdlib** (`urllib`/`json`/`ssl`) — nothing to install, so it can never be the
  "missing dependency" that skips a scan. Drops into `tools/` alongside the other Python tools.
- **No traffic to the target** — endoflife.date is a public metadata API.
- Uses the repo's confidence tags: `[CONFIRMED]` / `[POSSIBLE]` / `[INFORMATIONAL]`.
- Offline-cached (24h, `~/.cache/bughunter/eol`), so repeat runs are free.

## Design principle: prefer "indeterminate" over guessing

A lifecycle checker that guesses is worse than useless in a security context. So:

- An **unmatched or absent version yields `unknown`** — the tool never classifies an
  install from an unrelated release, and never emits `[CONFIRMED]` it can't substantiate.
- **Standard EOL is distinguished from extended/ESM support** (reads `support` + `eol` +
  `extendedSupport`), so an ESM-covered release (e.g. Ubuntu 20.04 → 2030) is reported as
  `[POSSIBLE] extended`, not `[CONFIRMED] no fixes`.
- **String-based cycle matching** on canonical identifiers — handles `v`-prefixed and
  patch-level versions and refuses ambiguous / mixed-identifier matches (e.g. won't match
  an AWS-Lambda `nodejs18.x` runtime against a `ruby4.0` cycle).
- Product slugs are **validated against `/api/all.json`**; genuinely ambiguous fingerprints
  (`iis`, bare `powershell`) are omitted rather than mapped to a wrong product.

## Safety / robustness (hardened against malformed / hostile data)

- Rejects control / format / separator characters **by Unicode category** (Cc/Cf/Cs/Zl/Zp)
  in any identifier, so a malformed cycle id or version can't be `str.strip()`-canonicalized
  into a false match; requires canonical `YYYY-MM-DD` dates so a non-schema date can't
  substantiate a verdict.
- Validates API and cache payload types (degrades to `unknown` instead of crashing on a
  non-list / rate-limit / truncated body), only matches string cycle ids, treats duplicate
  or ambiguous cycles as indeterminate, and downgrades a past-EOL record whose extended/ESM
  support can't be ruled out to `[POSSIBLE]` rather than `[CONFIRMED]`.
- Sanitizes slugs (no path traversal, no raw slug in the URL), caps both response and cache
  size, dedups fetches per run, and fails soft on every I/O / parse / cache-write path.
- `NO_COLOR` + non-TTY aware; strips terminal control characters from rendered output and
  from the `--json` artifact.
- CLI exit codes for automation: `2` = a `[CONFIRMED]` past-EOL item is present;
  `3` = `--strict` and something was indeterminate (lets CI tell "checked, fine" from
  "couldn't check"); `1` = a requested `--json` artifact could not be written; else `0`.

## Tests

`tests/test_eol_check.py` — **58 deterministic tests** (network mocked; all dates built
relative to "today" so nothing rots). Covers the no-fabrication contract, version matching
edge cases (v-prefix, patch-level, boundary, mixed/duplicate identifiers, Unicode-separator
rejection), extended/security-support semantics, malformed-payload and crash robustness,
slug + output sanitization, dedup, and CLI exit codes.

The tool was hardened across several adversarial review passes specifically to ensure it
prefers "indeterminate" over ever emitting an unsubstantiated `[CONFIRMED]` finding.

## Notes

- Targets the stable `endoflife.date` REST endpoint. A future enhancement could move to
  `/api/v1/products/{product}` to consume its native `isEoas`/`isMaintained` fields.
- Lifecycle data is courtesy of **endoflife.date** (MIT licensed); the credit string is
  retained in both the tool output and the JSON export.
