### PR TITLE
docs: lead with Open for Sponsorship + Sponsor button + site credit

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,6 @@
+# Sponsor BugHunter — helps fund new features and keeps the free standalone mode running.
+# Powered by AwareXone.com — https://awarexone.com
+
+custom:
+  - https://awarexone.com
+  - https://www.buymeacoffee.com/shuvonsec

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 ### Added
+- **AwareXone sponsorship & branding** — README now leads with an "Open for Sponsorship" callout and a "Powered by AwareXone.com" credit (hero badge + footer). Same credit added to the project site footer, plus a `.github/FUNDING.yml` so the repo shows a Sponsor button.
 - **OpenRouter provider** (`openrouter`) for standalone `bughunter` / `brain.py` — set `OPENROUTER_API_KEY`, choose option 7 in `bughunter setup`, or `BRAIN_PROVIDER=openrouter`. OpenAI-compatible gateway with default model `anthropic/claude-sonnet-4.6` and a short curated model list (same pattern as other cloud providers).
 - **Explicit Ollama model selection** — `bughunter setup` now lists installed local models and persists the selected provider/model pair; `bughunter setup --provider ollama --model <name>` supports non-interactive configuration. `--model` / `BRAIN_MODEL` provide one-off overrides, and explicit choices no longer silently fall back to or race a different model.
 - **Standalone installer updates** — rerunning `install.sh --agent standalone` now refreshes the active managed `bughunter` path instead of allowing an older system installation to shadow a newer user-local link, and verifies the updated symlink target.

--- a/README.md
+++ b/README.md
@@ -38,13 +38,17 @@
 
 <p align="center">
   <a href="https://awarexone.com">
-    <img src="assets/awarexone-logo.webp" alt="AwareXone" width="88"/>
+    <img src="assets/awarexone-logo.webp" alt="AwareXone" width="80"/>
   </a>
   <br/>
-  <b>Powered by <a href="https://awarexone.com">AwareXone.com</a></b>
-  <br/>
-  <sub>Your AI Agent Against Scams &amp; Fraud</sub>
+  <b>Powered by <a href="https://awarexone.com">AwareXone.com</a></b> — <sub>Your AI Agent Against Scams &amp; Fraud</sub>
 </p>
+
+> ### 💜 Open for Sponsorship
+>
+> **BugHunter is open for sponsorship.** Your support funds new features and keeps the free standalone mode running for everyone. Sponsors get a logo and link right here in the README, plus a credit in every release.
+>
+> **Want to sponsor?** Reach out at **[AwareXone.com](https://awarexone.com)** or email **[shuvonsec@gmail.com](mailto:shuvonsec@gmail.com)**.
 
 ---
 
@@ -538,22 +542,6 @@ If BugHunter helps your hunts, you can fuel more of them:
     <img src="https://cdn.buymeacoffee.com/buttons/v2/default-yellow.png" alt="Buy Me A Coffee" height="50"/>
   </a>
 </p>
-
----
-
-## Open for Sponsorship
-
-<p align="center">
-  <a href="https://awarexone.com">
-    <img src="assets/awarexone-logo.webp" alt="AwareXone" width="72"/>
-  </a>
-</p>
-
-BugHunter is open for sponsorship. Sponsoring helps fund new features and keeps the free standalone mode running for everyone.
-
-Sponsors get a logo and link here in the README, plus a credit in release notes.
-
-Want to sponsor? Get in touch at [AwareXone.com](https://awarexone.com) or email [shuvonsec@gmail.com](mailto:shuvonsec@gmail.com).
 
 ---
 

--- a/site/index.html
+++ b/site/index.html
@@ -1311,10 +1311,13 @@ single request.</div>
       <span>MIT licensed</span>
       <span class="sep">·</span>
       <span>Built by Shuvonsec</span>
+      <span class="sep">·</span>
+      <span>Powered by <a href="https://awarexone.com" target="_blank" rel="noopener" style="color:#7F55FF;text-decoration:none">AwareXone.com</a></span>
     </div>
     <div class="footer-links">
       <a href="https://github.com/shuvonsec/claude-bug-bounty" target="_blank" rel="noopener">GitHub</a>
       <a href="https://x.com/shuvonsec" target="_blank" rel="noopener">X</a>
+      <a href="https://awarexone.com" target="_blank" rel="noopener">AwareXone</a>
     </div>
   </div>
   <div class="footer-disclaimer">


### PR DESCRIPTION
Builds on the merged AwareXone branding (#103) with the sponsorship polish.

## Changes
- **Open for Sponsorship moved to the top** of the README as a clean 💜 callout, right under the banner — removed the old bottom section so it appears once.
- **`.github/FUNDING.yml`** — GitHub now shows a **Sponsor** button (AwareXone.com + Buy Me a Coffee).
- **Site footer credit** — "Powered by AwareXone.com" added to `site/index.html` footer, matching the existing style.
- **CHANGELOG** — noted under Unreleased.

## Notes
- Copy stays short and plain.
- No AI credit in any commit.