### PR TITLE
fix: point CLI banner at AwareXone + current repo path

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -688,8 +688,8 @@ def _print_banner():
     for line, color in LINES:
         print(f"{color}{line}{NC}")
     print()
-    print(f"  {G3}by {W}shuvonsec{NC}  {G3}·{NC}  {G2}shuvonsec.me{NC}  {G3}·{NC}  {G1}bughunter.fun{NC}")
-    print(f"  {G3}github.com/{G2}shuvonsec{G3}/claude-bug-bounty{NC}")
+    print(f"  {G3}by {W}AwareXone{NC}  {G3}·{NC}  {G2}awarexone.com{NC}  {G3}·{NC}  {G1}bughunter.fun{NC}")
+    print(f"  {G3}github.com/{G2}Awarexone{G3}/Agentic-Bug-Hunter{NC}")
     print(f"  {G3}free · open · no subscription required{NC}")
     print()
 

--- a/tools/banner.py
+++ b/tools/banner.py
@@ -48,7 +48,7 @@ _BOLD = "\033[1m"
 _DIM = "\033[2m"
 _NC = "\033[0m"
 
-_TAG = "bughunter.fun  ·  github.com/shuvonsec/claude-bug-bounty"
+_TAG = "bughunter.fun  ·  github.com/Awarexone/Agentic-Bug-Hunter"
 
 
 def _use_color(stream) -> bool:

--- a/tools/banner.sh
+++ b/tools/banner.sh
@@ -72,7 +72,7 @@ print_banner() {
         printf '  %s%s%s\n' "$CYAN" "$bar" "$NC"
         printf '  %s%s%s\n' "$CYAN" "$(_bb_center "$subtitle" $_BB_LOGO_WIDTH)" "$NC"
     fi
-    printf '  %s%s%s\n' "$DIM" "$(_bb_center 'bughunter.fun  ·  github.com/shuvonsec/claude-bug-bounty' $_BB_LOGO_WIDTH)" "$NC"
+    printf '  %s%s%s\n' "$DIM" "$(_bb_center 'bughunter.fun  ·  github.com/Awarexone/Agentic-Bug-Hunter' $_BB_LOGO_WIDTH)" "$NC"
     if [ -n "$target" ]; then
         printf '  %s%s%s\n' "$MAGENTA" "$(_bb_center "▸ target: $target" $_BB_LOGO_WIDTH)" "$NC"
     fi


### PR DESCRIPTION
## Summary
- `engine.py`'s standalone splash banner byline now reads `by AwareXone · awarexone.com · bughunter.fun` (was `by shuvonsec · shuvonsec.me · bughunter.fun`), and its repo line now points at `github.com/Awarexone/Agentic-Bug-Hunter`.
- `tools/banner.py` and `tools/banner.sh` — the shared ASCII banner used by both `agent.py` (Claude Code plugin path) and any shell scripts sourcing it — had the same stale `github.com/shuvonsec/claude-bug-bounty` tag, now fixed to the current path.

This covers what a user actually sees when running `bughunter` or `/recon` etc. — the splash banner — to match the branding/link updates already made in the README (#116, #117).

## Test plan
- [x] `grep -rn "shuvonsec/claude-bug-bounty" tools/banner.py tools/banner.sh engine.py` returns no matches.
- [x] Confirmed no tests assert on the old banner strings.
- [x] Verified commit author resolves to `shuvonsec` via the GitHub API.
- [ ] Run `bughunter` (or `python3 -m tools.banner`) locally to eyeball the banner render.