### PR TITLE
fix(readme): restore broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -507,11 +507,11 @@ git push origin feature/your-contribution
 ## Star History
 
 <p align="center">
-  <a href="https://www.star-history.com/?repos=shuvonsec%2Fclaude-bug-bounty&type=date&legend=top-left">
+  <a href="https://star-history.dera.page/#shuvonsec/claude-bug-bounty&type=date&legend=top-left">
     <picture>
-      <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=shuvonsec/claude-bug-bounty&type=date&theme=dark&legend=top-left" />
-      <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=shuvonsec/claude-bug-bounty&type=date&legend=top-left" />
-      <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=shuvonsec/claude-bug-bounty&type=date&legend=top-left" width="560" />
+      <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=shuvonsec/claude-bug-bounty&type=date&theme=dark&legend=top-left" />
+      <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=shuvonsec/claude-bug-bounty&type=date&legend=top-left" />
+      <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=shuvonsec/claude-bug-bounty&type=date&legend=top-left" width="560" />
     </picture>
   </a>
 </p>


### PR DESCRIPTION
The star history chart in the README is currently broken and renders nothing, which hurts the project's visibility. Switch the chart to the star-history.dera.page mirror so contributors and visitors can see the repository's growth again.

This replaces the api/star-history.com endpoints with the star-history.dera.page mirror, which uses a token-free data source and serves the chart on the /svg endpoint.