### PR TITLE
ci: run pytest on push and PR

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,40 @@
+name: tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: tests-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  pytest:
+    name: pytest (py${{ matrix.python-version }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.9", "3.11", "3.12"]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Run test suite
+        run: pytest -q

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12"]
 
     steps:
       - uses: actions/checkout@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,13 @@
 ## Unreleased
 
 ### Added
-- **Continuous integration** — `.github/workflows/tests.yml` runs the full `pytest` suite on every push to `main` and every pull request, across Python 3.9 / 3.11 / 3.12. A status badge is shown in the README.
+- **Continuous integration** — `.github/workflows/tests.yml` runs the full `pytest` suite on every push to `main` and every pull request, across Python 3.10 / 3.11 / 3.12. A status badge is shown in the README.
+
+### Changed
+- **Minimum Python is now stated as 3.10** (was advertised as 3.9). The codebase uses PEP 604 `X | None` unions at runtime (e.g. `memory/schemas.py`), which raise `TypeError` on 3.9 — CI confirmed 3.9 never actually worked. README badge updated to match.
+
+### Fixed
+- **`tests/test_bypass_403_review_fixes.py`** re-pointed at the current WAF-aware bypass verdict pipeline (block-baseline sampling + `_is_real_bypass` signature/length gating + confirmed-vs-uncertain output split). It was still asserting the pre-#40 `_normalize_body` internals that the rewrite removed, so it failed on every run once CI was added.
 - **Port/service scanning** (`/portscan`, `tools/port_scanner.py`) — wraps `naabu` with an `smap` passive fallback and flags the non-web services the HTTP-only recon pipeline can't see (Redis, Docker API, exposed DBs, RDP, SMB). Parsing + service classification are pure and unit-tested. Closes a `[registered-not-wired]` gap.
 - **Visual triage / PoC screenshots** (`/screenshot`, `tools/visual_triage.py`) — screenshots live hosts via `eyewitness`/`aquatone`/`httpx -screenshot` into a self-contained HTML gallery that doubles as report evidence. Tool selection, command build, and gallery rendering are unit-tested. Closes a `[registered-not-wired]` gap and the "no automatic PoC capture" gap.
 - **SAST source audit** (`/sast`, `tools/sast_scan.py`) — runs Semgrep security packs over fetched JS/source and normalizes results into the toolkit's severity + `POSSIBLE` confidence model (SAST is a lead, not proof — `/validate` still requires a runtime PoC). Result parsing is unit-tested. Closes a `[registered-not-wired]` gap.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 ### Added
+- **Continuous integration** — `.github/workflows/tests.yml` runs the full `pytest` suite on every push to `main` and every pull request, across Python 3.9 / 3.11 / 3.12. A status badge is shown in the README.
 - **Port/service scanning** (`/portscan`, `tools/port_scanner.py`) — wraps `naabu` with an `smap` passive fallback and flags the non-web services the HTTP-only recon pipeline can't see (Redis, Docker API, exposed DBs, RDP, SMB). Parsing + service classification are pure and unit-tested. Closes a `[registered-not-wired]` gap.
 - **Visual triage / PoC screenshots** (`/screenshot`, `tools/visual_triage.py`) — screenshots live hosts via `eyewitness`/`aquatone`/`httpx -screenshot` into a self-contained HTML gallery that doubles as report evidence. Tool selection, command build, and gallery rendering are unit-tested. Closes a `[registered-not-wired]` gap and the "no automatic PoC capture" gap.
 - **SAST source audit** (`/sast`, `tools/sast_scan.py`) — runs Semgrep security packs over fetched JS/source and normalizes results into the toolkit's severity + `POSSIBLE` confidence model (SAST is a lead, not proof — `/validate` still requires a runtime PoC). Result parsing is unit-tested. Closes a `[registered-not-wired]` gap.

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@
 
 <p align="center">
   <a href="https://github.com/shuvonsec/claude-bug-bounty/blob/main/LICENSE"><img src="https://img.shields.io/badge/License-MIT-yellow.svg?style=flat-square" alt="MIT License"></a>
-  <img src="https://img.shields.io/badge/Python-3.9+-3776AB.svg?style=flat-square&logo=python&logoColor=white" alt="Python 3.9+">
+  <img src="https://img.shields.io/badge/Python-3.10+-3776AB.svg?style=flat-square&logo=python&logoColor=white" alt="Python 3.10+">
   <img src="https://img.shields.io/badge/Standalone-Free-brightgreen.svg?style=flat-square" alt="Free Standalone Mode">
   <a href="https://claude.ai/claude-code"><img src="https://img.shields.io/badge/Claude_Code-Plugin-D97706.svg?style=flat-square" alt="Claude Code Plugin"></a>
   <a href="https://github.com/shuvonsec/claude-bug-bounty/actions/workflows/tests.yml"><img src="https://img.shields.io/github/actions/workflow/status/shuvonsec/claude-bug-bounty/tests.yml?branch=main&style=flat-square&label=tests" alt="Tests"></a>

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@
   <img src="https://img.shields.io/badge/Python-3.9+-3776AB.svg?style=flat-square&logo=python&logoColor=white" alt="Python 3.9+">
   <img src="https://img.shields.io/badge/Standalone-Free-brightgreen.svg?style=flat-square" alt="Free Standalone Mode">
   <a href="https://claude.ai/claude-code"><img src="https://img.shields.io/badge/Claude_Code-Plugin-D97706.svg?style=flat-square" alt="Claude Code Plugin"></a>
+  <a href="https://github.com/shuvonsec/claude-bug-bounty/actions/workflows/tests.yml"><img src="https://img.shields.io/github/actions/workflow/status/shuvonsec/claude-bug-bounty/tests.yml?branch=main&style=flat-square&label=tests" alt="Tests"></a>
   <a href="https://github.com/shuvonsec/claude-bug-bounty/stargazers"><img src="https://img.shields.io/github/stars/shuvonsec/claude-bug-bounty?style=flat-square&color=yellow" alt="GitHub Stars"></a>
   <a href="https://awarexone.com"><img src="https://img.shields.io/badge/Powered_by-AwareXone.com-7F55FF.svg?style=flat-square" alt="Powered by AwareXone.com"></a>
 </p>

--- a/tests/test_bypass_403_review_fixes.py
+++ b/tests/test_bypass_403_review_fixes.py
@@ -1,4 +1,14 @@
-"""Regression checks for the response-normalization bypass probe."""
+"""Regression checks for the 403/401 bypass probe's confidence model.
+
+PR #40 replaced the earlier token-normalizing body comparison
+(`_normalize_body` + `[CONFIRMED]/[POSSIBLE]/[INFORMATIONAL]` tiers) with a
+broader WAF-aware verdict pipeline: sample a block baseline, reject responses
+that match a WAF block signature, require the body length to diverge from the
+baseline, and split results into confirmed (`bypass_hits.txt`) vs needs-review
+(`bypass_uncertain.txt`). These tests guard that newer mechanism so a future
+rewrite can't silently drop the "is this a real bypass or still a block page?"
+check that keeps false positives out of findings.
+"""
 
 from pathlib import Path
 
@@ -6,19 +16,24 @@ from pathlib import Path
 BYPASS_PATH = Path(__file__).resolve().parents[1] / "tools" / "bypass_403.sh"
 
 
-def test_bypass_probe_normalizes_dynamic_bodies_before_comparing():
+def test_bypass_probe_baselines_and_compares_against_block_page():
     scanner = BYPASS_PATH.read_text()
 
-    assert "_normalize_body()" in scanner
-    assert "orig_norm" in scanner
-    assert "bypass_norm" in scanner
-    assert '[ "$bypass_norm" = "$orig_norm" ]' in scanner
-    assert "baseline_code=$orig_code" in scanner
+    # A block baseline is sampled and reused for divergence comparison.
+    assert "_sample_block_baseline()" in scanner
+    assert ".block_baseline.len" in scanner
+    # The verdict function gates on status, WAF signatures, and length divergence.
+    assert "_is_real_bypass()" in scanner
+    assert "_WAF_BLOCK_REGEX" in scanner
+    # Body length must diverge from the block baseline (not just any 200).
+    assert "body_len - bb_len" in scanner or "bb_len - body_len" in scanner
 
 
-def test_bypass_probe_keeps_confidence_tiers():
+def test_bypass_probe_separates_confirmed_from_uncertain():
     scanner = BYPASS_PATH.read_text()
 
-    assert '[CONFIRMED]' in scanner
-    assert '[POSSIBLE]' in scanner
-    assert '[INFORMATIONAL]' in scanner
+    # Confirmed bypasses and "200 body may still be a block page" are kept apart.
+    assert "bypass_hits.txt" in scanner
+    assert "bypass_uncertain.txt" in scanner
+    # A per-response verdict is computed rather than trusting the status code alone.
+    assert "_classify_with_analyzer" in scanner or "_is_real_bypass" in scanner


### PR DESCRIPTION
Adds continuous integration — the repo had ~250 tests but nothing ran them automatically.

## Changes
- **`.github/workflows/tests.yml`** — runs `pytest -q` on every push to `main` and every pull request, across Python **3.9 / 3.11 / 3.12** (matrix), with pip caching and read-only permissions.
- **README** — adds a `tests` status badge to the hero.
- **CHANGELOG** — noted under Unreleased.

## Why
Closes the blind spot flagged in #108: new tests couldn't be verified locally. From now on every PR (including the recon-tools tests just merged) is checked automatically before merge.