### PR TITLE
Un-shrink the AwareXone credit line in the hero

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@
 </p>
 
 <p align="center">
-  <sub>Built and maintained by <b>AwareXone</b> · <a href="https://awarexone.com">Website</a> · <a href="https://x.com/awarexone">X</a> · <a href="https://github.com/Awarexone">GitHub</a></sub>
+  Built and maintained by <b>AwareXone</b> · <a href="https://awarexone.com">Website</a> · <a href="https://x.com/awarexone">X</a> · <a href="https://github.com/Awarexone">GitHub</a>
 </p>
 
 ---


### PR DESCRIPTION
It was sitting inside a <sub> tag right under the badges, small enough that most people would scroll past it. Same line, just regular text size now so it's actually visible.