### PR TITLE
Improve standalone Ollama setup and lifecycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ### Added
 - **OpenRouter provider** (`openrouter`) for standalone `bughunter` / `brain.py` — set `OPENROUTER_API_KEY`, choose option 7 in `bughunter setup`, or `BRAIN_PROVIDER=openrouter`. OpenAI-compatible gateway with default model `anthropic/claude-sonnet-4.6` and a short curated model list (same pattern as other cloud providers).
+- **Explicit Ollama model selection** — `bughunter setup` now lists installed local models and persists the selected provider/model pair; `bughunter setup --provider ollama --model <name>` supports non-interactive configuration. `--model` / `BRAIN_MODEL` provide one-off overrides, and explicit choices no longer silently fall back to or race a different model.
+- **Standalone installer updates** — rerunning `install.sh --agent standalone` now refreshes the active managed `bughunter` path instead of allowing an older system installation to shadow a newer user-local link, and verifies the updated symlink target.
+- **SDK-free Ollama fallback** — standalone provider setup and chat now use Ollama's local HTTP API when the Python `ollama` package is unavailable; dependency installation failures are reported instead of silently ignored.
+- **Expanded uninstaller** — `uninstall.sh` now covers standalone and every supported agent harness, with managed-file checks, confirmation, configuration preservation by default, explicit `--purge-config` support, and compatibility with its previous `--claude` / `--opencode` / `--both` flags.
 
 ## v4.3.2 — AI Hunt Playbook (Jun 2026)
 

--- a/README.md
+++ b/README.md
@@ -92,6 +92,20 @@ cd claude-bug-bounty
 ./install.sh --agent standalone
 ```
 
+Rerun the same command after pulling updates. The installer detects and
+refreshes the active managed `bughunter` command, including older installations
+under `/usr/local/bin` or `~/.local/bin`, while preserving your saved provider
+configuration in `~/.bughunter/config.json`.
+
+To uninstall the standalone command while keeping its configuration:
+
+```bash
+./uninstall.sh --agent standalone
+```
+
+Use `--purge-config` to also delete `~/.bughunter/config.json`. The uninstaller
+also supports `claude`, `opencode`, `pi`, `codex`, `agents`, and `all` targets.
+
 ```
 bughunter help               # show every command
 bughunter setup              # choose your AI provider (Ollama is free + offline)
@@ -101,6 +115,7 @@ bughunter validate "finding" # 7-Question Gate on your finding
 bughunter report             # write a submission-ready report
 bughunter chat               # interactive AI hunting shell
 bughunter providers          # list all available AI providers
+bughunter models             # list models and show the selected one
 bughunter status             # check which provider is active
 bughunter h target.com       # short alias for hunt
 bughunter r target.com       # short alias for recon
@@ -120,7 +135,18 @@ bughunter v "finding"        # short alias for validate
 
 BugHunter auto-detects providers in this order: **Ollama → Groq → DeepSeek → … → OpenRouter → Claude → OpenAI**
 
-Switch providers anytime: `bughunter setup`
+Switch providers or choose an installed Ollama model anytime: `bughunter setup`.
+The setup can also be fully non-interactive:
+
+```bash
+bughunter setup --provider ollama --model qwen2.5:14b
+```
+
+For a one-off override, put the option before the command:
+
+```bash
+bughunter --provider ollama --model qwen3:14b hunt target.com
+```
 
 ### Zero-cost fully offline setup
 
@@ -135,7 +161,7 @@ cd claude-bug-bounty
 ./install.sh --agent standalone   # creates system-wide 'bughunter' command
 
 # 3. Hunt
-bughunter setup       # choose Ollama
+bughunter setup       # choose Ollama, then choose one of its installed models
 bughunter recon target.com
 ```
 

--- a/agent.py
+++ b/agent.py
@@ -999,14 +999,25 @@ class ReActAgent:
             raise RuntimeError("Ollama Python package not installed: pip install ollama")
 
         self.client = _ollama_lib.Client(host=OLLAMA_HOST)
-        self.model  = model or self._pick_tool_capable_model()
+        requested_model = model or os.environ.get("BRAIN_MODEL") or None
+        self.model  = requested_model or self._pick_tool_capable_model()
         if not self.model:
             raise RuntimeError("No Ollama model available. Pull one: ollama pull qwen2.5:32b")
 
-        # Build race roster: primary model + baron-llm if available and different
+        if requested_model:
+            available = [m.model for m in self.client.list().models]
+            if requested_model not in available:
+                raise RuntimeError(
+                    f"Requested Ollama model '{requested_model}' is not installed. "
+                    f"Run: ollama pull {requested_model}"
+                )
+
+        # Respect an explicit choice exclusively; only auto-race in automatic mode.
         try:
             available = [m.model for m in self.client.list().models]
-            if "baron-llm:latest" in available and "baron-llm:latest" != self.model:
+            if requested_model:
+                self._race_models = [self.model]
+            elif "baron-llm:latest" in available and "baron-llm:latest" != self.model:
                 self._race_models = [self.model, "baron-llm:latest"]
             else:
                 self._race_models = [self.model]
@@ -1432,6 +1443,7 @@ def run_agent_hunt(
     Called by hunt.py when --agent flag is passed.
     """
     h = _h()
+    model = model or os.environ.get("BRAIN_MODEL") or None
 
     # ── Resolve session ───────────────────────────────────────────────────
     session_id, recon_dir = h._activate_recon_session(

--- a/brain.py
+++ b/brain.py
@@ -13,6 +13,10 @@ Provider selection (in order of precedence):
                                perplexity | openrouter)
   2. Auto-detect: uses first provider whose API key / server is available
 
+Model selection:
+  BRAIN_MODEL env var forces one model. For Ollama, an unavailable explicit
+  model fails clearly instead of silently falling back to another local model.
+
 API keys (env vars):
   ANTHROPIC_API_KEY   — Claude (claude-opus-4-8, claude-sonnet-4-6, etc.)
   OPENAI_API_KEY      — OpenAI (gpt-4o, o1, etc.)
@@ -70,6 +74,7 @@ import time
 from datetime import datetime
 from pathlib import Path
 from urllib.parse import urlsplit
+from urllib.request import Request, urlopen
 
 try:
     import ollama as _ollama_lib
@@ -78,6 +83,75 @@ except ImportError:
 
 # ── Config ─────────────────────────────────────────────────────────────────────
 OLLAMA_HOST = os.environ.get("OLLAMA_HOST", "http://localhost:11434")
+
+
+if _ollama_lib is None:
+    class _OllamaModel:
+        def __init__(self, model: str):
+            self.model = model
+
+
+    class _OllamaListResponse:
+        def __init__(self, models: list[str]):
+            self.models = [_OllamaModel(model) for model in models]
+
+
+    class _OllamaHTTPClient:
+        """Small Ollama SDK-compatible fallback using only the standard library."""
+
+        def __init__(self, host: str = OLLAMA_HOST):
+            self.host = host.rstrip("/")
+
+        def _request(self, path: str, payload: dict | None = None) -> dict:
+            data = json.dumps(payload).encode() if payload is not None else None
+            request = Request(
+                f"{self.host}{path}",
+                data=data,
+                headers={"Content-Type": "application/json"},
+                method="POST" if payload is not None else "GET",
+            )
+            with urlopen(request, timeout=120) as response:
+                return json.loads(response.read().decode())
+
+        def list(self) -> _OllamaListResponse:
+            result = self._request("/api/tags")
+            names = [
+                item.get("name") or item.get("model")
+                for item in result.get("models", [])
+            ]
+            return _OllamaListResponse([name for name in names if name])
+
+        def chat(self, *, model: str, messages: list[dict],
+                 options: dict | None = None, stream: bool = False):
+            payload = {
+                "model": model,
+                "messages": messages,
+                "options": options or {},
+                "stream": stream,
+            }
+            if not stream:
+                return self._request("/api/chat", payload)
+
+            def _chunks():
+                request = Request(
+                    f"{self.host}/api/chat",
+                    data=json.dumps(payload).encode(),
+                    headers={"Content-Type": "application/json"},
+                    method="POST",
+                )
+                with urlopen(request, timeout=120) as response:
+                    for line in response:
+                        if line.strip():
+                            yield json.loads(line.decode())
+
+            return _chunks()
+
+
+    class _OllamaHTTPModule:
+        Client = _OllamaHTTPClient
+
+
+    _ollama_lib = _OllamaHTTPModule()
 
 # ── Multi-provider LLM client ──────────────────────────────────────────────────
 # Wraps Ollama, Claude, OpenAI, Grok behind a single .chat() interface.
@@ -122,8 +196,9 @@ class LLMClient:
         "ollama":      None,  # resolved dynamically
     }
 
-    def __init__(self, provider: str | None = None):
+    def __init__(self, provider: str | None = None, model: str | None = None):
         self.provider    = (provider or os.environ.get("BRAIN_PROVIDER", "")).lower()
+        self.model       = model or os.environ.get("BRAIN_MODEL") or None
         self._ollama     = None
         self._http       = None   # requests session for OpenAI-compatible APIs
         self.available   = False
@@ -340,6 +415,7 @@ class LLMClient:
         """Send a chat request; return the assistant reply as a string."""
         if not self.available:
             return ""
+        model = model or self.model
         try:
             if self.provider == "ollama":
                 return self._chat_ollama(model, system, user, max_tokens, temperature)
@@ -558,6 +634,8 @@ def _pick_model(preferred: str = None) -> str | None:
         matches = [m for m in available if m.startswith(preferred)]
         if matches:
             return matches[0]
+        # An explicit request must never silently switch to another model.
+        return None
 
     for candidate in MODEL_PRIORITY:
         if candidate in available:
@@ -591,7 +669,8 @@ class Brain:
     """
 
     def __init__(self, model: str = None, provider: str | None = None):
-        self._llm = LLMClient(provider or os.environ.get("BRAIN_PROVIDER"))
+        model = model or os.environ.get("BRAIN_MODEL") or None
+        self._llm = LLMClient(provider or os.environ.get("BRAIN_PROVIDER"), model=model)
 
         if not self._llm.available:
             print(f"{YELLOW}[!] No LLM provider available. Set BRAIN_PROVIDER and API key, or start Ollama.{NC}")
@@ -604,11 +683,17 @@ class Brain:
         if self._llm.provider == "ollama":
             self.model = _pick_model(model)
             if not self.model:
-                print(f"{YELLOW}[!] No models found in Ollama. Pull one: ollama pull qwen2.5:14b{NC}")
+                if model:
+                    print(f"{YELLOW}[!] Requested Ollama model '{model}' is not installed. "
+                          f"Run: ollama pull {model}{NC}")
+                else:
+                    print(f"{YELLOW}[!] No models found in Ollama. Pull one: ollama pull qwen2.5:14b{NC}")
                 self.enabled = False
                 return
             self.client = self._llm._ollama  # backward compat for code that uses self.client
-            self.triage_model = _pick_triage_model() or self.model
+            # An explicit model choice applies to every task, including triage.
+            # This avoids silently switching to a second local model.
+            self.triage_model = self.model if model else (_pick_triage_model() or self.model)
         else:
             self.model        = model or LLMClient.DEFAULT_MODELS.get(self._llm.provider)
             self.triage_model = self.model

--- a/config.example.json
+++ b/config.example.json
@@ -10,6 +10,10 @@
   "interactsh_server": "oast.pro",
 
   "_brain_comment": "Set BRAIN_PROVIDER env var to force a specific LLM provider. Auto-detect picks the first available.",
+  "_brain_model_comment": "Set BRAIN_MODEL for a one-off model override, or use bughunter setup to save a per-provider choice.",
+  "models": {
+    "ollama": "qwen2.5:14b"
+  },
   "_brain_providers": {
     "ollama":      "OLLAMA_HOST=http://localhost:11434  (free, local)",
     "groq":        "GROQ_API_KEY=...  (free tier — llama-3.3-70b)",

--- a/engine.py
+++ b/engine.py
@@ -153,26 +153,40 @@ def _import_brain():
         sys.exit(1)
 
 
+def _configured_model(cfg: dict, provider: str | None) -> str | None:
+    """Resolve a model override from env or the per-provider saved config."""
+    if os.environ.get("BRAIN_MODEL"):
+        return os.environ["BRAIN_MODEL"]
+    models = cfg.get("models", {})
+    if isinstance(models, dict) and provider:
+        return models.get(provider) or None
+    return None
+
+
 def _get_client(provider: str | None = None):
     """Return an LLMClient, applying saved config if no env override."""
     _, LLMClient = _import_brain()
     cfg = load_config()
-    if not provider and not os.environ.get("BRAIN_PROVIDER"):
-        provider = cfg.get("provider")
+    provider = provider or os.environ.get("BRAIN_PROVIDER") or cfg.get("provider")
     if provider:
         os.environ["BRAIN_PROVIDER"] = provider
-    return LLMClient(provider)
+    model = _configured_model(cfg, provider)
+    if model:
+        os.environ["BRAIN_MODEL"] = model
+    return LLMClient(provider, model=model)
 
 
 def _get_brain(provider: str | None = None):
     """Return a Brain instance."""
     Brain, _ = _import_brain()
     cfg = load_config()
-    if not provider and not os.environ.get("BRAIN_PROVIDER"):
-        provider = cfg.get("provider")
+    provider = provider or os.environ.get("BRAIN_PROVIDER") or cfg.get("provider")
     if provider:
         os.environ["BRAIN_PROVIDER"] = provider
-    return Brain()
+    model = _configured_model(cfg, provider)
+    if model:
+        os.environ["BRAIN_MODEL"] = model
+    return Brain(model=model, provider=provider)
 
 
 def _run_shell(cmd: str, cwd: str | None = None, timeout: int = 3600) -> tuple[bool, str]:
@@ -211,13 +225,26 @@ def cmd_setup(args):
         "7": ("openrouter", "OpenRouter (multi-model)       — needs OPENROUTER_API_KEY"),
     }
 
-    print("Choose your AI backend:\n")
-    for k, (_, desc) in providers.items():
-        print(f"  {k}) {desc}")
-    print()
+    requested_provider = (
+        getattr(args, "setup_provider", None)
+        or getattr(args, "provider", None)
+    )
+    if requested_provider:
+        provider = requested_provider.lower()
+        info(f"Selected provider: {provider}")
+    else:
+        print("Choose your AI backend:\n")
+        for k, (_, desc) in providers.items():
+            print(f"  {k}) {desc}")
+        print()
 
-    choice = input("Enter number [1]: ").strip() or "1"
-    provider = providers.get(choice, ("ollama", ""))[0]
+        choice = input("Enter number [1]: ").strip() or "1"
+        provider = providers.get(choice, ("ollama", ""))[0]
+
+    requested_model = (
+        getattr(args, "setup_model", None)
+        or getattr(args, "model", None)
+    )
 
     cfg = load_config()
     cfg["provider"] = provider
@@ -244,9 +271,6 @@ def cmd_setup(args):
         else:
             warn(f"No {env_var} set — provider may not work")
 
-    save_config(cfg)
-    ok(f"Config saved to {CONFIG}")
-
     # Test connection
     info("Testing connection...")
     _, LLMClient = _import_brain()
@@ -256,10 +280,59 @@ def cmd_setup(args):
     client = LLMClient(provider)
     if client.available:
         ok(f"Connected: {client.description}")
-        reply = client.chat(None, "You are a helpful assistant.",
+        selected_model = None
+        if provider == "ollama":
+            models = client.list_models()
+            if models:
+                if requested_model:
+                    if requested_model not in models:
+                        err(f"Ollama model '{requested_model}' is not installed")
+                        print("  Available models:")
+                        for model_name in models:
+                            print(f"    {model_name}")
+                        print(f"  Install it with: ollama pull {requested_model}")
+                        return
+                    selected_model = requested_model
+                else:
+                    saved_models = cfg.get("models", {})
+                    current = saved_models.get("ollama") if isinstance(saved_models, dict) else None
+                    default_index = models.index(current) + 1 if current in models else 1
+                    print("\nChoose the Ollama model BugHunter should use:\n")
+                    for index, model_name in enumerate(models, start=1):
+                        marker = " (current)" if model_name == current else ""
+                        print(f"  {index}) {model_name}{marker}")
+                    choice = input(f"\nEnter number [{default_index}]: ").strip()
+                    try:
+                        selected_model = models[int(choice or default_index) - 1]
+                    except (ValueError, IndexError):
+                        warn("Invalid model choice — using the default selection")
+                        selected_model = models[default_index - 1]
+                if not isinstance(cfg.get("models"), dict):
+                    cfg["models"] = {}
+                cfg.setdefault("models", {})["ollama"] = selected_model
+                os.environ["BRAIN_MODEL"] = selected_model
+                ok(f"Selected model: {selected_model}")
+            else:
+                warn("No local Ollama models found — pull one, then run setup again")
+        elif requested_model:
+            if not isinstance(cfg.get("models"), dict):
+                cfg["models"] = {}
+            cfg.setdefault("models", {})[provider] = requested_model
+            os.environ["BRAIN_MODEL"] = requested_model
+            selected_model = requested_model
+            ok(f"Selected model: {selected_model}")
+
+        save_config(cfg)
+        ok(f"Config saved to {CONFIG}")
+        reply = client.chat(selected_model, "You are a helpful assistant.",
                             "Reply with exactly: READY", max_tokens=10)
         ok(f"Model responded: {reply.strip()}" if reply else "Connected (no reply — pull a model if using Ollama)")
     else:
+        if not requested_model:
+            save_config(cfg)
+            ok(f"Config saved to {CONFIG}")
+        else:
+            warn("Configuration was not changed because the requested model could not be verified")
         err(f"Provider '{provider}' not available")
         if provider == "ollama":
             print(f"\n  {YELLOW}Install Ollama:{NC}")
@@ -326,9 +399,11 @@ def cmd_models(args):
         return
     models = client.list_models()
     info(f"Provider: {client.description}")
+    selected = _configured_model(cfg, client.provider)
     if models:
         for m in models:
-            print(f"  {GREEN}•{NC} {m}")
+            marker = f" {BOLD}<- selected{NC}" if m == selected else ""
+            print(f"  {GREEN}•{NC} {m}{marker}")
     else:
         warn("No models found")
         if client.provider == "ollama":
@@ -555,7 +630,9 @@ def cmd_status(args):
     print(f"\n  {BOLD}Provider:{NC} ", end="")
     client = _get_client()
     if client.available:
-        print(f"{GREEN}{client.description}{NC}")
+        model = _configured_model(load_config(), client.provider)
+        model_note = f" | model: {model}" if model else " | model: automatic"
+        print(f"{GREEN}{client.description}{model_note}{NC}")
     else:
         print(f"{RED}not configured{NC} — run: ./engine.py setup")
     print()
@@ -630,11 +707,21 @@ def main():
     )
     parser.add_argument("--provider", "-p",
                         help="Force provider: ollama / groq / deepseek / claude / openai / grok / openrouter")
+    parser.add_argument("--model", "-m", help="Force model for this invocation (for example qwen3:14b)")
     parser.add_argument("--no-banner", action="store_true", help="Suppress banner")
 
     sub = parser.add_subparsers(dest="command", metavar="COMMAND")
 
-    sub.add_parser("setup",     aliases=["init"], help="One-time config wizard")
+    p_setup = sub.add_parser("setup", aliases=["init"], help="Configure and persist provider/model")
+    p_setup.add_argument(
+        "--provider", dest="setup_provider",
+        choices=["ollama", "groq", "deepseek", "claude", "openai", "grok", "openrouter"],
+        help="Provider to persist (skips the provider prompt)",
+    )
+    p_setup.add_argument(
+        "--model", dest="setup_model",
+        help="Model to persist; an Ollama model must already be installed",
+    )
     sub.add_parser("providers", aliases=["p"], help="Show all providers + API key status")
     sub.add_parser("models",    aliases=["m"], help="List available models for active provider")
     sub.add_parser("status",    aliases=["s"], help="Show hunt pipeline status")
@@ -665,6 +752,8 @@ def main():
     # Apply provider override
     if getattr(args, "provider", None):
         os.environ["BRAIN_PROVIDER"] = args.provider
+    if getattr(args, "model", None):
+        os.environ["BRAIN_MODEL"] = args.model
 
     # Load saved API keys into environment before any LLM call
     cfg = load_config()

--- a/install.sh
+++ b/install.sh
@@ -15,7 +15,7 @@ Defaults:
   ./install.sh                    Install for Claude Code globally
 
 Standalone (no subscription needed):
-  ./install.sh --agent standalone Install 'bughunter' system command
+  ./install.sh --agent standalone Install or update the 'bughunter' system command
                                   After install, type from anywhere:
                                     bughunter help
                                     bughunter setup
@@ -235,48 +235,72 @@ install_standalone() {
     echo "════════════════════════════════════════════════════"
     echo ""
 
-    REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-    ENGINE="$REPO_DIR/engine.py"
+    local repo_dir engine existing_cmd bin_dir target action
+    local -a install_cmd
+    repo_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    engine="$repo_dir/engine.py"
 
     # Make engine.py executable
-    chmod +x "$ENGINE"
+    chmod +x "$engine"
 
     # ── Install bughunter system command ──────────────────────────────────────
-    # Try /usr/local/bin first (needs sudo on some systems), fall back to ~/.local/bin
-    BIN_DIR=""
-    if [ -w /usr/local/bin ]; then
-        BIN_DIR="/usr/local/bin"
-    elif sudo -n true 2>/dev/null; then
-        BIN_DIR="/usr/local/bin"
-        SUDO="sudo"
+    # Prefer updating the currently active managed installation. This prevents
+    # an old /usr/local/bin entry from shadowing a new ~/.local/bin symlink.
+    existing_cmd="$(command -v bughunter 2>/dev/null || true)"
+    if [ -n "${BBHUNTER_BIN_DIR:-}" ]; then
+        bin_dir="$BBHUNTER_BIN_DIR"
+    elif [ -n "$existing_cmd" ] && [[ -e "$existing_cmd" || -L "$existing_cmd" ]]; then
+        if [ -L "$existing_cmd" ] && [ "$(basename "$(readlink "$existing_cmd")")" = "engine.py" ]; then
+            bin_dir="$(dirname "$existing_cmd")"
+        elif [ -f "$existing_cmd" ] && grep -q "Standalone BugHunter CLI" "$existing_cmd" 2>/dev/null; then
+            bin_dir="$(dirname "$existing_cmd")"
+        elif [ -w /usr/local/bin ]; then
+            bin_dir="/usr/local/bin"
+        else
+            bin_dir="$HOME/.local/bin"
+        fi
+    elif [ -w /usr/local/bin ]; then
+        bin_dir="/usr/local/bin"
     else
-        BIN_DIR="$HOME/.local/bin"
-        mkdir -p "$BIN_DIR"
+        bin_dir="$HOME/.local/bin"
     fi
 
-    SUDO="${SUDO:-}"
-    TARGET="$BIN_DIR/bughunter"
+    target="$bin_dir/bughunter"
+    action="Installed"
+    if [ -e "$target" ] || [ -L "$target" ]; then
+        action="Updated"
+    fi
 
-    # Remove old symlink/file if exists
-    $SUDO rm -f "$TARGET" 2>/dev/null || true
-    $SUDO ln -sf "$ENGINE" "$TARGET"
+    install_cmd=()
+    if [ ! -d "$bin_dir" ] || [ ! -w "$bin_dir" ]; then
+        if command -v sudo >/dev/null 2>&1 && [[ "$bin_dir" == /usr/local/* ]]; then
+            install_cmd=(sudo)
+        else
+            mkdir -p "$bin_dir"
+        fi
+    fi
 
-    if [ -f "$TARGET" ] || [ -L "$TARGET" ]; then
-        echo "[+] Installed: bughunter -> $TARGET"
+    "${install_cmd[@]}" mkdir -p "$bin_dir"
+    "${install_cmd[@]}" ln -sfn "$engine" "$target"
+
+    if [ -L "$target" ] && [ "$(readlink "$target")" = "$engine" ]; then
+        echo "[+] $action: $target -> $engine"
     else
-        echo "[!] Could not install to $BIN_DIR — try: sudo ./install.sh --agent standalone"
+        echo "[!] Could not install or update $target" >&2
+        echo "    Try: sudo ./install.sh --agent standalone" >&2
         echo "    Or add this to ~/.bashrc / ~/.zshrc:"
-        echo "    alias bughunter='python3 $ENGINE'"
+        echo "    alias bughunter='python3 $engine'"
+        return 1
     fi
 
     # ── Check PATH ────────────────────────────────────────────────────────────
-    if ! echo "$PATH" | tr ':' '\n' | grep -q "$BIN_DIR"; then
+    if ! echo "$PATH" | tr ':' '\n' | grep -Fxq "$bin_dir"; then
         echo ""
-        echo "[!] $BIN_DIR is not in your PATH. Add it:"
+        echo "[!] $bin_dir is not in your PATH. Add it:"
         if echo "$SHELL" | grep -q zsh; then
-            echo "    echo 'export PATH=\"$BIN_DIR:\$PATH\"' >> ~/.zshrc && source ~/.zshrc"
+            echo "    echo 'export PATH=\"$bin_dir:\$PATH\"' >> ~/.zshrc && source ~/.zshrc"
         else
-            echo "    echo 'export PATH=\"$BIN_DIR:\$PATH\"' >> ~/.bashrc && source ~/.bashrc"
+            echo "    echo 'export PATH=\"$bin_dir:\$PATH\"' >> ~/.bashrc && source ~/.bashrc"
         fi
     fi
 
@@ -291,9 +315,13 @@ install_standalone() {
     fi
 
     # ── Optional Python deps ──────────────────────────────────────────────────
-    if command -v pip3 &>/dev/null; then
-        echo "Installing optional Python deps (requests, ollama)..."
-        pip3 install --quiet requests ollama 2>/dev/null || true
+    # Ollama setup/chat has a standard-library HTTP fallback, so a distro that
+    # blocks global pip installs still gets a working local provider.
+    if [ "${BBHUNTER_SKIP_DEPS:-0}" != "1" ] && command -v pip3 &>/dev/null; then
+        echo "Installing optional Python deps (cloud providers and agent mode)..."
+        if ! pip3 install --quiet requests ollama 2>/dev/null; then
+            echo "[!] Optional pip packages were not installed; standalone Ollama chat still works via HTTP."
+        fi
     fi
 
     echo ""
@@ -301,6 +329,7 @@ install_standalone() {
     echo "  Done! Type from anywhere:"
     echo ""
     echo "    bughunter setup"
+    echo "    bughunter models"
     echo "    bughunter recon target.com"
     echo "    bughunter hunt  target.com"
     echo "    bughunter validate \"<finding>\""

--- a/tests/test_model_selection.py
+++ b/tests/test_model_selection.py
@@ -1,0 +1,78 @@
+"""Tests for explicit provider model selection."""
+
+import json
+from types import SimpleNamespace
+
+import engine
+import brain
+
+
+def test_configured_model_uses_saved_provider_choice(monkeypatch):
+    monkeypatch.delenv("BRAIN_MODEL", raising=False)
+    cfg = {"provider": "ollama", "models": {"ollama": "qwen3:14b"}}
+
+    assert engine._configured_model(cfg, "ollama") == "qwen3:14b"
+
+
+def test_environment_model_overrides_saved_choice(monkeypatch):
+    monkeypatch.setenv("BRAIN_MODEL", "qwen3:8b")
+    cfg = {"models": {"ollama": "qwen3:14b"}}
+
+    assert engine._configured_model(cfg, "ollama") == "qwen3:8b"
+
+
+def test_provider_model_choices_are_isolated(monkeypatch):
+    monkeypatch.delenv("BRAIN_MODEL", raising=False)
+    cfg = {"models": {"ollama": "qwen3:14b", "groq": "custom-groq"}}
+
+    assert engine._configured_model(cfg, "ollama") == "qwen3:14b"
+    assert engine._configured_model(cfg, "groq") == "custom-groq"
+
+
+def test_explicit_missing_ollama_model_does_not_fall_back(monkeypatch):
+    monkeypatch.setattr(brain, "_get_available_models", lambda: ["qwen3:8b"])
+
+    assert brain._pick_model("missing:latest") is None
+
+
+def test_automatic_ollama_model_still_uses_priority(monkeypatch):
+    monkeypatch.setattr(
+        brain,
+        "_get_available_models",
+        lambda: ["random:latest", "qwen3:8b"],
+    )
+
+    assert brain._pick_model() == "qwen3:8b"
+
+
+def test_setup_persists_explicit_ollama_provider_and_model(monkeypatch, tmp_path):
+    class FakeClient:
+        available = True
+        description = "fake Ollama"
+
+        def __init__(self, provider, model=None):
+            assert provider == "ollama"
+
+        def list_models(self):
+            return ["qwen3:8b", "qwen2.5:14b"]
+
+        def chat(self, model, *args, **kwargs):
+            assert model == "qwen2.5:14b"
+            return "READY"
+
+    config_path = tmp_path / "config.json"
+    monkeypatch.setattr(engine, "CONFIG", config_path)
+    monkeypatch.setattr(engine, "_import_brain", lambda: (object, FakeClient))
+    monkeypatch.delenv("BRAIN_MODEL", raising=False)
+
+    engine.cmd_setup(SimpleNamespace(
+        setup_provider="ollama",
+        setup_model="qwen2.5:14b",
+        provider=None,
+        model=None,
+    ))
+
+    assert json.loads(config_path.read_text()) == {
+        "provider": "ollama",
+        "models": {"ollama": "qwen2.5:14b"},
+    }

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -1,194 +1,256 @@
 #!/bin/bash
-# Bug Bounty Hunter — uninstall skills/commands for Claude Code or OpenCode
+# BugHunter — remove installed skills, commands, agents, and standalone launcher.
 
-set -e
+set -euo pipefail
 
-REPO_ROOT="$(cd "$(dirname "$0")" && pwd)"
+AGENT="${BBHUNT_AGENT:-claude}"
+SCOPE="global"
+ASSUME_YES="no"
+PURGE_CONFIG="no"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-# ─────────────────────────────────────────────────────────────────────────────
-# Helpers
-# ─────────────────────────────────────────────────────────────────────────────
-detect_mode() {
-    if command -v claude >/dev/null 2>&1; then
-        echo "claude"
-    elif command -v opencode >/dev/null 2>&1; then
-        echo "opencode"
-    else
-        echo "claude"
-    fi
+usage() {
+    cat <<'EOF'
+Usage: ./uninstall.sh [--agent claude|opencode|pi|codex|agents|standalone|all] [--global|--project] [options]
+
+Examples:
+  ./uninstall.sh --agent standalone
+  ./uninstall.sh --agent codex --global
+  ./uninstall.sh --agent all --yes
+  ./uninstall.sh --agent standalone --purge-config
+
+Options:
+  --global          Remove global installation (default)
+  --project         Remove project-local installation
+  --purge-config    Also remove ~/.bughunter/config.json
+  -y, --yes         Skip confirmation
+  -h, --help        Show this help
+
+The BugHunter configuration is preserved unless --purge-config is supplied.
+EOF
 }
 
-removed=0
-skipped=0
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        --agent)
+            shift
+            AGENT="${1:?--agent requires a value}"
+            ;;
+        --agent=*) AGENT="${1#*=}" ;;
+        --all) AGENT="all" ;;
+        --claude) AGENT="claude" ;;
+        --opencode) AGENT="opencode" ;;
+        --both) AGENT="claude-opencode" ;;
+        --global) SCOPE="global" ;;
+        --project) SCOPE="project" ;;
+        --purge-config) PURGE_CONFIG="yes" ;;
+        -y|--yes) ASSUME_YES="yes" ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            echo "Unknown option: $1" >&2
+            usage >&2
+            exit 2
+            ;;
+    esac
+    shift
+done
 
-remove_file() {
-    local path="$1"
-    if [ -e "$path" ] || [ -L "$path" ]; then
-        rm -rf "$path"
-        echo "✓ Removed: $path"
-        removed=$((removed + 1))
-    else
-        echo "  (not found, skipping): $path"
-        skipped=$((skipped + 1))
-    fi
-}
-
-# ─────────────────────────────────────────────────────────────────────────────
-# Mode selection
-# ─────────────────────────────────────────────────────────────────────────────
-MODE="${1}"
-case "$MODE" in
-    --claude)
-        MODE="claude"
-        ;;
-    --opencode)
-        MODE="opencode"
-        ;;
-    --both)
-        MODE="both"
-        ;;
+case "$AGENT" in
+    claude|opencode|claude-opencode|pi|codex|agents|generic|standalone|engine|all) ;;
     *)
-        MODE=$(detect_mode)
-        echo "Auto-detected mode: $MODE"
-        echo ""
+        echo "Unsupported agent: $AGENT" >&2
+        usage >&2
+        exit 2
         ;;
 esac
 
-# ─────────────────────────────────────────────────────────────────────────────
-# Claude Code uninstall
-# ─────────────────────────────────────────────────────────────────────────────
-if [[ "$MODE" == "claude" ]] || [[ "$MODE" == "both" ]]; then
-    echo "Uninstalling from Claude Code..."
-    echo ""
-
-    INSTALL_DIR="${HOME}/.claude/skills"
-    COMMANDS_DIR="${HOME}/.claude/commands"
-    AGENTS_DIR="${HOME}/.claude/agents"
-
-    # Remove installed skills
-    for skill_dir in "${REPO_ROOT}/skills/"*/; do
-        skill_name=$(basename "$skill_dir")
-        remove_file "${INSTALL_DIR}/${skill_name}"
-    done
-
-    # Remove installed commands
-    for cmd_file in "${REPO_ROOT}/commands/"*.md; do
-        cmd_name=$(basename "$cmd_file")
-        remove_file "${COMMANDS_DIR}/${cmd_name}"
-    done
-
-    # Remove installed agents
-    for agent_file in "${REPO_ROOT}/agents/"*.md; do
-        agent_name=$(basename "$agent_file")
-        remove_file "${AGENTS_DIR}/${agent_name}"
-    done
-
-    # Clean up empty parent dirs (only if we created them and they're now empty)
-    for dir in "${INSTALL_DIR}" "${COMMANDS_DIR}" "${AGENTS_DIR}"; do
-        if [ -d "$dir" ] && [ -z "$(ls -A "$dir")" ]; then
-            rmdir "$dir"
-            echo "  (removed empty dir): $dir"
-        fi
-    done
-
-    echo ""
-    echo "✓ Claude Code uninstall complete."
-    echo ""
+if [ "$SCOPE" = "project" ] && [[ "$AGENT" == "standalone" || "$AGENT" == "engine" ]]; then
+    echo "Standalone BugHunter is a global command; --project is not applicable." >&2
+    exit 2
 fi
 
-# ─────────────────────────────────────────────────────────────────────────────
-# OpenCode uninstall
-# ─────────────────────────────────────────────────────────────────────────────
-if [[ "$MODE" == "opencode" ]] || [[ "$MODE" == "both" ]]; then
-    echo "Uninstalling from OpenCode..."
-    echo ""
-
-    SKILLS_DIR="${REPO_ROOT}/.opencode/skills"
-    COMMANDS_DIR="${REPO_ROOT}/.opencode/commands"
-    AGENTS_DIR="${REPO_ROOT}/.opencode/agents"
-
-    # Remove symlinked skills
-    for skill_dir in "${REPO_ROOT}/skills/"*/; do
-        skill_name=$(basename "$skill_dir")
-        remove_file "${SKILLS_DIR}/${skill_name}"
-    done
-
-    # Remove copied commands
-    for cmd_file in "${REPO_ROOT}/commands/"*.md; do
-        cmd_name=$(basename "$cmd_file")
-        remove_file "${COMMANDS_DIR}/${cmd_name}"
-    done
-
-    # Remove copied agents
-    for agent_file in "${REPO_ROOT}/agents/"*.md; do
-        agent_name=$(basename "$agent_file")
-        remove_file "${AGENTS_DIR}/${agent_name}"
-    done
-
-    # Clean up empty parent dirs
-    for dir in "${SKILLS_DIR}" "${COMMANDS_DIR}" "${AGENTS_DIR}"; do
-        if [ -d "$dir" ] && [ -z "$(ls -A "$dir")" ]; then
-            rmdir "$dir"
-            echo "  (removed empty dir): $dir"
-        fi
-    done
-
-    # Remove MCP entries from opencode.json
-    OPENCODE_JSON="${REPO_ROOT}/opencode.json"
-    if [ -f "$OPENCODE_JSON" ]; then
-        python3 - "$OPENCODE_JSON" <<'PYEOF'
-import json, os, sys
-
-path = sys.argv[1]
-try:
-    with open(path) as f:
-        config = json.load(f)
-except (json.JSONDecodeError, FileNotFoundError):
-    sys.exit(0)
-
-mcp = config.get("mcp", {})
-known = {"burp", "caido", "hackerone"}
-removed = [k for k in list(mcp) if k in known]
-for k in removed:
-    del mcp[k]
-
-if removed:
-    if not mcp:
-        config.pop("mcp", None)
-    # Remove $schema if config is now empty (just the schema key)
-    if set(config.keys()) <= {"$schema"}:
-        config.pop("$schema", None)
-    with open(path, "w") as f:
-        if config:
-            json.dump(config, f, indent=2)
-            f.write("\n")
-        # If config is empty, remove the file entirely
-    if not config:
-        os.remove(path)
-        print("✓ opencode.json removed (was empty)")
-    else:
-        print("✓ Removed MCP entries from opencode.json:", ", ".join(removed))
-else:
-    print("  (no managed MCP entries found in opencode.json)")
-PYEOF
-        removed=$((removed + 1))
+if [ "$ASSUME_YES" != "yes" ]; then
+    echo "This will uninstall BugHunter components for: $AGENT ($SCOPE)."
+    if [ "$PURGE_CONFIG" = "yes" ]; then
+        echo "The saved provider/model configuration will also be removed."
     else
-        echo "  (not found, skipping): ${OPENCODE_JSON}"
-        skipped=$((skipped + 1))
+        echo "The saved provider/model configuration will be preserved."
+    fi
+    read -r -p "Continue? (y/N): " answer
+    case "$answer" in
+        [Yy]|[Yy][Ee][Ss]) ;;
+        *) echo "Cancelled."; exit 0 ;;
+    esac
+fi
+
+removed=0
+
+remove_path() {
+    local path="$1"
+    local label="$2"
+    if [ -e "$path" ] || [ -L "$path" ]; then
+        rm -rf -- "$path"
+        echo "✓ Removed $label: $path"
+        removed=$((removed + 1))
+    fi
+}
+
+remove_tree_items() {
+    local src_glob="$1"
+    local dest_dir="$2"
+    local label="$3"
+    local item name
+    for item in $src_glob; do
+        [ -e "$item" ] || continue
+        name="$(basename "$item")"
+        remove_path "$dest_dir/$name" "$label"
+    done
+}
+
+remove_files() {
+    local src_glob="$1"
+    local dest_dir="$2"
+    local label="$3"
+    local item name
+    for item in $src_glob; do
+        [ -f "$item" ] || continue
+        name="$(basename "$item")"
+        remove_path "$dest_dir/$name" "$label"
+    done
+}
+
+uninstall_claude() {
+    local root="${1:-}"
+    if [ -z "$root" ]; then
+        if [ "$SCOPE" = "project" ]; then root="$SCRIPT_DIR/.claude"; else root="$HOME/.claude"; fi
+    fi
+    remove_tree_items "$SCRIPT_DIR/skills/*" "$root/skills" "Claude skill"
+    remove_files "$SCRIPT_DIR/commands/*.md" "$root/commands" "Claude command"
+    remove_files "$SCRIPT_DIR/agents/*.md" "$root/agents" "Claude agent"
+}
+
+uninstall_opencode() {
+    local root
+    if [ "$SCOPE" = "project" ]; then
+        root="$SCRIPT_DIR/.opencode"
+    else
+        root="${OPENCODE_CONFIG_DIR:-$HOME/.config/opencode}"
+    fi
+    remove_tree_items "$SCRIPT_DIR/skills/*" "$root/skills" "OpenCode skill"
+    remove_files "$SCRIPT_DIR/commands/*.md" "$root/commands" "OpenCode command"
+    remove_files "$SCRIPT_DIR/agents/*.md" "$root/agents" "OpenCode agent"
+}
+
+uninstall_pi() {
+    local root
+    if [ "$SCOPE" = "project" ]; then root="$SCRIPT_DIR/.pi"; else root="$HOME/.pi/agent"; fi
+    remove_tree_items "$SCRIPT_DIR/skills/*" "$root/skills" "Pi skill"
+    remove_files "$SCRIPT_DIR/commands/*.md" "$root/prompts" "Pi prompt"
+}
+
+uninstall_codex() {
+    local root
+    if [ "$SCOPE" = "project" ]; then root="$SCRIPT_DIR/.codex"; else root="${CODEX_HOME:-$HOME/.codex}"; fi
+    remove_tree_items "$SCRIPT_DIR/skills/*" "$root/skills" "Codex skill"
+    remove_files "$SCRIPT_DIR/commands/*.md" "$root/commands" "Codex command"
+}
+
+uninstall_agents() {
+    local root
+    if [ "$SCOPE" = "project" ]; then root="$SCRIPT_DIR/.agents"; else root="$HOME/.agents"; fi
+    remove_tree_items "$SCRIPT_DIR/skills/*" "$root/skills" "shared skill"
+}
+
+is_managed_bughunter() {
+    local path="$1"
+    if [ -L "$path" ]; then
+        [ "$(basename "$(readlink "$path")")" = "engine.py" ]
+    elif [ -f "$path" ]; then
+        grep -q "Standalone BugHunter CLI" "$path" 2>/dev/null
+    else
+        return 1
+    fi
+}
+
+remove_standalone_path() {
+    local target="$1"
+    local -a remove_cmd=()
+    [ -e "$target" ] || [ -L "$target" ] || return 0
+
+    if ! is_managed_bughunter "$target"; then
+        echo "! Preserved unrelated command: $target"
+        return 0
     fi
 
-    echo ""
-    echo "✓ OpenCode uninstall complete."
-    echo ""
+    if [ ! -w "$(dirname "$target")" ]; then
+        if command -v sudo >/dev/null 2>&1 && [[ "$target" == /usr/local/* ]]; then
+            remove_cmd=(sudo)
+        else
+            echo "! Cannot remove $target (directory is not writable)" >&2
+            return 1
+        fi
+    fi
+
+    "${remove_cmd[@]}" rm -f -- "$target"
+    echo "✓ Removed standalone command: $target"
+    removed=$((removed + 1))
+}
+
+uninstall_standalone() {
+    local active candidate
+    local -a candidates=()
+    if [ -n "${BBHUNTER_BIN_DIR:-}" ]; then
+        # Explicit override is intentionally exclusive, which also makes
+        # packaging/integration tests unable to touch a real installation.
+        candidates+=("$BBHUNTER_BIN_DIR/bughunter")
+    else
+        active="$(command -v bughunter 2>/dev/null || true)"
+        [ -n "$active" ] && candidates+=("$active")
+        candidates+=("/usr/local/bin/bughunter" "$HOME/.local/bin/bughunter")
+    fi
+
+    for candidate in "${candidates[@]}"; do
+        # Skip duplicate paths without requiring associative arrays (bash 3.2).
+        case " ${seen_standalone_paths:-} " in
+            *" $candidate "*) continue ;;
+        esac
+        seen_standalone_paths="${seen_standalone_paths:-} $candidate"
+        remove_standalone_path "$candidate"
+    done
+}
+
+case "$AGENT" in
+    claude) uninstall_claude ;;
+    opencode) uninstall_opencode ;;
+    claude-opencode) uninstall_claude; uninstall_opencode ;;
+    pi) uninstall_pi ;;
+    codex) uninstall_codex ;;
+    agents|generic) uninstall_agents ;;
+    standalone|engine) uninstall_standalone ;;
+    all)
+        uninstall_claude
+        uninstall_opencode
+        uninstall_pi
+        uninstall_codex
+        uninstall_agents
+        uninstall_standalone
+        ;;
+esac
+
+if [ "$PURGE_CONFIG" = "yes" ]; then
+    remove_path "$HOME/.bughunter/config.json" "BugHunter configuration"
+    if [ -d "$HOME/.bughunter" ] && [ -z "$(find "$HOME/.bughunter" -mindepth 1 -maxdepth 1 -print -quit)" ]; then
+        rmdir "$HOME/.bughunter"
+    fi
+else
+    echo "Preserved configuration: $HOME/.bughunter/config.json"
 fi
 
-# ─────────────────────────────────────────────────────────────────────────────
-# Summary
-# ─────────────────────────────────────────────────────────────────────────────
-echo "─────────────────────────────────────────────"
-echo "Summary: ${removed} item(s) removed, ${skipped} already absent."
-echo "─────────────────────────────────────────────"
-echo ""
-echo "Your recon/, memory/, tools/, and wordlists/ directories are untouched."
-echo "To reinstall at any time: ./install.sh"
-echo ""
+if [ "$removed" -eq 0 ]; then
+    echo "No managed BugHunter installation found for the selected target."
+else
+    echo "Done. Removed $removed managed item(s)."
+fi


### PR DESCRIPTION
## What changed

- let `bughunter setup` persist an explicit provider/model pair, including non-interactive `--provider ollama --model <name>` configuration
- propagate the selected model through standalone chat, analysis, triage, and autonomous-agent paths without silently switching or racing another model
- add an SDK-free Ollama HTTP fallback so local setup and chat work when distro-managed Python blocks installation of the `ollama` package
- make rerunning the standalone installer update the active managed `bughunter` command instead of leaving an older command earlier in `PATH`
- expand `uninstall.sh` across standalone, Claude, OpenCode, Pi, Codex, and shared-agent installations, preserving configuration by default
- document the new setup, update, override, and uninstall flows and add model-selection regression coverage

## Why

Standalone Ollama users could choose the provider but not persist the local model. BugHunter then selected models from an internal priority list and could use a different triage/racing model. On distro-managed Python installations, the installer also silently ignored a failed `pip install ollama`, leaving setup unable to connect even while the Ollama daemon was healthy.

This change makes provider/model selection explicit and durable, removes the Python SDK as a requirement for the core standalone flow, and makes installation lifecycle behavior predictable.

## User impact

Users can now run:

```bash
bughunter setup --provider ollama --model qwen2.5:14b
```

The exact installed model is validated, saved, displayed by status/model commands, and reused consistently. Existing standalone installations can be refreshed by rerunning `install.sh`, and removed safely with `uninstall.sh`.

## Validation

- focused provider/model tests: `12 passed`
- full suite: `382 passed, 2 failed`; both failures are existing `tools/bypass_403.sh` expectations in `tests/test_bypass_403_review_fixes.py`, and this branch does not modify that tool
- `python3 -m py_compile engine.py brain.py agent.py tests/test_model_selection.py`
- `bash -n install.sh uninstall.sh`
- `git diff --check`
- isolated installer/uninstaller integration checks, including update detection, config preservation/purge, legacy flags, and unrelated-command protection
- live Ollama setup with `qwen2.5:14b` connected and returned `READY`
