### PR TITLE
Sweep the rest of the old repo path out of the codebase

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -23,8 +23,8 @@ Bug hunters welcome. Every improvement here makes real hunts more effective.
 
 ```bash
 # 1. Fork and clone
-git clone https://github.com/YOUR_USERNAME/claude-bug-bounty.git
-cd claude-bug-bounty
+git clone https://github.com/YOUR_USERNAME/Agentic-Bug-Hunter.git
+cd Agentic-Bug-Hunter
 
 # 2. Create a branch
 git checkout -b feat/your-contribution
@@ -58,4 +58,4 @@ chore: maintenance (deps, CI, cleanup)
 
 ## Questions?
 
-Open a [GitHub Discussion](https://github.com/shuvonsec/claude-bug-bounty/discussions) or reach out at [shuvonsec@gmail.com](mailto:shuvonsec@gmail.com).
+Open a [GitHub Discussion](https://github.com/Awarexone/Agentic-Bug-Hunter/discussions) or reach out at [shuvonsec@gmail.com](mailto:shuvonsec@gmail.com).

--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,7 @@ api_keys.txt
 .private/
 
 # Nested local clones / sub-repos (not tracked)
-claude-bug-bounty/
+Agentic-Bug-Hunter/
 
 # Python
 __pycache__/

--- a/FAQ.md
+++ b/FAQ.md
@@ -189,7 +189,7 @@ Check your scope input. Run `/scope <asset>` before running `/hunt` or `/autopil
 **How do I update to the latest version?**
 
 ```bash
-cd claude-bug-bounty
+cd Agentic-Bug-Hunter
 git pull origin main
 chmod +x install.sh && ./install.sh   # reinstall skills + commands
 ```
@@ -198,7 +198,7 @@ chmod +x install.sh && ./install.sh   # reinstall skills + commands
 
 **Where do I report bugs or ask for help?**
 
-Open an issue on [GitHub](https://github.com/shuvonsec/claude-bug-bounty/issues). Include:
+Open an issue on [GitHub](https://github.com/Awarexone/Agentic-Bug-Hunter/issues). Include:
 - What command you ran
 - What you expected to happen
 - What actually happened

--- a/OPENCODE.md
+++ b/OPENCODE.md
@@ -19,8 +19,8 @@ You also need [OpenCode](https://opencode.ai) installed.
 ### Install
 
 ```bash
-git clone https://github.com/shuvonsec/claude-bug-bounty.git
-cd claude-bug-bounty
+git clone https://github.com/Awarexone/Agentic-Bug-Hunter.git
+cd Agentic-Bug-Hunter
 chmod +x install_tools.sh && ./install_tools.sh   # scanning tools
 chmod +x install.sh && ./install.sh --opencode    # skills + commands
 ```
@@ -33,7 +33,7 @@ The installer will:
 ### Verify Installation
 
 ```bash
-cd claude-bug-bounty
+cd Agentic-Bug-Hunter
 opencode
 # Ask: "do you have bug bounty skills?"
 # Should confirm skills are loaded
@@ -101,7 +101,7 @@ Commands auto-invoke based on context.
 ### Quick Start
 
 ```bash
-cd claude-bug-bounty
+cd Agentic-Bug-Hunter
 opencode
 
 # In OpenCode:

--- a/SKILL.md
+++ b/SKILL.md
@@ -1211,12 +1211,12 @@ To use this as a Claude Code skill, copy this file to your skills directory:
 
 ```bash
 # Option A: Clone the repo and link the skill
-git clone https://github.com/shuvonsec/claude-bug-bounty.git ~/.claude/skills/bug-bounty
+git clone https://github.com/Awarexone/Agentic-Bug-Hunter.git ~/.claude/skills/bug-bounty
 ln -s ~/.claude/skills/bug-bounty/SKILL.md ~/.claude/skills/bug-bounty/SKILL.md
 
 # Option B: Direct copy
 mkdir -p ~/.claude/skills/bug-bounty
-curl -s https://raw.githubusercontent.com/shuvonsec/claude-bug-bounty/main/SKILL.md \
+curl -s https://raw.githubusercontent.com/Awarexone/Agentic-Bug-Hunter/main/SKILL.md \
   -o ~/.claude/skills/bug-bounty/SKILL.md
 ```
 

--- a/brain.py
+++ b/brain.py
@@ -433,7 +433,7 @@ class LLMClient:
             self._http.headers.update({
                 "Authorization": f"Bearer {key}",
                 "Content-Type": "application/json",
-                "HTTP-Referer": "https://github.com/shuvonsec/claude-bug-bounty",
+                "HTTP-Referer": "https://github.com/Awarexone/Agentic-Bug-Hunter",
                 "X-Title": "BugHunter",
             })
             self._api_base   = "https://openrouter.ai/api/v1"
@@ -450,7 +450,7 @@ class LLMClient:
             self._http.headers.update({
                 "Authorization": f"Bearer {key}",
                 "Content-Type": "application/json",
-                "HTTP-Referer": "https://github.com/shuvonsec/claude-bug-bounty",
+                "HTTP-Referer": "https://github.com/Awarexone/Agentic-Bug-Hunter",
                 "X-Title": "BugHunter",
             })
             self._api_base   = "https://api.orcarouter.ai/v1"

--- a/docs/TUTORIAL.md
+++ b/docs/TUTORIAL.md
@@ -32,8 +32,8 @@ scanner available and skips the rest gracefully.
 ## A. Install (30 sec)
 
 ```bash
-git clone https://github.com/shuvonsec/claude-bug-bounty.git
-cd claude-bug-bounty
+git clone https://github.com/Awarexone/Agentic-Bug-Hunter.git
+cd Agentic-Bug-Hunter
 chmod +x install.sh && ./install.sh
 ```
 

--- a/mcp/hackerone-mcp/server.py
+++ b/mcp/hackerone-mcp/server.py
@@ -71,7 +71,7 @@ def _graphql_request(query: str, timeout: int = DEFAULT_TIMEOUT) -> dict:
         data=payload,
         headers={
             "Content-Type": "application/json",
-            "User-Agent": "claude-bug-bounty/2.1",
+            "User-Agent": "agentic-bug-hunter/2.1",
         },
     )
     try:

--- a/site/index.html
+++ b/site/index.html
@@ -791,7 +791,7 @@
       <a href="#capabilities">Capabilities</a>
       <a href="#faq">FAQ</a>
       <a href="#roadmap">Roadmap</a>
-      <a href="https://github.com/shuvonsec/claude-bug-bounty" target="_blank" class="nav-cta">GitHub →</a>
+      <a href="https://github.com/Awarexone/Agentic-Bug-Hunter" target="_blank" class="nav-cta">GitHub →</a>
     </nav>
   </div>
 </header>
@@ -814,7 +814,7 @@
       </p>
 
       <div class="hero-ctas">
-        <a href="https://github.com/shuvonsec/claude-bug-bounty" target="_blank" class="btn btn-primary">Get on GitHub →</a>
+        <a href="https://github.com/Awarexone/Agentic-Bug-Hunter" target="_blank" class="btn btn-primary">Get on GitHub →</a>
         <a href="#how" class="btn btn-secondary">See how it works</a>
       </div>
 
@@ -873,7 +873,7 @@
         <div class="step-number">Step 01 — Install</div>
         <div class="step-title">One command inside Claude Code</div>
         <p class="step-desc">Clone the repo, run the installer, you are ready. No SaaS signup. No keys to share.</p>
-        <div class="code-block">git clone https://github.com/shuvonsec/claude-bug-bounty &amp;&amp; cd claude-bug-bounty &amp;&amp; ./install.sh</div>
+        <div class="code-block">git clone https://github.com/Awarexone/Agentic-Bug-Hunter &amp;&amp; cd Agentic-Bug-Hunter &amp;&amp; ./install.sh</div>
       </div>
 
       <div class="step-card">
@@ -921,10 +921,10 @@
         <button class="prompt-copy" onclick="copyPrompt(this)">Copy ↗</button>
       </div>
       <div class="prompt-body">Help me install the Claude Bug Bounty toolkit from
-https://github.com/shuvonsec/claude-bug-bounty into ~/tools/.
+https://github.com/Awarexone/Agentic-Bug-Hunter into ~/tools/.
 
 Steps:
-1. git clone the repo into ~/tools/claude-bug-bounty
+1. git clone the repo into ~/tools/Agentic-Bug-Hunter
 2. cd into it and run ./install_tools.sh   (scanners: subfinder, httpx, nuclei, gau, katana, ffuf, dnsx, nmap)
 3. then run ./install.sh                   (registers the AI skills + 23 slash commands into ~/.claude/)
 4. verify by listing the new commands (/recon, /hunt, /validate, /report, /autopilot)
@@ -1287,7 +1287,7 @@ single request.</div>
 
     <div class="install-cmd" onclick="copyInstallCmd(this)" title="Click to copy">
       <span class="prompt-mark">$</span>
-      <span>git clone https://github.com/shuvonsec/claude-bug-bounty &amp;&amp; cd claude-bug-bounty &amp;&amp; ./install.sh</span>
+      <span>git clone https://github.com/Awarexone/Agentic-Bug-Hunter &amp;&amp; cd Agentic-Bug-Hunter &amp;&amp; ./install.sh</span>
       <span class="copy-hint" id="copy-hint">Click to copy</span>
     </div>
 
@@ -1296,7 +1296,7 @@ single request.</div>
     </p>
 
     <div class="cta-buttons">
-      <a href="https://github.com/shuvonsec/claude-bug-bounty" target="_blank" class="btn btn-primary">Get on GitHub →</a>
+      <a href="https://github.com/Awarexone/Agentic-Bug-Hunter" target="_blank" class="btn btn-primary">Get on GitHub →</a>
       <a href="#prompts" class="btn btn-secondary">See the prompts</a>
     </div>
   </section>
@@ -1315,7 +1315,7 @@ single request.</div>
       <span>Powered by <a href="https://awarexone.com" target="_blank" rel="noopener" style="color:#7F55FF;text-decoration:none">AwareXone.com</a></span>
     </div>
     <div class="footer-links">
-      <a href="https://github.com/shuvonsec/claude-bug-bounty" target="_blank" rel="noopener">GitHub</a>
+      <a href="https://github.com/Awarexone/Agentic-Bug-Hunter" target="_blank" rel="noopener">GitHub</a>
       <a href="https://x.com/shuvonsec" target="_blank" rel="noopener">X</a>
       <a href="https://awarexone.com" target="_blank" rel="noopener">AwareXone</a>
     </div>
@@ -1502,7 +1502,7 @@ single request.</div>
 
   /* ============ COPY ============ */
   function copyInstallCmd(el) {
-    const cmd = 'git clone https://github.com/shuvonsec/claude-bug-bounty && cd claude-bug-bounty && ./install.sh';
+    const cmd = 'git clone https://github.com/Awarexone/Agentic-Bug-Hunter && cd Agentic-Bug-Hunter && ./install.sh';
     navigator.clipboard.writeText(cmd).then(() => {
       const hint = document.getElementById('copy-hint');
       const original = hint.textContent;

--- a/skills/bug-bounty/SKILL.md
+++ b/skills/bug-bounty/SKILL.md
@@ -1633,12 +1633,12 @@ To use this as a Claude Code skill, copy this file to your skills directory:
 
 ```bash
 # Option A: Clone the repo and link the skill
-git clone https://github.com/shuvonsec/claude-bug-bounty.git ~/.claude/skills/bug-bounty
+git clone https://github.com/Awarexone/Agentic-Bug-Hunter.git ~/.claude/skills/bug-bounty
 ln -s ~/.claude/skills/bug-bounty/SKILL.md ~/.claude/skills/bug-bounty/SKILL.md
 
 # Option B: Direct copy
 mkdir -p ~/.claude/skills/bug-bounty
-curl -s https://raw.githubusercontent.com/shuvonsec/claude-bug-bounty/main/SKILL.md \
+curl -s https://raw.githubusercontent.com/Awarexone/Agentic-Bug-Hunter/main/SKILL.md \
   -o ~/.claude/skills/bug-bounty/SKILL.md
 ```
 

--- a/tools/breach_checker.py
+++ b/tools/breach_checker.py
@@ -29,7 +29,7 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
 
 API_URL = "https://api.pwnedpasswords.com/range/{}"
-USER_AGENT = "claude-bug-bounty/breach_checker"
+USER_AGENT = "agentic-bug-hunter/breach_checker"
 
 
 def sha1_prefix_suffix(password: str) -> tuple[str, str]:

--- a/tools/cors_scanner.py
+++ b/tools/cors_scanner.py
@@ -40,7 +40,7 @@ if _REPO not in sys.path:
     sys.path.insert(0, _REPO)
 from tools.safe_http import safe_urlopen  # noqa: E402
 
-USER_AGENT = "claude-bug-bounty/cors_scanner"
+USER_AGENT = "agentic-bug-hunter/cors_scanner"
 
 CRITICAL, HIGH, MEDIUM, LOW, INFO = "CRITICAL", "HIGH", "MEDIUM", "MEDIUM_LOW", "INFO"
 

--- a/tools/crlf_scanner.py
+++ b/tools/crlf_scanner.py
@@ -37,7 +37,7 @@ if _REPO not in sys.path:
     sys.path.insert(0, _REPO)
 from tools.safe_http import safe_urlopen  # noqa: E402
 
-USER_AGENT = "claude-bug-bounty/crlf_scanner"
+USER_AGENT = "agentic-bug-hunter/crlf_scanner"
 CANARY = "crlftest"
 CANARY_HEADER = "Set-Cookie"
 

--- a/tools/dom_xss_harness.py
+++ b/tools/dom_xss_harness.py
@@ -31,7 +31,7 @@ import uuid
 from dataclasses import dataclass, asdict
 from urllib.parse import urlparse, parse_qs, urlencode, urlunparse
 
-USER_AGENT = "claude-bug-bounty/dom_xss_harness"
+USER_AGENT = "agentic-bug-hunter/dom_xss_harness"
 
 CONFIRMED, POSSIBLE = "[CONFIRMED]", "[POSSIBLE]"
 

--- a/tools/hai_payload_builder.py
+++ b/tools/hai_payload_builder.py
@@ -223,7 +223,7 @@ Excessive data exposure in API response could be leveraged for social engineerin
 
 # ════════════════════════════════════════════════════════════════════════════════
 # VAPT PAYLOAD LIBRARY
-# Source: shuvonsec/claude-bug-bounty v2.1.0 + OBSIDIAN extensions
+# Source: Awarexone/Agentic-Bug-Hunter v2.1.0 + OBSIDIAN extensions
 # ════════════════════════════════════════════════════════════════════════════════
 
 VAPT_PAYLOADS = {

--- a/tools/llm_redteam.py
+++ b/tools/llm_redteam.py
@@ -34,7 +34,7 @@ import urllib.request
 import uuid
 from dataclasses import dataclass
 
-USER_AGENT = "claude-bug-bounty/llm_redteam"
+USER_AGENT = "agentic-bug-hunter/llm_redteam"
 
 
 @dataclass

--- a/tools/nosqli_scanner.py
+++ b/tools/nosqli_scanner.py
@@ -34,7 +34,7 @@ if _REPO not in sys.path:
     sys.path.insert(0, _REPO)
 from tools.safe_http import safe_urlopen  # noqa: E402
 
-USER_AGENT = "claude-bug-bounty/nosqli_scanner"
+USER_AGENT = "agentic-bug-hunter/nosqli_scanner"
 
 # Operator payloads that mean "match anything" / "always true".
 _AUTH_OPERATORS = [

--- a/tools/port_scanner.py
+++ b/tools/port_scanner.py
@@ -29,7 +29,7 @@ import sys
 from dataclasses import dataclass, asdict
 from pathlib import Path
 
-USER_AGENT = "claude-bug-bounty/port_scanner"
+USER_AGENT = "agentic-bug-hunter/port_scanner"
 
 # port -> (service, note). Anything here that is NOT 80/443 is worth a second
 # look because the HTTP pipeline never touched it.


### PR DESCRIPTION
Went looking for anything the README cleanup missed. The old shuvonsec/claude-bug-bounty path was still all over the place: install instructions in FAQ.md, OPENCODE.md, both SKILL.md copies, and the tutorial; the bughunter.fun landing page's own GitHub links and copy-to-clipboard install command; a stale .gitignore entry; and a handful of User-Agent/HTTP-Referer strings in brain.py, the tools scanners, and the HackerOne MCP server. Repointed everything at Awarexone/Agentic-Bug-Hunter.