### PR TITLE
feat(brain): add OrcaRouter LLM provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 - **OpenRouter provider** (`openrouter`) for standalone `bughunter` / `brain.py` — set `OPENROUTER_API_KEY`, choose option 7 in `bughunter setup`, or `BRAIN_PROVIDER=openrouter`. OpenAI-compatible gateway with default model `anthropic/claude-sonnet-4.6` and a short curated model list (same pattern as other cloud providers).
+- **OrcaRouter provider** (`orcarouter`) for standalone `bughunter` / `brain.py` — set `ORCAROUTER_API_KEY`, choose option 8 in `bughunter setup`, or `BRAIN_PROVIDER=orcarouter`. OpenAI-compatible gateway with default model `openai/gpt-4o` and a short curated model list (same pattern as other cloud providers).
 - **Explicit Ollama model selection** — `bughunter setup` now lists installed local models and persists the selected provider/model pair; `bughunter setup --provider ollama --model <name>` supports non-interactive configuration. `--model` / `BRAIN_MODEL` provide one-off overrides, and explicit choices no longer silently fall back to or race a different model.
 - **Standalone installer updates** — rerunning `install.sh --agent standalone` now refreshes the active managed `bughunter` path instead of allowing an older system installation to shadow a newer user-local link, and verifies the updated symlink target.
 - **SDK-free Ollama fallback** — standalone provider setup and chat now use Ollama's local HTTP API when the Python `ollama` package is unavailable; dependency installation failures are reported instead of silently ignored.

--- a/README.md
+++ b/README.md
@@ -100,8 +100,9 @@ bughunter v "finding"        # short alias for validate
 | OpenAI | Paid | Cloud | Fast | [platform.openai.com](https://platform.openai.com) |
 | **Grok (xAI)** | Paid | Cloud | Fast | [console.x.ai](https://console.x.ai) → `grok-4.5` |
 | **OpenRouter** | Subscription / pay-as-you-go | Cloud | Fast | [openrouter.ai/keys](https://openrouter.ai/keys) → get API key |
+| **OrcaRouter** | Subscription / pay-as-you-go | Cloud | Fast | [orcarouter.ai](https://www.orcarouter.ai) → get API key |
 
-BugHunter auto-detects providers in this order: **Ollama → Groq → DeepSeek → … → OpenRouter → Claude → OpenAI**
+BugHunter auto-detects providers in this order: **Ollama → Groq → DeepSeek → … → OrcaRouter → OpenRouter → Claude → OpenAI**
 
 Switch providers or choose an installed Ollama model anytime: `bughunter setup`.
 The setup can also be fully non-interactive:

--- a/brain.py
+++ b/brain.py
@@ -5,12 +5,12 @@ from __future__ import annotations
 Brain — Multi-Provider LLM Reasoning Layer for Bug Bounty & VAPT
 Supports: Ollama (local), Claude, OpenAI, Grok, Groq, DeepSeek,
           Gemini, Kimi (Moonshot), Mistral, Together AI, Cerebras, Perplexity,
-          OpenRouter
+          OpenRouter, OrcaRouter
 
 Provider selection (in order of precedence):
   1. BRAIN_PROVIDER env var  (ollama | claude | openai | grok | groq | deepseek |
                                gemini | kimi | mistral | together | cerebras |
-                               perplexity | openrouter)
+                               perplexity | openrouter | orcarouter)
   2. Auto-detect: uses first provider whose API key / server is available
 
 Model selection:
@@ -32,6 +32,7 @@ API keys (env vars):
   CEREBRAS_API_KEY    — Cerebras (fastest inference — llama3.3-70b)
   PERPLEXITY_API_KEY  — Perplexity (sonar-pro — live web search)
   OPENROUTER_API_KEY  — OpenRouter (multi-model gateway — anthropic/claude-sonnet-4.6, etc.)
+  ORCAROUTER_API_KEY  — OrcaRouter (multi-model gateway — openai/gpt-4o, orcarouter/auto, etc.)
   OLLAMA_HOST         — Ollama base URL (default: http://localhost:11434)
 
 Default model priority (uses first available):
@@ -178,7 +179,7 @@ class LLMClient:
     PROVIDER_PRIORITY = [
         "ollama", "groq", "deepseek", "cerebras",
         "gemini", "kimi", "mistral", "together",
-        "perplexity", "openrouter", "claude", "openai", "grok",
+        "perplexity", "orcarouter", "openrouter", "claude", "openai", "grok",
     ]
 
     # Default models per provider
@@ -195,6 +196,7 @@ class LLMClient:
         "cerebras":    "llama3.3-70b",
         "perplexity":  "sonar-pro",
         "openrouter":  "anthropic/claude-sonnet-4.6",
+        "orcarouter":  "openai/gpt-4o",
         "ollama":      None,  # resolved dynamically
     }
 
@@ -241,6 +243,7 @@ class LLMClient:
         "cerebras":    "CEREBRAS_API_KEY",
         "perplexity":  "PERPLEXITY_API_KEY",
         "openrouter":  "OPENROUTER_API_KEY",
+        "orcarouter":  "ORCAROUTER_API_KEY",
     }
 
     def _auto_detect(self) -> str:
@@ -435,6 +438,23 @@ class LLMClient:
             self.available   = True
             self.description = "OpenRouter (multi-model gateway)"
 
+        elif provider == "orcarouter":
+            key = os.environ.get("ORCAROUTER_API_KEY", "")
+            if not key:
+                return
+            import requests
+            self._http = requests.Session()
+            # HTTP-Referer + X-Title are optional OrcaRouter attribution headers
+            self._http.headers.update({
+                "Authorization": f"Bearer {key}",
+                "Content-Type": "application/json",
+                "HTTP-Referer": "https://github.com/shuvonsec/claude-bug-bounty",
+                "X-Title": "BugHunter",
+            })
+            self._api_base   = "https://api.orcarouter.ai/v1"
+            self.available   = True
+            self.description = "OrcaRouter (multi-model gateway)"
+
     def chat(self, model: str | None, system: str, user: str,
              max_tokens: int = 4000, temperature: float = 0.1) -> str:
         """Send a chat request; return the assistant reply as a string."""
@@ -449,7 +469,7 @@ class LLMClient:
             elif self.provider in (
                 "openai", "grok", "groq", "deepseek",
                 "gemini", "kimi", "mistral", "together", "cerebras", "perplexity",
-                "openrouter",
+                "openrouter", "orcarouter",
             ):
                 return self._chat_openai_compat(model, system, user, max_tokens, temperature)
         except Exception as e:
@@ -573,6 +593,17 @@ class LLMClient:
                 "google/gemini-2.0-flash-001",
                 "meta-llama/llama-3.3-70b-instruct",
                 "openrouter/auto",
+            ]
+        elif self.provider == "orcarouter":
+            return [
+                "orcarouter/auto",
+                "openai/gpt-5.5",
+                "openai/gpt-4o",
+                "anthropic/claude-opus-4.8",
+                "google/gemini-3.5-flash",
+                "grok/grok-4.3",
+                "deepseek/deepseek-v4-pro",
+                "qwen/qwen3.7-max",
             ]
         return []
 

--- a/config.example.json
+++ b/config.example.json
@@ -27,6 +27,7 @@
     "claude":      "ANTHROPIC_API_KEY=...  (claude-sonnet-4-6 / opus-4-8)",
     "openai":      "OPENAI_API_KEY=...  (gpt-4o / o1)",
     "grok":        "XAI_API_KEY=...  (grok-4.5 / grok-4.3)",
-    "openrouter":  "OPENROUTER_API_KEY=...  (anthropic/claude-sonnet-4.6 / openai/gpt-4o / …)"
+    "openrouter":  "OPENROUTER_API_KEY=...  (anthropic/claude-sonnet-4.6 / openai/gpt-4o / …)",
+    "orcarouter":  "ORCAROUTER_API_KEY=...  (openai/gpt-4o / orcarouter/auto / …)"
   }
 }

--- a/engine.py
+++ b/engine.py
@@ -16,6 +16,8 @@ Providers (auto-detected, first available wins):
          grok     — set XAI_API_KEY
          openrouter — multi-model gateway, set OPENROUTER_API_KEY
                     get key: https://openrouter.ai/keys
+         orcarouter — multi-model gateway, set ORCAROUTER_API_KEY
+                    get key: https://www.orcarouter.ai
 
 Usage:
   ./engine.py setup                        one-time config wizard
@@ -225,6 +227,7 @@ def cmd_setup(args):
         "5": ("openai",     "OpenAI     (paid)              — needs OPENAI_API_KEY"),
         "6": ("grok",       "Grok/xAI   (paid)              — needs XAI_API_KEY"),
         "7": ("openrouter", "OpenRouter (multi-model)       — needs OPENROUTER_API_KEY"),
+        "8": ("orcarouter", "OrcaRouter (multi-model)       — needs ORCAROUTER_API_KEY"),
     }
 
     requested_provider = (
@@ -258,6 +261,7 @@ def cmd_setup(args):
         "openai":     "OPENAI_API_KEY",
         "grok":       "XAI_API_KEY",
         "openrouter": "OPENROUTER_API_KEY",
+        "orcarouter": "ORCAROUTER_API_KEY",
     }
 
     if provider in env_map:
@@ -358,12 +362,14 @@ def cmd_providers(args):
         "openai":     "OPENAI_API_KEY",
         "grok":       "XAI_API_KEY",
         "openrouter": "OPENROUTER_API_KEY",
+        "orcarouter": "ORCAROUTER_API_KEY",
     }
     tier = {
         "ollama": "FREE (local)", "groq": "FREE tier",
         "deepseek": "cheap",      "claude": "paid",
         "openai": "paid",         "grok": "paid",
         "openrouter": "subscription",
+        "orcarouter": "subscription",
     }
 
     print(f"\n  {'PROVIDER':<12} {'TIER':<16} {'STATUS':<20} {'NOTE'}")
@@ -708,7 +714,7 @@ def main():
         """),
     )
     parser.add_argument("--provider", "-p",
-                        help="Force provider: ollama / groq / deepseek / claude / openai / grok / openrouter")
+                        help="Force provider: ollama / groq / deepseek / claude / openai / grok / openrouter / orcarouter")
     parser.add_argument("--model", "-m", help="Force model for this invocation (for example qwen3:14b)")
     parser.add_argument("--no-banner", action="store_true", help="Suppress banner")
 
@@ -717,7 +723,7 @@ def main():
     p_setup = sub.add_parser("setup", aliases=["init"], help="Configure and persist provider/model")
     p_setup.add_argument(
         "--provider", dest="setup_provider",
-        choices=["ollama", "groq", "deepseek", "claude", "openai", "grok", "openrouter"],
+        choices=["ollama", "groq", "deepseek", "claude", "openai", "grok", "openrouter", "orcarouter"],
         help="Provider to persist (skips the provider prompt)",
     )
     p_setup.add_argument(
@@ -760,7 +766,8 @@ def main():
     # Load saved API keys into environment before any LLM call
     cfg = load_config()
     for env_var in ("GROQ_API_KEY", "DEEPSEEK_API_KEY", "ANTHROPIC_API_KEY",
-                    "OPENAI_API_KEY", "XAI_API_KEY", "OPENROUTER_API_KEY"):
+                    "OPENAI_API_KEY", "XAI_API_KEY", "OPENROUTER_API_KEY",
+                    "ORCAROUTER_API_KEY"):
         if not os.environ.get(env_var) and cfg.get(env_var):
             os.environ[env_var] = cfg[env_var]
 

--- a/tests/test_brain_auto_detect.py
+++ b/tests/test_brain_auto_detect.py
@@ -19,7 +19,7 @@ sys.path.insert(0, ROOT)
 def brain_module(monkeypatch):
     for env in (
         "BRAIN_PROVIDER", "ANTHROPIC_API_KEY", "OPENAI_API_KEY", "XAI_API_KEY",
-        "OPENROUTER_API_KEY",
+        "OPENROUTER_API_KEY", "ORCAROUTER_API_KEY",
     ):
         monkeypatch.delenv(env, raising=False)
     import brain
@@ -128,3 +128,34 @@ def test_openrouter_init_sets_api_base(brain_module, monkeypatch):
     assert "openrouter" in client.description.lower()
     assert brain_module.LLMClient.DEFAULT_MODELS["openrouter"] == "anthropic/claude-sonnet-4.6"
     assert "anthropic/claude-sonnet-4.6" in brain_module.LLMClient.list_models(client)
+
+
+def test_orcarouter_key_jumps_to_front(brain_module, monkeypatch):
+    monkeypatch.setenv("ORCAROUTER_API_KEY", "sk-orca-test")
+    client = brain_module.LLMClient.__new__(brain_module.LLMClient)
+    client.available = False
+    tracker = _Tracker(available_provider="orcarouter")
+    tracker.bind(client)
+
+    chosen = brain_module.LLMClient._auto_detect(client)
+
+    assert chosen == "orcarouter"
+    assert tracker.calls[0] == "orcarouter"
+
+
+def test_orcarouter_init_sets_api_base(brain_module, monkeypatch):
+    monkeypatch.setenv("ORCAROUTER_API_KEY", "sk-orca-test")
+    client = brain_module.LLMClient.__new__(brain_module.LLMClient)
+    client.available = False
+    client._ollama = None
+    client._http = None
+    client.description = ""
+    client.provider = "orcarouter"
+
+    brain_module.LLMClient._init_provider(client, "orcarouter")
+
+    assert client.available is True
+    assert client._api_base == "https://api.orcarouter.ai/v1"
+    assert "orcarouter" in client.description.lower()
+    assert brain_module.LLMClient.DEFAULT_MODELS["orcarouter"] == "openai/gpt-4o"
+    assert "orcarouter/auto" in brain_module.LLMClient.list_models(client)


### PR DESCRIPTION
## Summary

Adds [OrcaRouter](https://www.orcarouter.ai) as a first-class LLM provider for the standalone `bughunter` / `brain.py`, mirroring the existing OpenRouter wiring (same OpenAI-compatible pattern as Groq, Together, Cerebras, etc.). OrcaRouter is an OpenAI-compatible model routing gateway exposing 150+ models from OpenAI, Anthropic, Google, DeepSeek, Qwen, MiniMax, xAI and others behind a single endpoint and API key. It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

I'm an engineer on the OrcaRouter team.

- **`brain.py`**: new `orcarouter` provider (base URL `https://api.orcarouter.ai/v1`, auth via `ORCAROUTER_API_KEY`, optional `HTTP-Referer`/`X-Title` attribution headers) wired into auto-detect priority, the default-model map, `chat()` OpenAI-compatible routing, and a curated `list_models()` set.
- **`engine.py`**: `orcarouter` added to the setup wizard (option 8), the `providers` status list, `--provider` help, and the saved-config API-key loader.
- **`config.example.json`**: `orcarouter` entry in `_brain_providers`.
- **`README.md`**: OrcaRouter row in the provider table and auto-detect order.
- **`CHANGELOG.md`**: Unreleased entry under Added.
- **`tests/test_brain_auto_detect.py`**: `test_orcarouter_key_jumps_to_front` and `test_orcarouter_init_sets_api_base`.

## Type

- [ ] Bug fix
- [x] New feature / scanner module
- [ ] Methodology improvement
- [ ] Documentation
- [ ] False positive reduction

## Test Plan

- [x] `pytest tests/test_brain_auto_detect.py` passes locally (8/8, including the two new OrcaRouter tests)
- [x] Full suite on Windows: 579 passed, 13 pre-existing environment-only failures (GBK codec / `fcntl` / path fixtures — identical on clean `main`)
- [x] No hardcoded targets, API keys, or real domain names
- [x] New functionality has at least one regression test
- [x] Live API test with a real key: `LLMClient("orcarouter")` connects to `https://api.orcarouter.ai/v1` and the default model `openai/gpt-4o` replies correctly

## Related Issue

N/A

## Evidence (for methodology changes)

N/A — provider wiring change; live connectivity verified against the OrcaRouter API.
