### PR TITLE
safety: wire scope enforcement into the live autopilot path (fail-closed); unbypassable spray confirmation

### DIFF
--- a/agent.py
+++ b/agent.py
@@ -101,6 +101,12 @@ except Exception as _brain_err:
     MODEL_PRIORITY = ["qwen3:8b"]
     OLLAMA_HOST = "http://localhost:11434"
 
+# ── Scope enforcement for autonomous tool dispatch ──────────────────────────────
+# _here is the repo root (inserted onto sys.path above), so tools.* / memory.*
+# import as regular packages here.
+from tools.scope_checker import ScopeChecker, _split_patterns  # noqa: E402
+from memory.audit_log import AutopilotGuard  # noqa: E402
+
 # ── Colours ───────────────────────────────────────────────────────────────────
 GREEN   = "\033[0;32m"
 CYAN    = "\033[0;36m"
@@ -507,20 +513,47 @@ class HuntMemory:
 class ToolDispatcher:
     """Execute tool calls and return plain-text observations."""
 
+    # Tool names that send traffic toward `domain` (directly or via
+    # subprocess-driven scanners) and therefore must clear the scope guard
+    # before running. Local/bookkeeping tools are excluded — they touch only
+    # session state on disk, never the network.
+    NETWORK_TOOLS = {
+        "run_recon", "run_vuln_scan", "run_js_analysis", "run_secret_hunt",
+        "run_param_discovery", "run_post_param_discovery", "run_api_fuzz",
+        "run_cors_check", "run_cms_exploit", "run_rce_scan",
+        "run_sqlmap_targeted", "run_sqlmap_on_file", "run_jwt_audit",
+    }
+
     def __init__(self, domain: str, memory: HuntMemory,
                  scope_lock: bool = False, max_urls: int = 100,
-                 default_cookies: str = ""):
+                 default_cookies: str = "", scope_checker: ScopeChecker | None = None):
         self.domain          = domain
-        self.memory          = memory
-        self.scope_lock      = scope_lock
-        self.max_urls        = max_urls
-        self.default_cookies = default_cookies
+        self.memory           = memory
+        self.scope_lock       = scope_lock
+        self.max_urls         = max_urls
+        self.default_cookies  = default_cookies
+        # fail_closed=True (AutopilotGuard default): if the caller didn't pass
+        # a scope_checker, every network tool call below is blocked rather
+        # than silently allowed. See main()/run_agent_hunt() for where
+        # scope_checker gets built from --domain/--exclude-domain.
+        self._guard = AutopilotGuard(scope_checker=scope_checker)
 
     def dispatch(self, name: str, args: dict) -> str:
         """Execute named tool and return text observation."""
         h = _h()
         domain = self.domain
         t0 = time.time()
+
+        # Scope gate: checked first, ahead of everything else, for any tool
+        # that actually sends traffic. `method` is nominal here — dispatch
+        # operates at whole-tool granularity (a shell-out to a scanner), not
+        # a single HTTP request, so there's no real verb to report. GET just
+        # selects "safe, no approval step" in AutopilotGuard's method policy;
+        # the check that matters at this layer is scope.
+        if name in self.NETWORK_TOOLS:
+            gate = self._guard.check_request("GET", f"https://{domain}")
+            if gate["decision"] != "allow":
+                return f"BLOCKED by scope guard: {gate['reason']}"
 
         try:
             if name == "run_recon":
@@ -1437,6 +1470,7 @@ def run_agent_hunt(
     model: str | None = None,
     resume_session_id: str | None = None,
     use_langgraph: bool = False,
+    scope_checker: ScopeChecker | None = None,
 ) -> dict:
     """
     Main entry point for agent-driven autonomous hunting.
@@ -1463,6 +1497,7 @@ def run_agent_hunt(
         scope_lock=scope_lock,
         max_urls=max_urls,
         default_cookies=cookies,
+        scope_checker=scope_checker,
     )
 
     # ── Run ───────────────────────────────────────────────────────────────
@@ -1537,6 +1572,10 @@ Examples:
   python3 agent.py --target example.com --langgraph
   python3 agent.py --target example.com --resume SESSION_ID
   python3 agent.py --list-models
+
+Scope (required before any tool that sends traffic will run):
+  python3 agent.py --target example.com -d example.com -d '*.example.com'
+  python3 agent.py --target example.com -d '*.example.com' -x blog.example.com
 """
     )
     parser.add_argument("--target",      required=False, help="Domain to hunt")
@@ -1545,6 +1584,14 @@ Examples:
     parser.add_argument("--cookie",      type=str,   default="",  help="Session cookie for POST discovery")
     parser.add_argument("--scope-lock",  action="store_true",     help="Stick to exact target only")
     parser.add_argument("--max-urls",    type=int,   default=100, help="Max URLs in recon (default 100)")
+    parser.add_argument("--domain", "-d", action="append", default=[],
+                        help="Program's in-scope domain pattern, e.g. target.com or "
+                             "'*.target.com'. Repeat or comma-separate. REQUIRED for any "
+                             "tool that sends traffic — with none given, autopilot refuses "
+                             "to run rather than hunt with no scope configured.")
+    parser.add_argument("--exclude-domain", "-x", action="append", default=[],
+                        help="Domain pattern excluded by the program despite matching "
+                             "--domain, e.g. blog.target.com. Repeat or comma-separate.")
     parser.add_argument("--model",       type=str,   default=None, help="Ollama model override")
     parser.add_argument("--langgraph",   action="store_true",     help="Use real LangGraph backend")
     parser.add_argument("--resume",      type=str,   default=None, help="Resume session ID")
@@ -1584,6 +1631,18 @@ Examples:
         parser.print_help()
         sys.exit(1)
 
+    domains = _split_patterns(args.domain)
+    scope_checker = ScopeChecker(
+        domains=domains,
+        excluded_domains=_split_patterns(args.exclude_domain),
+    ) if domains else None
+
+    if scope_checker is None:
+        print(f"{YELLOW}[Agent] No --domain given — every tool that sends traffic "
+              f"will be blocked (fail-closed).{NC}")
+        print(f"{YELLOW}[Agent] Pass scope explicitly, e.g.: "
+              f"-d {args.target} -d '*.{args.target}'{NC}")
+
     result = run_agent_hunt(
         args.target,
         scope_lock=args.scope_lock,
@@ -1594,6 +1653,7 @@ Examples:
         model=args.model,
         resume_session_id=args.resume,
         use_langgraph=args.langgraph,
+        scope_checker=scope_checker,
     )
 
     print(f"\n{BOLD}{'═'*60}{NC}")

--- a/memory/audit_log.py
+++ b/memory/audit_log.py
@@ -240,13 +240,19 @@ class SafeMethodPolicy:
 class AutopilotGuard:
     """Unified pre-request guard for autopilot mode.
 
-    Integrates CircuitBreaker + RateLimiter + SafeMethodPolicy into a single
-    check_request() call that returns allow / block / require_approval.
+    Integrates ScopeChecker + CircuitBreaker + RateLimiter + SafeMethodPolicy
+    into a single check_request() call that returns allow / block /
+    require_approval.
 
     Check order:
+      0. Scope check (out of scope? → block)  [HARD BLOCK, checked first]
       1. Circuit breaker (host blocked? → block)
       2. Safe method policy (unsafe method? → require_approval)
       3. Allow
+
+    If no scope_checker is supplied and fail_closed is True (the default),
+    every request is blocked — a run with no configured scope is treated as a
+    misconfiguration rather than an invitation to hit anything.
     """
 
     def __init__(
@@ -257,6 +263,8 @@ class AutopilotGuard:
         test_rps: float = 1.0,
         safe_methods_only: bool = True,
         safe_methods: set[str] | None = None,
+        scope_checker=None,
+        fail_closed: bool = True,
     ):
         self._breaker = CircuitBreaker(
             threshold=circuit_threshold,
@@ -267,6 +275,16 @@ class AutopilotGuard:
             safe_methods=safe_methods,
             enabled=safe_methods_only,
         )
+        # Scope enforcement. When a ScopeChecker is supplied, every request is
+        # checked against the program allowlist as a HARD BLOCK before any other
+        # gate. This is the backstop the manual /scope command cannot guarantee.
+        #
+        # fail_closed=True (default): if no scope_checker was supplied, block ALL
+        # requests rather than silently allowing everything. An autopilot run with
+        # no configured scope is almost certainly a misconfiguration, and the safe
+        # failure mode for an out-of-scope request is "don't send it."
+        self._scope_checker = scope_checker
+        self._fail_closed = fail_closed
 
     @staticmethod
     def _extract_host(url: str) -> str:
@@ -288,6 +306,31 @@ class AutopilotGuard:
             dict with 'decision' key: 'allow', 'block', or 'require_approval'.
         """
         host = self._extract_host(url)
+
+        # 0. Scope enforcement (HARD BLOCK, checked first).
+        # An out-of-scope request must never be sent, regardless of method or
+        # host health. This is deliberately the first gate.
+        if self._scope_checker is not None:
+            if not self._scope_checker.is_in_scope(url):
+                return {
+                    "decision": "block",
+                    "method": method.upper(),
+                    "url": url,
+                    "host": host,
+                    "reason": f"Out of scope: {host} is not on the program allowlist",
+                }
+        elif self._fail_closed:
+            return {
+                "decision": "block",
+                "method": method.upper(),
+                "url": url,
+                "host": host,
+                "reason": (
+                    "No scope configured and fail_closed is set — refusing to send "
+                    "requests. Configure a ScopeChecker with the program's in-scope "
+                    "domains before running autopilot."
+                ),
+            }
 
         # 1. Circuit breaker
         if self._breaker.is_tripped(host):

--- a/tests/test_agent_dispatcher_scope.py
+++ b/tests/test_agent_dispatcher_scope.py
@@ -1,0 +1,89 @@
+"""Tests for ToolDispatcher's scope gate — the live autopilot path that
+AutopilotGuard was NOT previously wired into.
+
+Before this fix, agent.py's ToolDispatcher.dispatch() called straight into
+hunt.py's run_* functions with no gate at all: no scope check, no circuit
+breaker, no method policy, regardless of whether a scope_checker was even
+supplied to run_agent_hunt(). These tests exercise the actual dispatch path,
+not just AutopilotGuard in isolation (see test_autopilot_guard.py for that).
+"""
+
+import pytest
+
+import agent
+from agent import HuntMemory, ToolDispatcher
+from tools.scope_checker import ScopeChecker
+
+
+@pytest.fixture
+def memory(tmp_path):
+    return HuntMemory(str(tmp_path / "agent_session.json"))
+
+
+@pytest.fixture
+def fake_hunt(monkeypatch):
+    """Stub out agent._h() so network tools don't actually shell out."""
+
+    class FakeHunt:
+        def __init__(self):
+            self.calls = []
+
+        def run_recon(self, domain, **kwargs):
+            self.calls.append(("run_recon", domain, kwargs))
+            return True
+
+        def run_vuln_scan(self, domain, **kwargs):
+            self.calls.append(("run_vuln_scan", domain, kwargs))
+            return True
+
+        def _resolve_recon_dir(self, domain):
+            return str(domain)
+
+    fake = FakeHunt()
+    monkeypatch.setattr(agent, "_h", lambda: fake)
+    return fake
+
+
+class TestNoScopeConfigured:
+    """fail_closed=True is the AutopilotGuard default — dispatch() must
+    inherit it even when nobody threads a scope_checker through."""
+
+    def test_network_tool_blocked_with_no_scope_checker(self, memory, fake_hunt):
+        dispatcher = ToolDispatcher("target.com", memory)
+        result = dispatcher.dispatch("run_recon", {})
+        assert result.startswith("BLOCKED by scope guard:")
+        assert "no scope" in result.lower()
+        assert fake_hunt.calls == []  # the real tool must never have run
+
+    def test_local_tools_unaffected_by_missing_scope(self, memory, fake_hunt):
+        dispatcher = ToolDispatcher("target.com", memory)
+        result = dispatcher.dispatch("update_working_memory", {"notes": "hi"})
+        assert "Working memory updated" in result
+        result = dispatcher.dispatch("finish", {"verdict": "done"})
+        assert result.startswith("FINISH:")
+
+
+class TestScopeConfigured:
+    def test_in_scope_domain_allowed_through(self, memory, fake_hunt):
+        checker = ScopeChecker(domains=["target.com", "*.target.com"])
+        dispatcher = ToolDispatcher("target.com", memory, scope_checker=checker)
+        result = dispatcher.dispatch("run_recon", {})
+        assert not result.startswith("BLOCKED")
+        assert fake_hunt.calls and fake_hunt.calls[0][0] == "run_recon"
+
+    def test_out_of_scope_domain_blocked(self, memory, fake_hunt):
+        """The dispatcher was constructed for a domain that isn't actually
+        on the program's allowlist — e.g. --target typo'd against --domain."""
+        checker = ScopeChecker(domains=["other-program.com"])
+        dispatcher = ToolDispatcher("target.com", memory, scope_checker=checker)
+        result = dispatcher.dispatch("run_vuln_scan", {})
+        assert result.startswith("BLOCKED by scope guard:")
+        assert "scope" in result.lower()
+        assert fake_hunt.calls == []
+
+    def test_lookalike_domain_blocked(self, memory, fake_hunt):
+        checker = ScopeChecker(domains=["*.target.com"])
+        dispatcher = ToolDispatcher("evil-target.com", memory, scope_checker=checker)
+        result = dispatcher.dispatch("run_recon", {})
+        assert result.startswith("BLOCKED by scope guard:")
+        assert fake_hunt.calls == []

--- a/tests/test_autopilot_guard.py
+++ b/tests/test_autopilot_guard.py
@@ -15,17 +15,17 @@ class TestAutopilotGuardAllow:
     """Safe requests on healthy hosts should be allowed."""
 
     def test_safe_get_on_healthy_host(self):
-        guard = AutopilotGuard()
+        guard = AutopilotGuard(fail_closed=False)
         result = guard.check_request("GET", "https://target.com/api/users")
         assert result["decision"] == "allow"
 
     def test_safe_head_allowed(self):
-        guard = AutopilotGuard()
+        guard = AutopilotGuard(fail_closed=False)
         result = guard.check_request("HEAD", "https://target.com/")
         assert result["decision"] == "allow"
 
     def test_safe_options_allowed(self):
-        guard = AutopilotGuard()
+        guard = AutopilotGuard(fail_closed=False)
         result = guard.check_request("OPTIONS", "https://target.com/api")
         assert result["decision"] == "allow"
 
@@ -34,23 +34,23 @@ class TestAutopilotGuardUnsafeMethods:
     """Unsafe methods should require approval."""
 
     def test_post_requires_approval(self):
-        guard = AutopilotGuard()
+        guard = AutopilotGuard(fail_closed=False)
         result = guard.check_request("POST", "https://target.com/api/users")
         assert result["decision"] == "require_approval"
         assert "unsafe method" in result["reason"].lower() or "method" in result["reason"].lower()
 
     def test_put_requires_approval(self):
-        guard = AutopilotGuard()
+        guard = AutopilotGuard(fail_closed=False)
         result = guard.check_request("PUT", "https://target.com/api/users/1")
         assert result["decision"] == "require_approval"
 
     def test_delete_requires_approval(self):
-        guard = AutopilotGuard()
+        guard = AutopilotGuard(fail_closed=False)
         result = guard.check_request("DELETE", "https://target.com/api/users/1")
         assert result["decision"] == "require_approval"
 
     def test_patch_requires_approval(self):
-        guard = AutopilotGuard()
+        guard = AutopilotGuard(fail_closed=False)
         result = guard.check_request("PATCH", "https://target.com/api/users/1")
         assert result["decision"] == "require_approval"
 
@@ -59,7 +59,7 @@ class TestAutopilotGuardCircuitBreaker:
     """Requests to tripped hosts should be blocked."""
 
     def test_block_when_circuit_tripped(self):
-        guard = AutopilotGuard(circuit_threshold=2)
+        guard = AutopilotGuard(circuit_threshold=2, fail_closed=False)
         # Trip the breaker
         guard.record_failure("target.com")
         guard.record_failure("target.com")
@@ -68,7 +68,7 @@ class TestAutopilotGuardCircuitBreaker:
         assert "circuit" in result["reason"].lower() or "tripped" in result["reason"].lower()
 
     def test_allow_after_cooldown(self):
-        guard = AutopilotGuard(circuit_threshold=2, circuit_cooldown=0.1)
+        guard = AutopilotGuard(circuit_threshold=2, circuit_cooldown=0.1, fail_closed=False)
         guard.record_failure("target.com")
         guard.record_failure("target.com")
         assert guard.check_request("GET", "https://target.com/api")["decision"] == "block"
@@ -76,7 +76,7 @@ class TestAutopilotGuardCircuitBreaker:
         assert guard.check_request("GET", "https://target.com/api")["decision"] == "allow"
 
     def test_success_resets_breaker(self):
-        guard = AutopilotGuard(circuit_threshold=3)
+        guard = AutopilotGuard(circuit_threshold=3, fail_closed=False)
         guard.record_failure("target.com")
         guard.record_failure("target.com")
         guard.record_success("target.com")
@@ -86,7 +86,7 @@ class TestAutopilotGuardCircuitBreaker:
         assert result["decision"] == "allow"
 
     def test_different_hosts_independent(self):
-        guard = AutopilotGuard(circuit_threshold=2)
+        guard = AutopilotGuard(circuit_threshold=2, fail_closed=False)
         guard.record_failure("bad.com")
         guard.record_failure("bad.com")
         # bad.com is tripped, but good.com is fine
@@ -98,14 +98,14 @@ class TestAutopilotGuardHostExtraction:
     """Guard should extract host from URL for circuit breaker checks."""
 
     def test_extracts_host_from_https(self):
-        guard = AutopilotGuard(circuit_threshold=2)
+        guard = AutopilotGuard(circuit_threshold=2, fail_closed=False)
         guard.record_failure("target.com")
         guard.record_failure("target.com")
         result = guard.check_request("GET", "https://target.com/api/users")
         assert result["decision"] == "block"
 
     def test_extracts_host_with_port(self):
-        guard = AutopilotGuard(circuit_threshold=2)
+        guard = AutopilotGuard(circuit_threshold=2, fail_closed=False)
         guard.record_failure("target.com:8080")
         guard.record_failure("target.com:8080")
         result = guard.check_request("GET", "https://target.com:8080/api")
@@ -117,7 +117,7 @@ class TestAutopilotGuardCombined:
 
     def test_circuit_breaker_takes_precedence(self):
         """If host is tripped, block even for safe methods."""
-        guard = AutopilotGuard(circuit_threshold=2)
+        guard = AutopilotGuard(circuit_threshold=2, fail_closed=False)
         guard.record_failure("target.com")
         guard.record_failure("target.com")
         result = guard.check_request("GET", "https://target.com/api")
@@ -125,13 +125,13 @@ class TestAutopilotGuardCombined:
 
     def test_unsafe_method_on_healthy_host(self):
         """Healthy host + unsafe method = require_approval, not block."""
-        guard = AutopilotGuard()
+        guard = AutopilotGuard(fail_closed=False)
         result = guard.check_request("DELETE", "https://target.com/api/users/1")
         assert result["decision"] == "require_approval"
 
     def test_unsafe_method_on_tripped_host(self):
         """Tripped host + unsafe method = block (circuit breaker wins)."""
-        guard = AutopilotGuard(circuit_threshold=2)
+        guard = AutopilotGuard(circuit_threshold=2, fail_closed=False)
         guard.record_failure("target.com")
         guard.record_failure("target.com")
         result = guard.check_request("DELETE", "https://target.com/api")
@@ -142,13 +142,13 @@ class TestAutopilotGuardStatus:
     """Getting guard status for a host."""
 
     def test_status_healthy(self):
-        guard = AutopilotGuard()
+        guard = AutopilotGuard(fail_closed=False)
         status = guard.get_host_status("target.com")
         assert status["circuit_tripped"] is False
         assert status["failures"] == 0
 
     def test_status_after_failures(self):
-        guard = AutopilotGuard(circuit_threshold=5)
+        guard = AutopilotGuard(circuit_threshold=5, fail_closed=False)
         guard.record_failure("target.com")
         guard.record_failure("target.com")
         status = guard.get_host_status("target.com")
@@ -156,7 +156,7 @@ class TestAutopilotGuardStatus:
         assert status["circuit_tripped"] is False
 
     def test_status_tripped(self):
-        guard = AutopilotGuard(circuit_threshold=2)
+        guard = AutopilotGuard(circuit_threshold=2, fail_closed=False)
         guard.record_failure("target.com")
         guard.record_failure("target.com")
         status = guard.get_host_status("target.com")
@@ -167,6 +167,79 @@ class TestAutopilotGuardDisabledPolicy:
     """When safe_methods_only is disabled, all methods pass method check."""
 
     def test_disabled_allows_delete(self):
-        guard = AutopilotGuard(safe_methods_only=False)
+        guard = AutopilotGuard(safe_methods_only=False, fail_closed=False)
         result = guard.check_request("DELETE", "https://target.com/api/users/1")
+        assert result["decision"] == "allow"
+
+
+# ---------------------------------------------------------------------------
+# Scope enforcement (added: wire ScopeChecker into the autopilot guard so an
+# out-of-scope request is a hard block, and a missing scope config fails closed)
+# ---------------------------------------------------------------------------
+
+from tools.scope_checker import ScopeChecker
+
+
+def _scoped(**kwargs):
+    """AutopilotGuard scoped to *.target.com for scope tests."""
+    checker = ScopeChecker(domains=["target.com", "*.target.com"])
+    return AutopilotGuard(scope_checker=checker, **kwargs)
+
+
+class TestAutopilotGuardScope:
+    """A ScopeChecker turns scope into an automatic hard block."""
+
+    def test_in_scope_host_allowed(self):
+        guard = _scoped()
+        result = guard.check_request("GET", "https://api.target.com/users")
+        assert result["decision"] == "allow"
+
+    def test_out_of_scope_host_blocked(self):
+        guard = _scoped()
+        result = guard.check_request("GET", "https://evil.com/users")
+        assert result["decision"] == "block"
+        assert "scope" in result["reason"].lower()
+
+    def test_lookalike_domain_blocked(self):
+        """evil-target.com must not match *.target.com."""
+        guard = _scoped()
+        result = guard.check_request("GET", "https://evil-target.com/")
+        assert result["decision"] == "block"
+        assert "scope" in result["reason"].lower()
+
+    def test_scope_checked_before_method_policy(self):
+        """An out-of-scope unsafe method is blocked, not merely held for approval."""
+        guard = _scoped()
+        result = guard.check_request("DELETE", "https://evil.com/api")
+        assert result["decision"] == "block"
+        assert "scope" in result["reason"].lower()
+
+    def test_scope_checked_before_circuit_breaker(self):
+        """Scope is the first gate: out-of-scope blocks with a scope reason,
+        even on a host that would otherwise be healthy."""
+        guard = _scoped(circuit_threshold=2)
+        result = guard.check_request("GET", "https://evil.com/api")
+        assert result["decision"] == "block"
+        assert "scope" in result["reason"].lower()
+
+    def test_in_scope_unsafe_method_still_needs_approval(self):
+        """Being in scope doesn't waive the method policy."""
+        guard = _scoped()
+        result = guard.check_request("POST", "https://api.target.com/users")
+        assert result["decision"] == "require_approval"
+
+
+class TestAutopilotGuardFailClosed:
+    """With no scope configured, the default is to block everything."""
+
+    def test_no_scope_blocks_by_default(self):
+        guard = AutopilotGuard()  # fail_closed defaults to True
+        result = guard.check_request("GET", "https://anything.com/")
+        assert result["decision"] == "block"
+        assert "no scope" in result["reason"].lower()
+
+    def test_fail_open_opt_out_allows(self):
+        """Explicit fail_closed=False restores the old permissive behavior."""
+        guard = AutopilotGuard(fail_closed=False)
+        result = guard.check_request("GET", "https://anything.com/")
         assert result["decision"] == "allow"

--- a/tools/spray_orchestrator.sh
+++ b/tools/spray_orchestrator.sh
@@ -134,7 +134,20 @@ log_warn "  - Read the program policy for 'credential stuffing', 'brute force',"
 log_warn "    'authentication testing' — these are usually explicitly excluded"
 log_warn "  - If unsure, ABORT and ask the program first"
 
-if [ "$I_UNDERSTAND" != true ] && [ "$DRY_RUN" != true ]; then
+# The typed-hostname confirmation is the single strongest guard against
+# spraying the wrong target, so it is UNCONDITIONAL for any run that actually
+# sends traffic. --i-understand can waive the softer "type yes" lockout prompt
+# below, but it can NEVER waive this one. Only --dry-run (which sends nothing)
+# skips it.
+if [ "$DRY_RUN" != true ]; then
+    # Require an interactive terminal: a human must type this, not a pipe or an
+    # automated agent feeding stdin. This defeats "--i-understand + echo host |"
+    # style bypasses.
+    if [ ! -t 0 ]; then
+        log_err "Refusing to spray: hostname confirmation requires an interactive terminal."
+        log_err "This guard cannot be satisfied by piped or automated input. Aborting."
+        exit 2
+    fi
     echo ""
     read -r -p "Type the target hostname ($TARGET_HOST) to confirm: " TYPED
     if [ "$TYPED" != "$TARGET_HOST" ]; then


### PR DESCRIPTION
## Summary

The README/TERMS promise "every URL is checked against the scope allowlist
before any request is sent." A source-level review found that promise didn't
hold, in two layers:

1. **`AutopilotGuard` (`memory/audit_log.py`) never called the scope
   checker.** It only enforced circuit-breaker + method policy. Fixed by
   wiring `ScopeChecker` in as the first, hard-block gate, with
   `fail_closed=True` by default — no scope configured means every request
   is blocked rather than silently unscoped.
2. **Even patched, the guard was never wired into the live autopilot path.**
   `agent.py`'s `ToolDispatcher.dispatch()` — what the LLM-driven ReAct loop
   (and the LangGraph backend, which wraps the same dispatcher) actually
   calls for every tool — went straight into `hunt.py`'s `run_recon`,
   `run_vuln_scan`, etc. with no gate at all. `AutopilotGuard`'s own unit
   tests were the only thing that ever exercised it.

This PR fixes both. `ToolDispatcher` now builds and checks the guard for
every network-facing tool call; `agent.py` gains `--domain`/`-d` and
`--exclude-domain`/`-x` flags (matching `tools/scope_checker.py`'s existing
flag names) to declare scope explicitly — no inference from `--target`, same
fail-closed philosophy throughout. Running `agent.py --target X` with no
`--domain` now prints a warning and blocks every network tool call rather
than hunting unscoped.

Also, separately: `tools/spray_orchestrator.sh`'s typed-hostname
confirmation could be skipped entirely by `--i-understand` combined with
piped stdin — an automated caller (or copy-paste one-liner) could launch a
live credential spray with no human re-stating the target. The confirmation
is now unconditional for any run that sends traffic and requires an
interactive TTY; only `--dry-run` skips it.

## What this does NOT fix (disclosed, not silently left)

Scope enforcement at the `ToolDispatcher` boundary is domain-level. A
program's per-subdomain exclusion (`-x blog.target.com` on an otherwise
in-scope `*.target.com`) is accepted by the CLI and threaded through, but the
individual scanner scripts under `tools/` (`vuln_scanner.sh`,
`port_scanner.py`, etc.) don't yet re-check each discovered host against it
before hitting it. Closing that fully means threading `ScopeChecker` into
those scripts directly — a bigger change than this PR attempts.

`engine.py`'s `hunt`/`recon` subcommands are a separate, human-driven
deterministic pipeline (not the LLM-autonomous loop) and were out of scope
for this pass.

## Test plan

- [x] `python3 -m pytest tests/ -q` — 636 passed, 0 regressions (623 baseline
      + 8 `AutopilotGuard` scope tests + 5 new `ToolDispatcher` scope-gate
      tests covering: no-scope-configured blocks network tools but not local
      ones, in-scope domain passes through, out-of-scope domain blocks,
      lookalike-domain blocks)
- [x] `agent.py --help` confirms the new flags parse correctly
- [x] Manually traced both the built-in ReAct loop and the LangGraph backend
      to confirm both route through the same gated `dispatch()`

Happy to adjust `fail_closed`'s default if you'd rather ship it opt-in — I
think fail-closed is the right call for something that runs autonomously
against live targets, but that's your call as maintainer.
