### PR TITLE
feat(brain): add OpenRouter LLM provider for standalone bughunter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+### Added
+- **OpenRouter provider** (`openrouter`) for standalone `bughunter` / `brain.py` — set `OPENROUTER_API_KEY`, choose option 7 in `bughunter setup`, or `BRAIN_PROVIDER=openrouter`. OpenAI-compatible gateway with default model `anthropic/claude-sonnet-4.6` and a short curated model list (same pattern as other cloud providers).
+
 ## v4.3.2 — AI Hunt Playbook (Jun 2026)
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -115,8 +115,9 @@ bughunter v "finding"        # short alias for validate
 | **DeepSeek** | Very cheap ($0.001/1K tokens) | Cloud | Fast | [platform.deepseek.com](https://platform.deepseek.com) |
 | Claude API | Paid | Cloud | Fast | [console.anthropic.com](https://console.anthropic.com) |
 | OpenAI | Paid | Cloud | Fast | [platform.openai.com](https://platform.openai.com) |
+| **OpenRouter** | Subscription / pay-as-you-go | Cloud | Fast | [openrouter.ai/keys](https://openrouter.ai/keys) → get API key |
 
-BugHunter auto-detects providers in this order: **Ollama → Groq → DeepSeek → Claude → OpenAI**
+BugHunter auto-detects providers in this order: **Ollama → Groq → DeepSeek → … → OpenRouter → Claude → OpenAI**
 
 Switch providers anytime: `bughunter setup`
 

--- a/brain.py
+++ b/brain.py
@@ -4,11 +4,13 @@ from __future__ import annotations
 """
 Brain — Multi-Provider LLM Reasoning Layer for Bug Bounty & VAPT
 Supports: Ollama (local), Claude, OpenAI, Grok, Groq, DeepSeek,
-          Gemini, Kimi (Moonshot), Mistral, Together AI, Cerebras, Perplexity
+          Gemini, Kimi (Moonshot), Mistral, Together AI, Cerebras, Perplexity,
+          OpenRouter
 
 Provider selection (in order of precedence):
   1. BRAIN_PROVIDER env var  (ollama | claude | openai | grok | groq | deepseek |
-                               gemini | kimi | mistral | together | cerebras | perplexity)
+                               gemini | kimi | mistral | together | cerebras |
+                               perplexity | openrouter)
   2. Auto-detect: uses first provider whose API key / server is available
 
 API keys (env vars):
@@ -23,6 +25,7 @@ API keys (env vars):
   TOGETHER_API_KEY    — Together AI (Llama, Qwen, etc. in cloud)
   CEREBRAS_API_KEY    — Cerebras (fastest inference — llama3.3-70b)
   PERPLEXITY_API_KEY  — Perplexity (sonar-pro — live web search)
+  OPENROUTER_API_KEY  — OpenRouter (multi-model gateway — anthropic/claude-sonnet-4.6, etc.)
   OLLAMA_HOST         — Ollama base URL (default: http://localhost:11434)
 
 Default model priority (uses first available):
@@ -99,7 +102,7 @@ class LLMClient:
     PROVIDER_PRIORITY = [
         "ollama", "groq", "deepseek", "cerebras",
         "gemini", "kimi", "mistral", "together",
-        "perplexity", "claude", "openai", "grok",
+        "perplexity", "openrouter", "claude", "openai", "grok",
     ]
 
     # Default models per provider
@@ -115,6 +118,7 @@ class LLMClient:
         "together":    "meta-llama/Llama-3.3-70B-Instruct-Turbo",
         "cerebras":    "llama3.3-70b",
         "perplexity":  "sonar-pro",
+        "openrouter":  "anthropic/claude-sonnet-4.6",
         "ollama":      None,  # resolved dynamically
     }
 
@@ -143,6 +147,7 @@ class LLMClient:
         "together":    "TOGETHER_API_KEY",
         "cerebras":    "CEREBRAS_API_KEY",
         "perplexity":  "PERPLEXITY_API_KEY",
+        "openrouter":  "OPENROUTER_API_KEY",
     }
 
     def _auto_detect(self) -> str:
@@ -313,6 +318,23 @@ class LLMClient:
             self.available   = True
             self.description = "Perplexity AI (sonar-pro — live web search)"
 
+        elif provider == "openrouter":
+            key = os.environ.get("OPENROUTER_API_KEY", "")
+            if not key:
+                return
+            import requests
+            self._http = requests.Session()
+            # HTTP-Referer + X-Title are optional OpenRouter attribution headers
+            self._http.headers.update({
+                "Authorization": f"Bearer {key}",
+                "Content-Type": "application/json",
+                "HTTP-Referer": "https://github.com/shuvonsec/claude-bug-bounty",
+                "X-Title": "BugHunter",
+            })
+            self._api_base   = "https://openrouter.ai/api/v1"
+            self.available   = True
+            self.description = "OpenRouter (multi-model gateway)"
+
     def chat(self, model: str | None, system: str, user: str,
              max_tokens: int = 4000, temperature: float = 0.1) -> str:
         """Send a chat request; return the assistant reply as a string."""
@@ -326,6 +348,7 @@ class LLMClient:
             elif self.provider in (
                 "openai", "grok", "groq", "deepseek",
                 "gemini", "kimi", "mistral", "together", "cerebras", "perplexity",
+                "openrouter",
             ):
                 return self._chat_openai_compat(model, system, user, max_tokens, temperature)
         except Exception as e:
@@ -411,6 +434,16 @@ class LLMClient:
             return ["llama3.3-70b", "llama3.1-8b"]
         elif self.provider == "perplexity":
             return ["sonar-pro", "sonar", "sonar-reasoning-pro", "sonar-reasoning"]
+        elif self.provider == "openrouter":
+            return [
+                "anthropic/claude-sonnet-4.6",
+                "anthropic/claude-opus-4",
+                "openai/gpt-4o",
+                "openai/gpt-4o-mini",
+                "google/gemini-2.0-flash-001",
+                "meta-llama/llama-3.3-70b-instruct",
+                "openrouter/auto",
+            ]
         return []
 
 # Model preference order — first available wins

--- a/config.example.json
+++ b/config.example.json
@@ -22,6 +22,7 @@
     "perplexity":  "PERPLEXITY_API_KEY=...  (sonar-pro — live web search)",
     "claude":      "ANTHROPIC_API_KEY=...  (claude-sonnet-4-6 / opus-4-8)",
     "openai":      "OPENAI_API_KEY=...  (gpt-4o / o1)",
-    "grok":        "XAI_API_KEY=...  (grok-3 / grok-2-latest)"
+    "grok":        "XAI_API_KEY=...  (grok-3 / grok-2-latest)",
+    "openrouter":  "OPENROUTER_API_KEY=...  (anthropic/claude-sonnet-4.6 / openai/gpt-4o / …)"
   }
 }

--- a/engine.py
+++ b/engine.py
@@ -14,6 +14,8 @@ Providers (auto-detected, first available wins):
   PAID:  claude   — set ANTHROPIC_API_KEY
          openai   — set OPENAI_API_KEY
          grok     — set XAI_API_KEY
+         openrouter — multi-model gateway, set OPENROUTER_API_KEY
+                    get key: https://openrouter.ai/keys
 
 Usage:
   ./engine.py setup                        one-time config wizard
@@ -200,12 +202,13 @@ def cmd_setup(args):
     header("BugHunter Setup")
 
     providers = {
-        "1": ("ollama",   "Ollama  (local, FREE)       — needs ollama running locally"),
-        "2": ("groq",     "Groq    (cloud, FREE tier)  — needs GROQ_API_KEY"),
-        "3": ("deepseek", "DeepSeek (cloud, very cheap)— needs DEEPSEEK_API_KEY"),
-        "4": ("claude",   "Claude  (paid)              — needs ANTHROPIC_API_KEY"),
-        "5": ("openai",   "OpenAI  (paid)              — needs OPENAI_API_KEY"),
-        "6": ("grok",     "Grok/xAI (paid)             — needs XAI_API_KEY"),
+        "1": ("ollama",     "Ollama     (local, FREE)       — needs ollama running locally"),
+        "2": ("groq",       "Groq       (cloud, FREE tier)  — needs GROQ_API_KEY"),
+        "3": ("deepseek",   "DeepSeek   (cloud, very cheap)— needs DEEPSEEK_API_KEY"),
+        "4": ("claude",     "Claude     (paid)              — needs ANTHROPIC_API_KEY"),
+        "5": ("openai",     "OpenAI     (paid)              — needs OPENAI_API_KEY"),
+        "6": ("grok",       "Grok/xAI   (paid)              — needs XAI_API_KEY"),
+        "7": ("openrouter", "OpenRouter (multi-model)       — needs OPENROUTER_API_KEY"),
     }
 
     print("Choose your AI backend:\n")
@@ -220,11 +223,12 @@ def cmd_setup(args):
     cfg["provider"] = provider
 
     env_map = {
-        "groq":     "GROQ_API_KEY",
-        "deepseek": "DEEPSEEK_API_KEY",
-        "claude":   "ANTHROPIC_API_KEY",
-        "openai":   "OPENAI_API_KEY",
-        "grok":     "XAI_API_KEY",
+        "groq":       "GROQ_API_KEY",
+        "deepseek":   "DEEPSEEK_API_KEY",
+        "claude":     "ANTHROPIC_API_KEY",
+        "openai":     "OPENAI_API_KEY",
+        "grok":       "XAI_API_KEY",
+        "openrouter": "OPENROUTER_API_KEY",
     }
 
     if provider in env_map:
@@ -272,17 +276,19 @@ def cmd_providers(args):
     saved = cfg.get("provider", "")
 
     env_map = {
-        "ollama":   None,
-        "groq":     "GROQ_API_KEY",
-        "deepseek": "DEEPSEEK_API_KEY",
-        "claude":   "ANTHROPIC_API_KEY",
-        "openai":   "OPENAI_API_KEY",
-        "grok":     "XAI_API_KEY",
+        "ollama":     None,
+        "groq":       "GROQ_API_KEY",
+        "deepseek":   "DEEPSEEK_API_KEY",
+        "claude":     "ANTHROPIC_API_KEY",
+        "openai":     "OPENAI_API_KEY",
+        "grok":       "XAI_API_KEY",
+        "openrouter": "OPENROUTER_API_KEY",
     }
     tier = {
         "ollama": "FREE (local)", "groq": "FREE tier",
         "deepseek": "cheap",      "claude": "paid",
         "openai": "paid",         "grok": "paid",
+        "openrouter": "subscription",
     }
 
     print(f"\n  {'PROVIDER':<12} {'TIER':<16} {'STATUS':<20} {'NOTE'}")
@@ -623,7 +629,7 @@ def main():
         """),
     )
     parser.add_argument("--provider", "-p",
-                        help="Force provider: ollama / groq / deepseek / claude / openai / grok")
+                        help="Force provider: ollama / groq / deepseek / claude / openai / grok / openrouter")
     parser.add_argument("--no-banner", action="store_true", help="Suppress banner")
 
     sub = parser.add_subparsers(dest="command", metavar="COMMAND")
@@ -663,7 +669,7 @@ def main():
     # Load saved API keys into environment before any LLM call
     cfg = load_config()
     for env_var in ("GROQ_API_KEY", "DEEPSEEK_API_KEY", "ANTHROPIC_API_KEY",
-                    "OPENAI_API_KEY", "XAI_API_KEY"):
+                    "OPENAI_API_KEY", "XAI_API_KEY", "OPENROUTER_API_KEY"):
         if not os.environ.get(env_var) and cfg.get(env_var):
             os.environ[env_var] = cfg[env_var]
 

--- a/tests/test_brain_auto_detect.py
+++ b/tests/test_brain_auto_detect.py
@@ -17,7 +17,10 @@ sys.path.insert(0, ROOT)
 
 @pytest.fixture
 def brain_module(monkeypatch):
-    for env in ("BRAIN_PROVIDER", "ANTHROPIC_API_KEY", "OPENAI_API_KEY", "XAI_API_KEY"):
+    for env in (
+        "BRAIN_PROVIDER", "ANTHROPIC_API_KEY", "OPENAI_API_KEY", "XAI_API_KEY",
+        "OPENROUTER_API_KEY",
+    ):
         monkeypatch.delenv(env, raising=False)
     import brain
     importlib.reload(brain)
@@ -64,7 +67,9 @@ def test_openai_and_grok_keys_both_front_nothing_available(brain_module, monkeyp
     assert chosen == "ollama"
     assert set(tracker.calls[:2]) == {"openai", "grok"}, \
         "key-bearing providers must be probed before the rest"
-    assert tracker.calls[2:] == ["ollama", "claude"], \
+    rest = [p for p in brain_module.LLMClient.PROVIDER_PRIORITY
+            if p not in ("openai", "grok")]
+    assert tracker.calls[2:] == rest, \
         "providers without keys keep their original relative order"
 
 
@@ -92,3 +97,34 @@ def test_key_set_but_provider_unavailable_falls_through(brain_module, monkeypatc
     assert chosen == "ollama"
     assert tracker.calls[0] == "claude"
     assert "ollama" in tracker.calls
+
+
+def test_openrouter_key_jumps_to_front(brain_module, monkeypatch):
+    monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or-test")
+    client = brain_module.LLMClient.__new__(brain_module.LLMClient)
+    client.available = False
+    tracker = _Tracker(available_provider="openrouter")
+    tracker.bind(client)
+
+    chosen = brain_module.LLMClient._auto_detect(client)
+
+    assert chosen == "openrouter"
+    assert tracker.calls[0] == "openrouter"
+
+
+def test_openrouter_init_sets_api_base(brain_module, monkeypatch):
+    monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or-test")
+    client = brain_module.LLMClient.__new__(brain_module.LLMClient)
+    client.available = False
+    client._ollama = None
+    client._http = None
+    client.description = ""
+    client.provider = "openrouter"
+
+    brain_module.LLMClient._init_provider(client, "openrouter")
+
+    assert client.available is True
+    assert client._api_base == "https://openrouter.ai/api/v1"
+    assert "openrouter" in client.description.lower()
+    assert brain_module.LLMClient.DEFAULT_MODELS["openrouter"] == "anthropic/claude-sonnet-4.6"
+    assert "anthropic/claude-sonnet-4.6" in brain_module.LLMClient.list_models(client)


### PR DESCRIPTION
## Summary
- Add **OpenRouter** as a first-class LLM provider for standalone `bughunter` / `brain.py` (same OpenAI-compatible pattern as Groq, Together, etc.).
- Wire it through `bughunter setup` (option 7), `bughunter providers`, config key rehydration, auto-detect via `OPENROUTER_API_KEY`, and `--provider openrouter`.
- Default model: `anthropic/claude-sonnet-4.6` with a short curated model list (no live catalog fetch — matches other cloud providers).

## Usage
```bash
export OPENROUTER_API_KEY=sk-or-v1-...
bughunter setup          # choose 7) OpenRouter
# or
export BRAIN_PROVIDER=openrouter
bughunter providers
bughunter models
bughunter chat
```

## Test plan
- [x] `pytest tests/test_brain_auto_detect.py` (6 passed)
- [ ] `bughunter setup` → option 7 → paste key → connection test
- [ ] `bughunter providers` shows openrouter key set / active
- [ ] `bughunter models` lists `anthropic/claude-sonnet-4.6` first
- [ ] `bughunter chat` returns a normal reply via OpenRouter