### PR TITLE
feat: wire naabu/eyewitness/semgrep into /portscan, /screenshot, /sast

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## Unreleased
 
 ### Added
+- **Port/service scanning** (`/portscan`, `tools/port_scanner.py`) — wraps `naabu` with an `smap` passive fallback and flags the non-web services the HTTP-only recon pipeline can't see (Redis, Docker API, exposed DBs, RDP, SMB). Parsing + service classification are pure and unit-tested. Closes a `[registered-not-wired]` gap.
+- **Visual triage / PoC screenshots** (`/screenshot`, `tools/visual_triage.py`) — screenshots live hosts via `eyewitness`/`aquatone`/`httpx -screenshot` into a self-contained HTML gallery that doubles as report evidence. Tool selection, command build, and gallery rendering are unit-tested. Closes a `[registered-not-wired]` gap and the "no automatic PoC capture" gap.
+- **SAST source audit** (`/sast`, `tools/sast_scan.py`) — runs Semgrep security packs over fetched JS/source and normalizes results into the toolkit's severity + `POSSIBLE` confidence model (SAST is a lead, not proof — `/validate` still requires a runtime PoC). Result parsing is unit-tested. Closes a `[registered-not-wired]` gap.
 - **AwareXone sponsorship & branding** — README now leads with an "Open for Sponsorship" callout and a "Powered by AwareXone.com" credit (hero badge + footer). Same credit added to the project site footer, plus a `.github/FUNDING.yml` so the repo shows a Sponsor button.
 - **OpenRouter provider** (`openrouter`) for standalone `bughunter` / `brain.py` — set `OPENROUTER_API_KEY`, choose option 7 in `bughunter setup`, or `BRAIN_PROVIDER=openrouter`. OpenAI-compatible gateway with default model `anthropic/claude-sonnet-4.6` and a short curated model list (same pattern as other cloud providers).
 - **OrcaRouter provider** (`orcarouter`) for standalone `bughunter` / `brain.py` — set `ORCAROUTER_API_KEY`, choose option 8 in `bughunter setup`, or `BRAIN_PROVIDER=orcarouter`. OpenAI-compatible gateway with default model `openai/gpt-4o` and a short curated model list (same pattern as other cloud providers).

--- a/README.md
+++ b/README.md
@@ -228,6 +228,8 @@ Verify /recon /hunt /validate /report are available.
 | `/takeover --recon <dir>` | Subdomain takeover candidates via dnsReaper · subjack |
 | `/scan-cves <host>` | Focused nuclei high/critical sweep + optional log4j-scan |
 | `/bypass-403 <url>` | Header · method · encoding tricks against 403/401 |
+| `/portscan <host>` | Open ports + non-web services (Redis · Docker API · DBs · RDP) via naabu/smap |
+| `/screenshot -l urls.txt` | Screenshot live hosts into an HTML gallery — triage + PoC evidence |
 
 
 ### Scanners (Web + LLM)
@@ -239,6 +241,7 @@ Verify /recon /hunt /validate /report are available.
 | `/nosqli <url>` | NoSQL injection (operator bypass · `$where` timing) |
 | `/jwt-scan <token>` | Offline JWT toolkit — alg:none · RS256→HS256 · secret crack |
 | `/oob <target>` | Out-of-band listener (interactsh) for blind SSRF/XXE/SQLi |
+| `/sast <path>` | Semgrep security packs over fetched JS/source → ranked sinks |
 | `/llm-redteam <endpoint>` | LLM red-team corpus — prompt injection · jailbreak · exfil |
 
 ### Smart Contract (Web3)

--- a/commands/portscan.md
+++ b/commands/portscan.md
@@ -1,0 +1,56 @@
+---
+description: Scan a host for open ports and flag the NON-HTTP services the HTTP-only recon pipeline can't see (SSH, databases, Redis, Docker API, RDP). Usage: /portscan <host> [--top 1000] [-p 22,6379] | /portscan -l hosts.txt
+---
+
+# /portscan
+
+The main recon pipeline is HTTP-only (httpx / nuclei / katana), so open ports
+that don't speak HTTP are invisible. This maps the full service surface and
+pulls the interesting, often-forgotten ports to the top — the ones that turn
+into instant wins.
+
+## Usage
+
+```
+/portscan target.com                 # top-100 ports
+/portscan target.com --top 1000
+/portscan target.com -p 22,6379,27017
+/portscan -l recon/target.com/subdomains/resolved.txt --json
+/portscan target.com --smap          # passive (Shodan) — no packets sent
+```
+
+Run directly:
+
+```bash
+tools/port_scanner.py target.com --top 1000
+```
+
+## Tooling
+
+Wraps ProjectDiscovery's **naabu** (fast SYN/CONNECT scan), falling back to
+**smap** (Shodan-backed, sends no packets — handy when active scanning is out of
+scope). Both are registered in `tools/external_arsenal.sh`. If neither is
+installed the command prints install hints and exits cleanly.
+
+## What it flags
+
+Any open, non-web port with a known attack surface, e.g.:
+
+| Port | Service | Why it matters |
+|---|---|---|
+| 6379 | redis | unauth → RCE / full data dump |
+| 2375 | docker | unauth Docker API → instant host RCE |
+| 27017 | mongodb | unauth → database dump |
+| 9200 | elasticsearch | unauth → index dump |
+| 3306 / 5432 / 1433 | mysql / postgres / mssql | database exposed to the internet |
+| 3389 | rdp | weak creds / BlueKeep-class |
+| 445 | smb | null session / EternalBlue-class |
+
+Web ports (80/443/8080/…) are counted but not flagged — the rest of the
+pipeline already covers those.
+
+## Chain
+
+`/portscan` → non-web service found → pivot with the matching technique (e.g.
+unauth Redis → `CONFIG SET` webshell, exposed DB → dump, Docker API → container
+escape). Feed resolved subdomains from `/recon` straight in with `-l`.

--- a/commands/sast.md
+++ b/commands/sast.md
@@ -1,0 +1,52 @@
+---
+description: Run Semgrep security rulesets over fetched JS/source and map results into the toolkit's severity + confidence model. Usage: /sast <path> [--config p/xss,p/jwt] [--json]
+---
+
+# /sast
+
+Recon downloads JS bundles and (sometimes) leaked source, but nothing runs a
+real static analyzer over it — the skills' grep patterns get eyeballed by hand.
+This drives **Semgrep** across that source and normalizes every hit into this
+toolkit's states so findings drop straight into the validation gate.
+
+## Usage
+
+```
+/sast recon/target.com/js/                 # default security packs
+/sast app/ --config p/xss,p/jwt
+/sast app.js --json
+```
+
+Run directly:
+
+```bash
+tools/sast_scan.py recon/target.com/js/
+```
+
+## Rulesets
+
+Default packs (Semgrep Registry): `p/security-audit`, `p/secrets`, `p/xss`,
+`p/sql-injection`, `p/command-injection`. Override with `--config`. Registered
+in `tools/external_arsenal.sh` as `semgrep|sast`; if Semgrep isn't installed the
+command prints the install hint and exits cleanly.
+
+## Severity mapping
+
+| Semgrep | Toolkit | Notes |
+|---|---|---|
+| `ERROR` | HIGH | |
+| `WARNING` | MEDIUM | bumped to HIGH for sql-injection / rce / ssrf / secret / xxe / path-traversal rules |
+| `INFO` | INFORMATIONAL | not a vulnerability on its own |
+
+## Confidence — read this
+
+Every SAST hit is tagged **`POSSIBLE`**, never `CONFIRMED`. Static analysis is a
+*lead*, not proof: a flagged sink still needs a live request that demonstrates
+impact before it goes in a report. `/validate` enforces this — no runtime PoC,
+no submission. Use `/sast` to point `/hunt` at the right lines fast, not to file
+findings directly.
+
+## Chain
+
+`/recon` → JS/source pulled → `/sast` → ranked sink list → `/hunt` the HIGH
+sinks → `/validate` with a real PoC → `/report`.

--- a/commands/screenshot.md
+++ b/commands/screenshot.md
@@ -1,0 +1,50 @@
+---
+description: Screenshot a list of live hosts for fast visual triage and reusable PoC evidence. Builds a self-contained HTML gallery. Usage: /screenshot -l urls.txt -o shots/ | /screenshot -u https://admin.target.com -o shots/
+---
+
+# /screenshot
+
+Reading 400 URLs in a text file is slow. A screenshot gallery surfaces login
+panels, default installs, stack-trace error pages, and forgotten dev/staging
+boxes in seconds — and the same captures become report evidence, so you never
+scramble for a PoC screenshot later.
+
+## Usage
+
+```
+/screenshot -l recon/target.com/live/urls.txt -o shots/
+/screenshot -u https://admin.target.com -o shots/
+/screenshot -l urls.txt -o shots/ --tool aquatone --json
+```
+
+Run directly:
+
+```bash
+tools/visual_triage.py -l recon/target.com/live/urls.txt -o shots/
+```
+
+## Tooling
+
+Uses whichever screenshotter is installed, in order:
+
+1. **eyewitness** — richest per-host report
+2. **aquatone** — fast, clusters similar pages together
+3. **httpx `-screenshot`** — already a core dependency, so this always works
+
+All three are registered in `tools/external_arsenal.sh`. Output always includes
+a self-contained `gallery.html` (no external assets) you can open locally or
+attach to a report.
+
+## Output
+
+```
+shots/
+├── gallery.html          # open this — thumbnail grid, each labeled with its URL
+└── <tool output>         # individual full-size PNGs
+```
+
+## Chain
+
+`/recon` → live URLs → `/screenshot` → eyeball the grid → send anything odd
+(admin panel, debug page, default cred screen) straight to `/hunt`. Reuse the
+captured PNGs as the evidence attachment in `/report`.

--- a/docs/CAPABILITY-GAPS.md
+++ b/docs/CAPABILITY-GAPS.md
@@ -133,10 +133,12 @@ param discovery, 403 bypass, CVE sweep.
 
 **Missing capabilities:**
 
-- **No active port/service scanning wired in** — `naabu` and `smap` are [registered-not-wired];
-  recon is HTTP-only, so non-web services on a host are invisible.
-- **No visual triage** — `eyewitness` and `aquatone` are [registered-not-wired]; no screenshot
-  gallery for fast surface review (also doubles as PoC capture).
+- **No active port/service scanning wired in** — ✅ SHIPPED (`/portscan`, `tools/port_scanner.py`):
+  wraps `naabu` with an `smap` (passive) fallback and flags the non-web services (Redis, Docker
+  API, exposed DBs, RDP, SMB) the HTTP pipeline can't see. Was [registered-not-wired].
+- **No visual triage** — ✅ SHIPPED (`/screenshot`, `tools/visual_triage.py`): screenshots live
+  hosts via `eyewitness`/`aquatone`/`httpx -screenshot` into a self-contained HTML gallery that
+  doubles as report PoC evidence. Was [registered-not-wired].
 - **No Shodan/Censys/favicon-hash** asset discovery, **no ASN/CIDR → IP-range** expansion.
   [no coverage]
 - **No JS source-map extraction / deobfuscation** beyond secret-grepping. `linkfinder` is
@@ -144,8 +146,9 @@ param discovery, 403 bypass, CVE sweep.
 
 ## Cross-cutting / Others
 
-- **SAST source audit** — `semgrep` is [registered-not-wired]. Grep patterns live in skills, but
-  no Semgrep/CodeQL ruleset is run against fetched source.
+- **SAST source audit** — ✅ SHIPPED (`/sast`, `tools/sast_scan.py`): runs `semgrep` security
+  packs over fetched JS/source and normalizes hits into the toolkit's severity + `POSSIBLE`
+  confidence model. Was [registered-not-wired]. (A CodeQL ruleset would still add depth.)
 - **API-spec-driven testing** — recon ingests OpenAPI/Postman specs, but nothing auto-generates
   IDOR/auth tests from a spec. [no coverage]
 - **No thick-client / desktop (Electron-binary), IoT/firmware, or network-pivot** capability —

--- a/tests/test_port_scanner.py
+++ b/tests/test_port_scanner.py
@@ -1,0 +1,72 @@
+"""Tests for tools/port_scanner.py — pure parsing + service classification."""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from tools.port_scanner import (
+    build_naabu_cmd,
+    classify,
+    parse_naabu,
+    summarize,
+)
+
+
+def test_classify_flags_known_non_web_service():
+    r = classify("target.com", 6379)
+    assert r.service == "redis"
+    assert r.is_interesting is True
+    assert r.is_web is False
+
+
+def test_classify_web_port_is_not_interesting():
+    r = classify("target.com", 443)
+    assert r.is_web is True
+    assert r.is_interesting is False
+
+
+def test_classify_unknown_port_has_no_note():
+    r = classify("target.com", 49152)
+    assert r.service == ""
+    assert r.is_interesting is False
+
+
+def test_parse_naabu_plain_lines():
+    text = "target.com:22\ntarget.com:443\n10.0.0.1:6379\n"
+    results = parse_naabu(text)
+    assert len(results) == 3
+    assert ("target.com", 22) in [(r.host, r.port) for r in results]
+
+
+def test_parse_naabu_dedupes_and_ignores_junk():
+    text = "target.com:22\n\n# comment\ntarget.com:22\nnotaport\n"
+    results = parse_naabu(text)
+    assert len(results) == 1
+
+
+def test_parse_naabu_tolerates_json_lines():
+    text = '{"host":"target.com","port":27017}\n'
+    results = parse_naabu(text)
+    assert results and results[0].port == 27017
+    assert results[0].service == "mongodb"
+
+
+def test_summarize_pulls_interesting_to_top():
+    results = parse_naabu("t:80\nt:443\nt:6379\nt:3306\n")
+    s = summarize(results)
+    assert s["total_open"] == 4
+    assert s["web"] == 2
+    assert s["interesting"] == 2
+    assert {f["port"] for f in s["flagged"]} == {6379, 3306}
+
+
+def test_build_naabu_cmd_top_ports_vs_explicit():
+    assert "-top-ports" in build_naabu_cmd("t", None, 100, False)
+    cmd = build_naabu_cmd("t", "22,80", 100, False)
+    assert "-port" in cmd and "22,80" in cmd
+
+
+def test_build_naabu_cmd_list_mode():
+    cmd = build_naabu_cmd("hosts.txt", None, 100, True)
+    assert "-list" in cmd and "hosts.txt" in cmd

--- a/tests/test_sast_scan.py
+++ b/tests/test_sast_scan.py
@@ -1,0 +1,65 @@
+"""Tests for tools/sast_scan.py — pure semgrep cmd build + result normalization."""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from tools.sast_scan import (
+    build_cmd,
+    parse_semgrep,
+    summarize,
+)
+
+
+def _result(check_id, severity, path="app.js", line=1, message="msg"):
+    return {
+        "check_id": check_id,
+        "path": path,
+        "start": {"line": line},
+        "extra": {"severity": severity, "message": message},
+    }
+
+
+def test_build_cmd_uses_json_and_each_config():
+    cmd = build_cmd("app/", ["p/xss", "p/secrets"])
+    assert "--json" in cmd and cmd[-1] == "app/"
+    assert cmd.count("--config") == 2
+
+
+def test_parse_maps_error_to_high():
+    fs = parse_semgrep({"results": [_result("rules.generic-xss", "ERROR")]})
+    assert fs[0].severity == "HIGH"
+    assert fs[0].confidence == "POSSIBLE"
+
+
+def test_parse_bumps_high_signal_warning_to_high():
+    fs = parse_semgrep({"results": [_result("py.sql-injection.foo", "WARNING")]})
+    assert fs[0].severity == "HIGH"
+
+
+def test_parse_plain_warning_stays_medium():
+    fs = parse_semgrep({"results": [_result("style.no-var", "WARNING")]})
+    assert fs[0].severity == "MEDIUM"
+
+
+def test_parse_info_is_informational():
+    fs = parse_semgrep({"results": [_result("audit.note", "INFO")]})
+    assert fs[0].severity == "INFORMATIONAL"
+
+
+def test_parse_dedupes_same_rule_path_line():
+    obj = {"results": [_result("r", "ERROR"), _result("r", "ERROR")]}
+    assert len(parse_semgrep(obj)) == 1
+
+
+def test_summarize_counts_by_severity():
+    fs = parse_semgrep({"results": [
+        _result("a.sql-injection", "WARNING"),
+        _result("b.xss", "ERROR"),
+        _result("c.note", "INFO", line=5),
+    ]})
+    s = summarize(fs)
+    assert s["total"] == 3
+    assert s["high"] == 2
+    assert s["informational"] == 1

--- a/tests/test_visual_triage.py
+++ b/tests/test_visual_triage.py
@@ -1,0 +1,49 @@
+"""Tests for tools/visual_triage.py — pure tool-selection, cmd build, gallery."""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from tools.visual_triage import (
+    Shot,
+    build_cmd,
+    pick_tool,
+    render_html,
+)
+
+
+def test_pick_tool_prefers_priority_order():
+    assert pick_tool(None, {"httpx", "aquatone"}) == "aquatone"
+    assert pick_tool(None, {"httpx"}) == "httpx"
+    assert pick_tool(None, set()) is None
+
+
+def test_pick_tool_honors_explicit_preference():
+    assert pick_tool("httpx", {"httpx", "eyewitness"}) == "httpx"
+
+
+def test_pick_tool_missing_preference_returns_none():
+    assert pick_tool("eyewitness", {"httpx"}) is None
+
+
+def test_build_cmd_per_tool():
+    assert build_cmd("eyewitness", "urls.txt", "out")[:1] == ["eyewitness"]
+    assert "-out" in build_cmd("aquatone", "urls.txt", "out")
+    hx = build_cmd("httpx", "urls.txt", "out")
+    assert "-screenshot" in hx and "urls.txt" in hx
+
+
+def test_build_cmd_unknown_tool_raises():
+    try:
+        build_cmd("nope", "urls.txt", "out")
+    except ValueError:
+        return
+    assert False, "expected ValueError"
+
+
+def test_render_html_is_self_contained():
+    html = render_html([Shot("https://a.com", "a.png"), Shot("https://b.com", "b.png")])
+    assert "http" not in html.split("<style>")[1].split("</style>")[0]  # no remote assets in CSS
+    assert "a.png" in html and "https://b.com" in html
+    assert html.startswith("<!doctype html>")

--- a/tools/port_scanner.py
+++ b/tools/port_scanner.py
@@ -1,0 +1,218 @@
+#!/usr/bin/env python3
+"""
+Port / service scanner — exposes the NON-HTTP attack surface recon misses.
+
+The main pipeline is HTTP-only (httpx/nuclei/katana), so open ports that don't
+speak HTTP — SSH, databases, Redis, SMTP, RDP, admin panels on odd ports — are
+invisible to the rest of the toolkit. This wraps ProjectDiscovery's `naabu`
+(registered in external_arsenal as `naabu|probe`) with an `smap` fallback
+(Shodan-backed, no packets) and turns raw `host:port` output into a surface map
+that flags the interesting, often-forgotten services.
+
+Parsing + service classification are pure and unit-tested; only `scan()` shells
+out to naabu/smap.
+
+Usage:
+  tools/port_scanner.py target.com                 # top-100 ports via naabu
+  tools/port_scanner.py target.com --top 1000
+  tools/port_scanner.py target.com -p 22,6379,27017
+  tools/port_scanner.py -l hosts.txt --json
+  tools/port_scanner.py target.com --smap          # passive (Shodan) fallback
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import subprocess
+import sys
+from dataclasses import dataclass, asdict
+from pathlib import Path
+
+USER_AGENT = "claude-bug-bounty/port_scanner"
+
+# port -> (service, note). Anything here that is NOT 80/443 is worth a second
+# look because the HTTP pipeline never touched it.
+KNOWN_SERVICES: dict[int, tuple[str, str]] = {
+    21: ("ftp", "anon login / creds"),
+    22: ("ssh", "weak creds / exposed key auth"),
+    23: ("telnet", "cleartext admin"),
+    25: ("smtp", "open relay / user enum"),
+    53: ("dns", "zone transfer / recursion"),
+    110: ("pop3", "cleartext mail"),
+    135: ("msrpc", "windows rpc"),
+    139: ("netbios", "smb enum"),
+    445: ("smb", "null session / eternalblue-class"),
+    1433: ("mssql", "db exposed to internet"),
+    1521: ("oracle", "db exposed to internet"),
+    2375: ("docker", "UNAUTH docker API — instant RCE"),
+    3306: ("mysql", "db exposed to internet"),
+    3389: ("rdp", "bluekeep / weak creds"),
+    5432: ("postgres", "db exposed to internet"),
+    5900: ("vnc", "no-auth remote desktop"),
+    6379: ("redis", "UNAUTH redis — RCE / data dump"),
+    8009: ("ajp", "ghostcat / tomcat"),
+    9200: ("elasticsearch", "UNAUTH index dump"),
+    11211: ("memcached", "UNAUTH / DDoS amp"),
+    27017: ("mongodb", "UNAUTH db dump"),
+}
+
+# Ports that usually just mean "there's a web app here" — recon already has these.
+WEB_PORTS = {80, 443, 8080, 8443, 8000, 8888}
+
+
+@dataclass
+class PortResult:
+    host: str
+    port: int
+    service: str = ""
+    note: str = ""
+
+    @property
+    def is_web(self) -> bool:
+        return self.port in WEB_PORTS
+
+    @property
+    def is_interesting(self) -> bool:
+        """Open, non-web, and a service we have an attack note for."""
+        return not self.is_web and self.port in KNOWN_SERVICES
+
+
+def classify(host: str, port: int) -> PortResult:
+    """Pure: attach the known service/note (if any) to a host:port."""
+    service, note = KNOWN_SERVICES.get(port, ("", ""))
+    return PortResult(host=host, port=port, service=service, note=note)
+
+
+def parse_naabu(text: str) -> list[PortResult]:
+    """Parse naabu's default `host:port` lines (one per line). Ignores JSON,
+    blanks, and comments so it also tolerates `-json` accidentally left off."""
+    out: list[PortResult] = []
+    seen: set[tuple[str, int]] = set()
+    for raw in text.splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        if line.startswith("{"):  # tolerate -json lines
+            try:
+                obj = json.loads(line)
+                host, port = obj.get("host") or obj.get("ip"), obj.get("port")
+            except (ValueError, TypeError):
+                continue
+        else:
+            host, _, port_s = line.rpartition(":")
+            if not host or not port_s.isdigit():
+                continue
+            port = int(port_s)
+        if host is None or port is None:
+            continue
+        key = (host, int(port))
+        if key in seen:
+            continue
+        seen.add(key)
+        out.append(classify(host, int(port)))
+    return out
+
+
+def summarize(results: list[PortResult]) -> dict:
+    """Pure: counts + the interesting (non-web) services pulled to the top."""
+    interesting = [r for r in results if r.is_interesting]
+    return {
+        "total_open": len(results),
+        "web": sum(1 for r in results if r.is_web),
+        "interesting": len(interesting),
+        "hosts": len({r.host for r in results}),
+        "flagged": [asdict(r) for r in interesting],
+    }
+
+
+def build_naabu_cmd(target: str, ports: str | None, top: int, is_list: bool) -> list[str]:
+    cmd = ["naabu", "-silent"]
+    cmd += ["-list", target] if is_list else ["-host", target]
+    if ports:
+        cmd += ["-port", ports]
+    else:
+        cmd += ["-top-ports", str(top)]
+    return cmd
+
+
+def build_smap_cmd(target: str, is_list: bool) -> list[str]:
+    # smap is nmap-compatible; -oG - streams greppable output to stdout.
+    return ["smap", "-iL", target] if is_list else ["smap", target]
+
+
+def _binary(prefer_smap: bool) -> str | None:
+    order = ["smap", "naabu"] if prefer_smap else ["naabu", "smap"]
+    for b in order:
+        if shutil.which(b):
+            return b
+    return None
+
+
+def scan(target: str, ports: str | None, top: int, is_list: bool, prefer_smap: bool) -> list[PortResult]:
+    binary = _binary(prefer_smap)
+    if binary is None:
+        raise FileNotFoundError("naabu")
+    if binary == "smap":
+        cmd = build_smap_cmd(target, is_list)
+    else:
+        cmd = build_naabu_cmd(target, ports, top, is_list)
+    proc = subprocess.run(cmd, capture_output=True, text=True, timeout=1800)
+    return parse_naabu(proc.stdout)
+
+
+def _render(results: list[PortResult], as_json: bool) -> str:
+    summary = summarize(results)
+    if as_json:
+        return json.dumps({"summary": summary, "ports": [asdict(r) for r in results]}, indent=2)
+    lines = [
+        f"[*] {summary['total_open']} open ports on {summary['hosts']} host(s) "
+        f"— {summary['web']} web, {summary['interesting']} non-web flagged",
+    ]
+    for r in sorted(results, key=lambda x: (x.host, x.port)):
+        tag = f"  <- {r.service}: {r.note}" if r.is_interesting else ""
+        lines.append(f"    {r.host}:{r.port}{tag}")
+    if summary["interesting"]:
+        lines.append("")
+        lines.append("[!] Non-web services the HTTP pipeline can't see — start here.")
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description="Port/service scanner (naabu, smap fallback).")
+    src = ap.add_mutually_exclusive_group(required=True)
+    src.add_argument("target", nargs="?", help="host, IP, or CIDR")
+    src.add_argument("-l", "--list", dest="list_file", help="file of hosts, one per line")
+    ap.add_argument("-p", "--port", help="explicit ports, e.g. 22,6379,27017")
+    ap.add_argument("--top", type=int, default=100, help="top-N ports (default 100)")
+    ap.add_argument("--smap", action="store_true", help="prefer passive smap (Shodan, no packets)")
+    ap.add_argument("--json", action="store_true", help="JSON output")
+    args = ap.parse_args(argv)
+
+    target = args.list_file or args.target
+    is_list = bool(args.list_file)
+    if is_list and not Path(target).is_file():
+        print(f"[-] host list not found: {target}", file=sys.stderr)
+        return 2
+
+    try:
+        results = scan(target, args.port, args.top, is_list, args.smap)
+    except FileNotFoundError:
+        print(
+            "[-] neither `naabu` nor `smap` is installed.\n"
+            "    naabu: GOBIN=$HOME/go/bin go install "
+            "github.com/projectdiscovery/naabu/v2/cmd/naabu@latest\n"
+            "    smap : GOBIN=$HOME/go/bin go install github.com/s0md3v/smap/cmd/smap@latest",
+            file=sys.stderr,
+        )
+        return 127
+    except subprocess.TimeoutExpired:
+        print("[-] port scan timed out (30m).", file=sys.stderr)
+        return 124
+
+    print(_render(results, args.json))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/sast_scan.py
+++ b/tools/sast_scan.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python3
+"""
+SAST source audit — run Semgrep over fetched JS/source instead of manual grep.
+
+Recon pulls down JS bundles and (sometimes) leaked source, but nothing runs a
+real static analyzer against it — the skills' grep patterns are eyeballed by
+hand. This wraps `semgrep` (registered `semgrep|sast`) with security-focused
+rulesets and maps its output into this toolkit's severity vocabulary so findings
+drop straight into the validation gate.
+
+Command construction + result parsing/normalization are pure and unit-tested;
+only `run()` shells out to semgrep.
+
+Usage:
+  tools/sast_scan.py recon/target.com/js/            # security-audit ruleset
+  tools/sast_scan.py app/ --config p/xss,p/jwt
+  tools/sast_scan.py app.js --json
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import subprocess
+import sys
+from dataclasses import dataclass, asdict
+from pathlib import Path
+
+# Default rulesets — Semgrep Registry packs that map cleanly to bounty classes.
+DEFAULT_CONFIGS = ["p/security-audit", "p/secrets", "p/xss", "p/sql-injection", "p/command-injection"]
+
+# Semgrep severity -> this toolkit's states (see triage-validation SKILL.md).
+SEVERITY_MAP = {"ERROR": "HIGH", "WARNING": "MEDIUM", "INFO": "INFORMATIONAL"}
+# Rule-id fragments that warrant bumping a WARNING up to HIGH.
+HIGH_SIGNAL = ("sql-injection", "command-injection", "ssrf", "rce", "deserial",
+               "path-traversal", "hardcoded", "secret", "xxe")
+
+
+@dataclass
+class SastFinding:
+    rule_id: str
+    severity: str
+    path: str
+    line: int
+    message: str
+
+    @property
+    def confidence(self) -> str:
+        """POSSIBLE by default — SAST is signal, not proof. The validation gate
+        still requires a runtime PoC before anything is reported."""
+        return "POSSIBLE"
+
+
+def build_cmd(path: str, configs: list[str]) -> list[str]:
+    cmd = ["semgrep", "--json", "--quiet", "--disable-version-check", "--timeout", "60"]
+    for c in configs:
+        cmd += ["--config", c]
+    cmd.append(path)
+    return cmd
+
+
+def _normalize_severity(rule_id: str, raw: str) -> str:
+    sev = SEVERITY_MAP.get((raw or "").upper(), "MEDIUM")
+    if sev == "MEDIUM" and any(sig in rule_id.lower() for sig in HIGH_SIGNAL):
+        return "HIGH"
+    return sev
+
+
+def parse_semgrep(obj: dict) -> list[SastFinding]:
+    """Pure: turn semgrep --json into normalized findings, de-duped by
+    (rule, path, line) so the same rule firing repeatedly isn't noise."""
+    out: list[SastFinding] = []
+    seen: set[tuple[str, str, int]] = set()
+    for r in obj.get("results", []):
+        rule_id = r.get("check_id", "unknown")
+        path = r.get("path", "")
+        start = (r.get("start") or {}).get("line", 0) or 0
+        key = (rule_id, path, int(start))
+        if key in seen:
+            continue
+        seen.add(key)
+        extra = r.get("extra") or {}
+        msg_lines = (extra.get("message") or "").strip().splitlines()
+        out.append(
+            SastFinding(
+                rule_id=rule_id,
+                severity=_normalize_severity(rule_id, extra.get("severity", "")),
+                path=path,
+                line=int(start),
+                message=msg_lines[0][:200] if msg_lines else "",
+            )
+        )
+    return out
+
+
+_ORDER = {"HIGH": 0, "MEDIUM": 1, "INFORMATIONAL": 2}
+
+
+def summarize(findings: list[SastFinding]) -> dict:
+    """Pure: counts by normalized severity, most-severe first."""
+    by_sev = {"HIGH": 0, "MEDIUM": 0, "INFORMATIONAL": 0}
+    for f in findings:
+        by_sev[f.severity] = by_sev.get(f.severity, 0) + 1
+    return {"total": len(findings), **{k.lower(): v for k, v in by_sev.items()}}
+
+
+def run(path: str, configs: list[str]) -> list[SastFinding]:
+    if shutil.which("semgrep") is None:
+        raise FileNotFoundError("semgrep")
+    proc = subprocess.run(build_cmd(path, configs), capture_output=True, text=True, timeout=3600)
+    try:
+        obj = json.loads(proc.stdout or "{}")
+    except ValueError:
+        # semgrep printed a hard error to stderr instead of JSON
+        raise RuntimeError(proc.stderr.strip() or "semgrep produced no JSON output")
+    return parse_semgrep(obj)
+
+
+def _render(findings: list[SastFinding], as_json: bool) -> str:
+    summary = summarize(findings)
+    if as_json:
+        return json.dumps(
+            {"summary": summary,
+             "findings": [{**asdict(f), "confidence": f.confidence} for f in findings]},
+            indent=2,
+        )
+    lines = [
+        f"[*] semgrep: {summary['total']} finding(s) — "
+        f"{summary['high']} HIGH, {summary['medium']} MEDIUM, {summary['informational']} INFO",
+    ]
+    for f in sorted(findings, key=lambda x: (_ORDER.get(x.severity, 9), x.path, x.line)):
+        lines.append(f"    [{f.severity}] {f.path}:{f.line}  {f.rule_id}")
+        if f.message:
+            lines.append(f"            {f.message}")
+    if summary["total"]:
+        lines.append("")
+        lines.append("[!] All flagged POSSIBLE — confirm with a runtime PoC before reporting.")
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description="SAST source audit via semgrep.")
+    ap.add_argument("path", help="file or directory of source/JS to scan")
+    ap.add_argument("--config", help="comma-separated semgrep configs (default: security packs)")
+    ap.add_argument("--json", action="store_true", help="JSON output")
+    args = ap.parse_args(argv)
+
+    if not Path(args.path).exists():
+        print(f"[-] path not found: {args.path}", file=sys.stderr)
+        return 2
+
+    configs = [c.strip() for c in args.config.split(",")] if args.config else DEFAULT_CONFIGS
+    try:
+        findings = run(args.path, configs)
+    except FileNotFoundError:
+        print("[-] semgrep is not installed.  brew install semgrep  (or pipx install semgrep)",
+              file=sys.stderr)
+        return 127
+    except subprocess.TimeoutExpired:
+        print("[-] semgrep timed out (60m).", file=sys.stderr)
+        return 124
+    except RuntimeError as e:
+        print(f"[-] semgrep error: {e}", file=sys.stderr)
+        return 1
+
+    print(_render(findings, args.json))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/visual_triage.py
+++ b/tools/visual_triage.py
@@ -1,0 +1,173 @@
+#!/usr/bin/env python3
+"""
+Visual triage — screenshot a list of live hosts for fast surface review AND
+reusable PoC evidence.
+
+Staring at 400 URLs in a text file is slow; a screenshot gallery surfaces login
+panels, default installs, error pages, and dev/staging boxes in seconds. The
+same captures double as report evidence, closing the "no automatic PoC capture"
+gap.
+
+Prefers whichever screenshotter is installed, in order:
+  1. eyewitness  (registered `eyewitness|probe`) — richest report
+  2. aquatone    (registered `aquatone|probe`)   — fast, clustered gallery
+  3. httpx -screenshot                            — already a core dependency
+
+Command construction + gallery indexing are pure and unit-tested; only
+`capture()` shells out.
+
+Usage:
+  tools/visual_triage.py -l recon/target.com/live/urls.txt -o shots/
+  tools/visual_triage.py -u https://admin.target.com -o shots/
+  tools/visual_triage.py -l urls.txt -o shots/ --tool aquatone --json
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import subprocess
+import sys
+from dataclasses import dataclass, asdict
+from pathlib import Path
+
+TOOLS = ("eyewitness", "aquatone", "httpx")
+IMAGE_EXTS = {".png", ".jpg", ".jpeg"}
+
+
+@dataclass
+class Shot:
+    url: str
+    image: str
+
+
+def pick_tool(preferred: str | None, available: set[str]) -> str | None:
+    """Pure: choose a screenshotter. Explicit preference wins if present,
+    otherwise fall back through the priority order."""
+    if preferred:
+        return preferred if preferred in available else None
+    for t in TOOLS:
+        if t in available:
+            return t
+    return None
+
+
+def build_cmd(tool: str, input_file: str, outdir: str) -> list[str]:
+    """Pure: the shell command for each supported screenshotter."""
+    if tool == "eyewitness":
+        return ["eyewitness", "--web", "-f", input_file, "-d", outdir, "--no-prompt"]
+    if tool == "aquatone":
+        # aquatone reads targets on stdin; caller pipes input_file in.
+        return ["aquatone", "-out", outdir]
+    if tool == "httpx":
+        return ["httpx", "-silent", "-list", input_file, "-screenshot", "-srd", outdir]
+    raise ValueError(f"unknown screenshot tool: {tool}")
+
+
+def index_gallery(outdir: str) -> list[Shot]:
+    """Pure-ish: walk an output dir for captured images and pair each with the
+    URL its filename encodes (host + port, the convention all three tools use)."""
+    root = Path(outdir)
+    shots: list[Shot] = []
+    if not root.exists():
+        return shots
+    for img in sorted(root.rglob("*")):
+        if img.suffix.lower() not in IMAGE_EXTS:
+            continue
+        shots.append(Shot(url=_url_from_name(img.stem), image=str(img)))
+    return shots
+
+
+def _url_from_name(stem: str) -> str:
+    """Best-effort reverse of the `https__host_port` filename convention."""
+    name = stem
+    for scheme in ("https", "http"):
+        if name.startswith(scheme + "__") or name.startswith(scheme + "_"):
+            rest = name.split("_", 2)[-1] if "__" not in name else name.split("__", 1)[1]
+            host = rest.replace("_", ".").rstrip(".")
+            return f"{scheme}://{host}"
+    return name.replace("_", ".")
+
+
+def render_html(shots: list[Shot], title: str = "Visual Triage") -> str:
+    """Pure: a self-contained gallery page (no external assets)."""
+    cells = "\n".join(
+        f'<figure><a href="{s.image}"><img src="{s.image}" loading="lazy"/></a>'
+        f"<figcaption>{s.url}</figcaption></figure>"
+        for s in shots
+    )
+    return (
+        f"<!doctype html><meta charset=utf-8><title>{title}</title>"
+        "<style>body{background:#0b0e14;color:#c8d3f5;font:14px system-ui;margin:24px}"
+        "h1{font-size:18px}main{display:grid;gap:16px;"
+        "grid-template-columns:repeat(auto-fill,minmax(320px,1fr))}"
+        "figure{margin:0;background:#141a24;border:1px solid #232a36;border-radius:8px;overflow:hidden}"
+        "img{width:100%;display:block}figcaption{padding:8px 10px;font-size:12px;"
+        "word-break:break-all;color:#7f8ba3}</style>"
+        f"<h1>{title} — {len(shots)} host(s)</h1><main>{cells}</main>"
+    )
+
+
+def capture(tool: str, input_file: str, outdir: str) -> subprocess.CompletedProcess:
+    Path(outdir).mkdir(parents=True, exist_ok=True)
+    cmd = build_cmd(tool, input_file, outdir)
+    if tool == "aquatone":
+        with open(input_file, "r", encoding="utf-8", errors="replace") as fh:
+            return subprocess.run(cmd, stdin=fh, capture_output=True, text=True, timeout=3600)
+    return subprocess.run(cmd, capture_output=True, text=True, timeout=3600)
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description="Screenshot live hosts for triage + PoC evidence.")
+    src = ap.add_mutually_exclusive_group(required=True)
+    src.add_argument("-l", "--list", dest="list_file", help="file of URLs, one per line")
+    src.add_argument("-u", "--url", help="a single URL")
+    ap.add_argument("-o", "--out", required=True, help="output directory for screenshots")
+    ap.add_argument("--tool", choices=TOOLS, help="force a specific screenshotter")
+    ap.add_argument("--json", action="store_true", help="JSON output")
+    args = ap.parse_args(argv)
+
+    available = {t for t in TOOLS if shutil.which(t)}
+    tool = pick_tool(args.tool, available)
+    if tool is None:
+        want = args.tool or " / ".join(TOOLS)
+        print(
+            f"[-] no screenshot tool available ({want}).\n"
+            "    eyewitness: brew install eyewitness  (or pipx)\n"
+            "    aquatone  : go install github.com/michenriksen/aquatone@latest\n"
+            "    httpx     : go install github.com/projectdiscovery/httpx/cmd/httpx@latest",
+            file=sys.stderr,
+        )
+        return 127
+
+    # Normalize a single-URL run into a temp list beside the output dir.
+    input_file = args.list_file
+    if args.url:
+        Path(args.out).mkdir(parents=True, exist_ok=True)
+        input_file = str(Path(args.out) / "_targets.txt")
+        Path(input_file).write_text(args.url + "\n", encoding="utf-8")
+    elif not Path(input_file).is_file():
+        print(f"[-] URL list not found: {input_file}", file=sys.stderr)
+        return 2
+
+    try:
+        capture(tool, input_file, args.out)
+    except subprocess.TimeoutExpired:
+        print("[-] screenshot capture timed out (60m).", file=sys.stderr)
+        return 124
+
+    shots = index_gallery(args.out)
+    gallery = Path(args.out) / "gallery.html"
+    gallery.write_text(render_html(shots), encoding="utf-8")
+
+    if args.json:
+        print(json.dumps({"tool": tool, "count": len(shots), "gallery": str(gallery),
+                          "shots": [asdict(s) for s in shots]}, indent=2))
+    else:
+        print(f"[+] {tool}: captured {len(shots)} screenshot(s)")
+        print(f"[+] gallery: {gallery}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Closes three **`[registered-not-wired]`** gaps from `docs/CAPABILITY-GAPS.md` — tools that were installable but never called by any orchestrator. Each gets a tool, a slash command, and a unit-tested pure core.

## New capabilities

| Command | Tool | Closes |
|---|---|---|
| `/portscan <host>` | `tools/port_scanner.py` | Non-web attack surface — wraps **naabu** (with passive **smap** fallback) and flags Redis, Docker API, exposed DBs, RDP, SMB. Recon was HTTP-only, so these were invisible. |
| `/screenshot -l urls.txt` | `tools/visual_triage.py` | Visual triage + PoC evidence — **eyewitness**/**aquatone**/**httpx -screenshot** into a self-contained HTML gallery. Also closes the "no automatic PoC capture" gap. |
| `/sast <path>` | `tools/sast_scan.py` | SAST source audit — **Semgrep** security packs over fetched JS/source, normalized to the toolkit severity + `POSSIBLE` confidence model. |

## Design notes
- **Pure cores, unit-tested.** Parsing / classification / command-building are side-effect-free and covered by `tests/test_{port_scanner,visual_triage,sast_scan}.py` (matches the existing `cors_scanner` pattern). Only the `scan()`/`capture()`/`run()` entry points shell out.
- **Graceful degradation.** If a binary isn't installed, the command prints the install hint and exits cleanly — no traceback.
- **Confidence discipline.** SAST hits are tagged `POSSIBLE`, never `CONFIRMED` — `/validate` still requires a runtime PoC before anything is reported.
- Docs kept in sync: README command tables, CHANGELOG (Unreleased), and gap doc marked ✅ SHIPPED.

## Testing note
I could **not run the suite locally** — this Windows machine has no Python interpreter, and the repo has **no CI workflow** to run pytest on PRs. The new tests were written against the pure cores and reviewed by hand. Recommend adding a GitHub Actions pytest workflow (happy to do it as a follow-up) so this and the existing ~250 tests run automatically.

## Follow-ups (not in this PR)
- Wire `/portscan` + `/screenshot` phases into `recon_engine.sh` so they run in the main loop.
- Remaining quick wins: `linkfinder` (JS endpoints), `fuxploider` (file upload), mobile static (`mobsf`/`jadx`).