### PR TITLE
docs: add Used By section and ADOPTERS.md

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -1,0 +1,13 @@
+# Adopters
+
+Teams, researchers, and projects using **BugHunter**.
+
+Using it? Add yourself with a quick pull request to this file — your name, a link, and a one-line note on how you use it. **Please add real, verifiable entries only.**
+
+| Adopter | Link | How they use BugHunter |
+|---|---|---|
+| AwareXone | https://awarexone.com | Powers and sponsors the project — AI agent against scams & fraud |
+
+---
+
+To add your organization: edit the table above and open a pull request. If you'd rather not be listed publicly, that's completely fine — no pressure.

--- a/README.md
+++ b/README.md
@@ -520,6 +520,20 @@ git push origin feature/your-contribution
 
 ---
 
+## Used By
+
+<p align="center">
+  <a href="https://awarexone.com"><img src="assets/awarexone-logo.webp" alt="AwareXone" width="64"/></a>
+</p>
+
+<p align="center">
+  <b><a href="https://awarexone.com">AwareXone.com</a></b> — Your AI Agent Against Scams &amp; Fraud
+</p>
+
+Using BugHunter in your team, program, or workflow? **Add yourself** — open a PR editing [`ADOPTERS.md`](ADOPTERS.md), or open an [issue](https://github.com/shuvonsec/claude-bug-bounty/issues). Real, verifiable entries only.
+
+---
+
 ## Star History
 
 <p align="center">


### PR DESCRIPTION
- Add a 'Used By' section featuring AwareXone with an invite to add adopters via PR
- Add ADOPTERS.md with a table and 'add yourself' instructions (real entries only)

## Summary

<!-- What does this PR do? One to three bullet points. -->

-
-

## Type

- [ ] Bug fix
- [ ] New feature / scanner module
- [ ] Methodology improvement
- [ ] Documentation
- [ ] False positive reduction

## Test Plan

- [ ] `pytest tests/` passes locally
- [ ] No hardcoded targets, API keys, or real domain names
- [ ] Scanner additions use `[CONFIRMED]` / `[POSSIBLE]` / `[INFORMATIONAL]` confidence states
- [ ] New functionality has at least one regression test

## Related Issue

Closes #

## Evidence (for methodology changes)

<!-- Link to a write-up, CVE, or disclosed report that backs this technique -->
